### PR TITLE
fix: room expiry edge cases

### DIFF
--- a/app/src/hooks/useChatRoom.ts
+++ b/app/src/hooks/useChatRoom.ts
@@ -330,6 +330,7 @@ export function useChatRoom(
       meeting.chat.off("chatUpdate", syncMessages)
       if (hasJoinedRef.current && !hasLeftRef.current) meeting.leaveRoom()
       hasJoinedRef.current = false
+      hasLeftRef.current = false
       if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current)
       if (expiryFinalRef.current) clearTimeout(expiryFinalRef.current)
       if (countdownRef.current) clearInterval(countdownRef.current)

--- a/app/src/hooks/useChatRoom.ts
+++ b/app/src/hooks/useChatRoom.ts
@@ -28,6 +28,7 @@ export function useChatRoom(
   const expiresAtRef = useRef<number>(0)
   const joinedMeetingRef = useRef<typeof meeting | null>(null)
   const hasJoinedRef = useRef(false)
+  const hasLeftRef = useRef(false)
   const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const expiryFinalRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -208,7 +209,26 @@ export function useChatRoom(
       setMessages([...mapped])
     }
 
+    const doExpireLeave = () => {
+      if (hasLeftRef.current) return
+      hasLeftRef.current = true
+      setExpiryWarning(
+        "Room session expired. Please re-open the link to rejoin."
+      )
+      meeting.leaveRoom().catch(() => {})
+      if (typeof window !== "undefined") {
+        window.location.href = "/"
+      }
+    }
+
     const onRoomLeft = ({ state }: { state: string }) => {
+      if (hasLeftRef.current) return
+      const isExpired =
+        expiresAtRef.current > 0 && Date.now() >= expiresAtRef.current
+      if (isExpired) {
+        doExpireLeave()
+        return
+      }
       if (state === "disconnected") {
         setConnectionStatus("reconnecting")
       } else if (state === "failed") {
@@ -237,31 +257,51 @@ export function useChatRoom(
     })
     hasJoinedRef.current = true
 
-    const joinedAt = Date.now()
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible" && expiresAtRef.current > 0) {
+        const remaining = Math.max(
+          0,
+          Math.floor((expiresAtRef.current - Date.now()) / 1000)
+        )
+        setTimeLeft(remaining)
+        if (remaining === 0) doExpireLeave()
+      }
+    }
+    document.addEventListener("visibilitychange", onVisibilityChange)
+
     countdownRef.current = setInterval(() => {
-      const base = expiresAtRef.current || joinedAt + 2 * 60 * 60 * 1000
+      const base = expiresAtRef.current
+      if (!base) return
       const remaining = Math.max(0, Math.floor((base - Date.now()) / 1000))
       setTimeLeft(remaining)
-      if (remaining === 0 && countdownRef.current) {
-        clearInterval(countdownRef.current)
+      if (remaining === 0) {
+        clearInterval(countdownRef.current!)
+        countdownRef.current = null
+        doExpireLeave()
       }
     }, 1000)
 
-    expiryTimerRef.current = setTimeout(() => {
-      setExpiryWarning(
-        "This room will expire in 10 minutes. Copy the link and re-open to continue."
-      )
-    }, 6600 * 1000)
-
-    expiryFinalRef.current = setTimeout(() => {
-      setExpiryWarning(
-        "Room session expired. Please re-open the link to rejoin."
-      )
-      meeting.leaveRoom().catch(() => {})
-      if (typeof window !== "undefined") {
-        window.location.href = "/"
+    const scheduleWarning = () => {
+      if (!expiresAtRef.current) return
+      const warnDelay = expiresAtRef.current - Date.now() - 10 * 60 * 1000
+      if (warnDelay <= 0) {
+        setExpiryWarning(
+          "This room will expire in 10 minutes. Copy the link and re-open to continue."
+        )
+        return
       }
-    }, 7200 * 1000)
+      expiryTimerRef.current = setTimeout(() => {
+        setExpiryWarning(
+          "This room will expire in 10 minutes. Copy the link and re-open to continue."
+        )
+      }, warnDelay)
+    }
+    scheduleWarning()
+
+    const finalDelay = expiresAtRef.current
+      ? Math.max(0, expiresAtRef.current - Date.now())
+      : 7200 * 1000
+    expiryFinalRef.current = setTimeout(doExpireLeave, finalDelay)
 
     meeting.self.on("roomLeft", onRoomLeft)
     meeting.self.on("roomJoined", onRoomJoined)
@@ -277,6 +317,7 @@ export function useChatRoom(
     buildParticipants()
 
     return () => {
+      document.removeEventListener("visibilitychange", onVisibilityChange)
       meeting.self.off("roomLeft", onRoomLeft)
       meeting.self.off("roomJoined", onRoomJoined)
       ;(meeting.meta as any).off("socketConnectionUpdate", onSocketUpdate)
@@ -287,7 +328,7 @@ export function useChatRoom(
       meeting.self.off("screenShareUpdate", buildParticipants)
       meeting.participants.joined.off("screenShareUpdate", buildParticipants)
       meeting.chat.off("chatUpdate", syncMessages)
-      if (hasJoinedRef.current) meeting.leaveRoom()
+      if (hasJoinedRef.current && !hasLeftRef.current) meeting.leaveRoom()
       hasJoinedRef.current = false
       if (expiryTimerRef.current) clearTimeout(expiryTimerRef.current)
       if (expiryFinalRef.current) clearTimeout(expiryFinalRef.current)

--- a/app/src/pages/api/token.ts
+++ b/app/src/pages/api/token.ts
@@ -32,6 +32,7 @@ const MAX_NAME_LENGTH = 32
 const ROOM_MAX_AGE_MS = 2 * 60 * 60 * 1000 // 2 hours
 const RATE_LIMIT_WINDOW_S = 60
 const RATE_LIMIT_MAX = 20
+const ROOM_KV_TTL_S = 4 * 3600
 
 function rtkBase(env: Env) {
   return `https://api.cloudflare.com/client/v4/accounts/${env.CF_ACCOUNT_ID}/realtime/kit/${env.RTK_APP_ID}`
@@ -99,7 +100,7 @@ async function getOrCreateMeeting(
         botEnabled: record.botEnabled || enableBot,
       }
       await env.ROOMS_KV.put(key, JSON.stringify(upgraded), {
-        expirationTtl: 30 * 24 * 3600,
+        expirationTtl: ROOM_KV_TTL_S,
       })
       return {
         meetingId: record.meetingId,
@@ -139,7 +140,7 @@ async function getOrCreateMeeting(
     botEnabled: enableBot,
   }
   await env.ROOMS_KV.put(key, JSON.stringify(record), {
-    expirationTtl: 30 * 24 * 3600,
+    expirationTtl: ROOM_KV_TTL_S,
   })
   return {
     meetingId,


### PR DESCRIPTION
## Summary

Oracle analysis of the room expiry flow identified several bugs and edge cases.

## Fixes

### 🔴 Bugs

**Double `leaveRoom()` (#6)**
Both the `setInterval` countdown-to-zero path and `expiryFinalRef` setTimeout called `leaveRoom()` + redirect, causing the second call to throw on an already-destroyed meeting object. Added `hasLeftRef` guard so the leave executes exactly once regardless of which path fires first.

**Cron disconnect shows "Reconnecting" instead of expiry message (#5)**
When the cron job deletes participants, RTK fires a disconnect event and `onRoomLeft` was unconditionally setting `connectionStatus = "reconnecting"`, leaving users staring at a spinner with no explanation. Now checks `Date.now() >= expiresAtRef.current` in `onRoomLeft` — if the room has expired, calls `doExpireLeave()` and redirects home instead.

### 🟡 Improvements

**Warning timer drift (#7A)**
`expiryTimerRef` was hardcoded to `6600 * 1000ms`. If the device sleeps and resumes, the setTimeout fires late. Changed to `expiresAt - now - 10min` so the delay is always calibrated to the absolute expiry time.

**Backgrounded tab throttling (#7B)**
Browsers throttle `setInterval` in backgrounded tabs to ≥1 minute, causing the countdown to desync. Added a `visibilitychange` listener that recalibrates `timeLeft` from `expiresAt` immediately when the tab becomes visible again. If the room has already expired, calls `doExpireLeave()` directly.

**KV TTL reduced from 30 days to 4 hours (#4)**
Rooms live for 2 hours. Keeping KV records for 30 days was wasteful and caused the cron's `kv.list()` to scan through large amounts of dead records. Changed to 4 hours (2h room lifetime + 2h buffer) so KV auto-purges stale records. Cron is kept as defense-in-depth but is no longer the primary cleanup mechanism.