### PR TITLE
feat: add Mixpanel product event tracking

### DIFF
--- a/app/src/common/utils.tsx
+++ b/app/src/common/utils.tsx
@@ -98,13 +98,56 @@ export const gtagEvent = (action, category, label, value) => {
   })
 }
 
-export const umamiEvent = (eventName, eventData) => {
-  if (!Object.hasOwn(window, "umami")) {
-    return
+type AnalyticsProperties = Record<string, unknown>
+
+type AnalyticsWindow = Window & {
+  umami?: {
+    track: (eventName: string, eventData?: AnalyticsProperties) => void
   }
-  // @ts-ignore
-  window.umami.track(eventName, eventData)
+  zaraz?: {
+    track: (
+      eventName: string,
+      eventData?: AnalyticsProperties
+    ) => Promise<void> | void
+  }
 }
+
+const trackWithZaraz = (
+  eventName: string,
+  eventData: AnalyticsProperties
+) => {
+  const send = () => {
+    const zaraz = (window as AnalyticsWindow).zaraz
+    if (!zaraz) return false
+    try {
+      void Promise.resolve(zaraz.track(eventName, eventData)).catch(() => {})
+    } catch {
+      // Analytics must never block the product flow.
+    }
+    return true
+  }
+
+  if (!send()) window.setTimeout(send, 500)
+}
+
+export const trackAnalyticsEvent = (
+  eventName: string,
+  eventData: AnalyticsProperties = {}
+) => {
+  if (typeof window === "undefined") return
+
+  const umami = (window as AnalyticsWindow).umami
+  try {
+    umami?.track(eventName, eventData)
+  } catch {
+    // Analytics must never block the product flow.
+  }
+  trackWithZaraz(eventName, eventData)
+}
+
+// Keep existing instrumentation and its Umami reports working while forwarding
+// product events through the Cloudflare Zaraz Mixpanel tag.
+export const umamiEvent = trackAnalyticsEvent
 
 export const hashRoom = (roomName: string): string => {
   let h = 0x811c9dc5

--- a/app/src/common/utils.tsx
+++ b/app/src/common/utils.tsx
@@ -107,15 +107,12 @@ type AnalyticsWindow = Window & {
   zaraz?: {
     track: (
       eventName: string,
-      eventData?: AnalyticsProperties
+      eventData?: AnalyticsProperties,
     ) => Promise<void> | void
   }
 }
 
-const trackWithZaraz = (
-  eventName: string,
-  eventData: AnalyticsProperties
-) => {
+const trackWithZaraz = (eventName: string, eventData: AnalyticsProperties) => {
   const send = () => {
     const zaraz = (window as AnalyticsWindow).zaraz
     if (!zaraz) return false
@@ -132,7 +129,7 @@ const trackWithZaraz = (
 
 export const trackAnalyticsEvent = (
   eventName: string,
-  eventData: AnalyticsProperties = {}
+  eventData: AnalyticsProperties = {},
 ) => {
   if (typeof window === "undefined") return
 

--- a/app/src/common/utils.tsx
+++ b/app/src/common/utils.tsx
@@ -107,7 +107,7 @@ type AnalyticsWindow = Window & {
   zaraz?: {
     track: (
       eventName: string,
-      eventData?: AnalyticsProperties,
+      eventData?: AnalyticsProperties
     ) => Promise<void> | void
   }
 }
@@ -129,7 +129,7 @@ const trackWithZaraz = (eventName: string, eventData: AnalyticsProperties) => {
 
 export const trackAnalyticsEvent = (
   eventName: string,
-  eventData: AnalyticsProperties = {},
+  eventData: AnalyticsProperties = {}
 ) => {
   if (typeof window === "undefined") return
 

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -6,7 +6,12 @@ import { LOCAL_PEER_ID } from "@common/consts"
 
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
-import { umamiEvent, hashRoom, participantsBucket } from "../common/utils"
+import {
+  umamiEvent,
+  trackAnalyticsEvent,
+  hashRoom,
+  participantsBucket,
+} from "../common/utils"
 import { useChatRoom } from "../hooks/useChatRoom"
 
 const REACTION_EMOJIS = ["👍", "😂", "🔥", "❓"]
@@ -194,6 +199,7 @@ export default function RoomContent({
   }, [])
 
   const lastBucketRef = useRef<string>("")
+  const activatedRoomRef = useRef(false)
   useEffect(() => {
     const bucket = participantsBucket(participants.length)
     if (bucket !== lastBucketRef.current) {
@@ -205,6 +211,27 @@ export default function RoomContent({
       })
     }
   }, [participants.length, roomName, resolvedRoomType])
+
+  useEffect(() => {
+    if (
+      activatedRoomRef.current ||
+      connectionStatus !== "connected" ||
+      participants.length < 2
+    ) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => {
+      activatedRoomRef.current = true
+      trackAnalyticsEvent("RoomActivated", {
+        roomType: resolvedRoomType,
+        participantBucket: participantsBucket(participants.length),
+        activationDelaySeconds: 30,
+      })
+    }, 30_000)
+
+    return () => window.clearTimeout(timeout)
+  }, [connectionStatus, participants.length, resolvedRoomType])
 
   useEffect(() => {
     messages.forEach((m) => {
@@ -346,6 +373,10 @@ export default function RoomContent({
         encodeURIComponent(roomName) +
         (resolvedRoomType === "screenshare" ? "&type=screenshare" : "")
       navigator.clipboard.writeText(url)
+      trackAnalyticsEvent("InviteLinkCopied", {
+        surface: "room",
+        roomType: resolvedRoomType,
+      })
       setRoomLinkCopied(true)
       setTimeout(() => setRoomLinkCopied(false), 2000)
     }

--- a/app/src/hooks/useChatRoom.ts
+++ b/app/src/hooks/useChatRoom.ts
@@ -4,6 +4,7 @@ import { useRealtimeKitClient } from "@cloudflare/realtimekit-react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
 import { UserInfo, Message, ActionType } from "@common/types"
+import { trackAnalyticsEvent } from "@common/utils"
 
 type ConnectionStatus = "connecting" | "connected" | "reconnecting" | "failed"
 
@@ -29,6 +30,9 @@ export function useChatRoom(
   const joinedMeetingRef = useRef<typeof meeting | null>(null)
   const hasJoinedRef = useRef(false)
   const hasLeftRef = useRef(false)
+  const connectionTrackedRef = useRef(false)
+  const resolvedRoomTypeRef = useRef<"audio" | "screenshare">(roomType)
+  const botEnabledRef = useRef(false)
   const expiryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const expiryFinalRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -37,6 +41,7 @@ export function useChatRoom(
     if (!roomName || !nickName) return
 
     const controller = new AbortController()
+    connectionTrackedRef.current = false
 
     fetch(`/api/token`, {
       method: "POST",
@@ -73,6 +78,9 @@ export function useChatRoom(
               Math.max(0, Math.floor((data.expiresAt - Date.now()) / 1000))
             )
           }
+          const nextRoomType = data.roomType ?? roomType
+          resolvedRoomTypeRef.current = nextRoomType
+          botEnabledRef.current = Boolean(data.botEnabled)
           if (data.roomType) setResolvedRoomType(data.roomType)
           if (data.botEnabled) setBotEnabled(true)
           if (data.typeConflict) {
@@ -90,6 +98,14 @@ export function useChatRoom(
       )
       .catch((err: Error) => {
         if (err.name === "AbortError") return
+        const code = [
+          "room_expired",
+          "rate_limited",
+          "verification_failed",
+        ].includes(err.message)
+          ? err.message
+          : "server_error"
+        trackAnalyticsEvent("RoomJoinFailed", { stage: "token", code })
         setConnectionStatus("failed")
         if (err.message === "room_expired") {
           setError(
@@ -237,6 +253,13 @@ export function useChatRoom(
     }
 
     const onRoomJoined = ({ reconnected }: { reconnected: boolean }) => {
+      if (!reconnected && !connectionTrackedRef.current) {
+        connectionTrackedRef.current = true
+        trackAnalyticsEvent("RoomConnected", {
+          roomType: resolvedRoomTypeRef.current,
+          botEnabled: botEnabledRef.current,
+        })
+      }
       if (reconnected) {
         setError("")
         setConnectionStatus("connected")
@@ -252,6 +275,10 @@ export function useChatRoom(
     }
 
     meeting.join().catch((err: Error) => {
+      trackAnalyticsEvent("RoomJoinFailed", {
+        stage: "meeting",
+        code: "join_failed",
+      })
       setConnectionStatus("failed")
       setError("Failed to join room: " + err.message)
     })

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -6,6 +6,7 @@ import {
   randomName,
   saveRoomToLocalStorage,
   umamiEvent,
+  trackAnalyticsEvent,
   hashRoom,
 } from "../common/utils"
 import Header from "../components/Header"
@@ -32,6 +33,10 @@ export default function Home() {
         sessionStorage.setItem("enable_bot", enableBot ? "1" : "0")
       }
       const roomType = screenShare ? "screenshare" : "audio"
+      trackAnalyticsEvent("RoomJoinAttempted", {
+        roomType,
+        botEnabled: enableBot,
+      })
       umamiEvent("RoomJoin", { type: roomType, roomHash: hashRoom(roomName) })
       const url =
         "/room?id=" +
@@ -46,6 +51,7 @@ export default function Home() {
       const url =
         window.location.origin + "/room?id=" + encodeURIComponent(roomName)
       navigator.clipboard.writeText(url)
+      trackAnalyticsEvent("InviteLinkCopied", { surface: "landing" })
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     }


### PR DESCRIPTION
## Summary

Routes browser product events through the existing Cloudflare Zaraz setup so the configured Mixpanel destination can receive them. No Mixpanel SDK, token, or new third-party script is added.

- preserves existing Umami calls and forwards those events to Zaraz asynchronously
- adds a room funnel: `RoomJoinAttempted` → `RoomConnected` / `RoomJoinFailed` → `RoomActivated`
- records invite-link copies from the landing and room pages

`RoomActivated` fires only after at least two participants have remained in a connected room for 30 seconds, which makes it a more meaningful signal than a page view or button click.

## Events available in Mixpanel

| Event | Useful breakdown |
| --- | --- |
| `RoomJoinAttempted` | `roomType`, `botEnabled` |
| `RoomConnected` | `roomType`, `botEnabled` |
| `RoomJoinFailed` | `stage`, `code` |
| `RoomActivated` | `roomType`, `participantBucket` |
| `InviteLinkCopied` | `surface`, `roomType` |
| existing `ChatActivity`, `ChatAction`, `ScreenShare`, `RoomSize` | existing feature/type properties |

## Verification

- compared against the current `cloudflare` head: one commit, four intended files, no merge-base drift
- re-fetched the branch files and verified the Zaraz bridge and all funnel event names

## Follow-up

In Cloudflare Zaraz, ensure the existing Mixpanel web tag is configured to receive custom client events (the `zaraz.track()` events above), not only pageviews.