### PR TITLE
fix: harden SFU room lifecycle

### DIFF
--- a/app/src/common/utils.tsx
+++ b/app/src/common/utils.tsx
@@ -98,13 +98,53 @@ export const gtagEvent = (action, category, label, value) => {
   })
 }
 
-export const umamiEvent = (eventName, eventData) => {
-  if (!Object.hasOwn(window, "umami")) {
-    return
+type AnalyticsProperties = Record<string, unknown>
+
+type AnalyticsWindow = Window & {
+  umami?: {
+    track: (eventName: string, eventData?: AnalyticsProperties) => void
   }
-  // @ts-ignore
-  window.umami.track(eventName, eventData)
+  zaraz?: {
+    track: (
+      eventName: string,
+      eventData?: AnalyticsProperties
+    ) => Promise<void> | void
+  }
 }
+
+const trackWithZaraz = (eventName: string, eventData: AnalyticsProperties) => {
+  const send = () => {
+    const zaraz = (window as AnalyticsWindow).zaraz
+    if (!zaraz) return false
+    try {
+      void Promise.resolve(zaraz.track(eventName, eventData)).catch(() => {})
+    } catch {
+      // Analytics must never block the product flow.
+    }
+    return true
+  }
+
+  if (!send()) window.setTimeout(send, 500)
+}
+
+export const trackAnalyticsEvent = (
+  eventName: string,
+  eventData: AnalyticsProperties = {}
+) => {
+  if (typeof window === "undefined") return
+
+  const umami = (window as AnalyticsWindow).umami
+  try {
+    umami?.track(eventName, eventData)
+  } catch {
+    // Analytics must never block the product flow.
+  }
+  trackWithZaraz(eventName, eventData)
+}
+
+// Keep existing instrumentation and its Umami reports working while forwarding
+// product events through the Cloudflare Zaraz Mixpanel tag.
+export const umamiEvent = trackAnalyticsEvent
 
 export const hashRoom = (roomName: string): string => {
   let h = 0x811c9dc5

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -6,7 +6,12 @@ import { LOCAL_PEER_ID } from "@common/consts"
 
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
-import { umamiEvent, hashRoom, participantsBucket } from "../common/utils"
+import {
+  umamiEvent,
+  trackAnalyticsEvent,
+  hashRoom,
+  participantsBucket,
+} from "../common/utils"
 import { useSfuChatRoom } from "../hooks/useSfuChatRoom"
 
 const REACTION_EMOJIS = ["👍", "😂", "🔥", "❓"]
@@ -194,6 +199,7 @@ export default function RoomContent({
   }, [])
 
   const lastBucketRef = useRef<string>("")
+  const activatedRoomRef = useRef(false)
   useEffect(() => {
     const bucket = participantsBucket(participants.length)
     if (bucket !== lastBucketRef.current) {
@@ -205,6 +211,27 @@ export default function RoomContent({
       })
     }
   }, [participants.length, roomName, resolvedRoomType])
+
+  useEffect(() => {
+    if (
+      activatedRoomRef.current ||
+      connectionStatus !== "connected" ||
+      participants.length < 2
+    ) {
+      return
+    }
+
+    const timeout = window.setTimeout(() => {
+      activatedRoomRef.current = true
+      trackAnalyticsEvent("RoomActivated", {
+        roomType: resolvedRoomType,
+        participantBucket: participantsBucket(participants.length),
+        activationDelaySeconds: 30,
+      })
+    }, 30_000)
+
+    return () => window.clearTimeout(timeout)
+  }, [connectionStatus, participants.length, resolvedRoomType])
 
   useEffect(() => {
     messages.forEach((m) => {
@@ -346,6 +373,10 @@ export default function RoomContent({
         encodeURIComponent(roomName) +
         (resolvedRoomType === "screenshare" ? "&type=screenshare" : "")
       navigator.clipboard.writeText(url)
+      trackAnalyticsEvent("InviteLinkCopied", {
+        surface: "room",
+        roomType: resolvedRoomType,
+      })
       setRoomLinkCopied(true)
       setTimeout(() => setRoomLinkCopied(false), 2000)
     }

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -26,7 +26,9 @@ type ControlRequest =
   | {
       action: "register"
       participant: Omit<SfuParticipant, "connected" | "lastSeenAt">
+      enableBot: boolean
     }
+  | { action: "bot-status" }
   | {
       action: "authorize"
       participantId: string
@@ -35,6 +37,13 @@ type ControlRequest =
       trackSessionId?: string
       trackName?: string
       dataChannelSessionId?: string
+    }
+  | {
+      action: "reconnect"
+      participantId: string
+      token: string
+      sessionId: string
+      newSessionId: string
     }
   | {
       action: "publish"
@@ -80,6 +89,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     return {
       createdAt: room.createdAt,
       expiresAt: room.expiresAt,
+      botEnabled: room.botEnabled ?? false,
       participants: Object.values(room.participants)
         .filter((participant) => participant.connected)
         .map(
@@ -169,9 +179,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         room = {
           createdAt: now,
           expiresAt: now + ROOM_MAX_AGE_MS,
+          botEnabled: request.enableBot,
           participants: {},
           messages: [],
         }
+      } else if (request.enableBot && !room.botEnabled) {
+        room.botEnabled = true
       }
       const participant: SfuParticipant = {
         ...request.participant,
@@ -188,11 +201,20 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       return this.json({
         state: this.stateFor(room),
         expiresAt: room.expiresAt,
+        botEnabled: room.botEnabled ?? false,
       })
     }
 
     const room = await this.activeRoom()
     if (!room) return this.json({ error: "room_expired" }, 410)
+
+    if (request.action === "bot-status") {
+      return this.json({
+        botEnabled: room.botEnabled ?? false,
+        createdAt: room.createdAt,
+        expiresAt: room.expiresAt,
+      })
+    }
 
     if (request.action === "authorize") {
       const participant = this.findParticipant(
@@ -222,6 +244,28 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           return this.json({ error: "datachannel_session_not_found" }, 404)
       }
       return this.json({ ok: true })
+    }
+
+    if (request.action === "reconnect") {
+      const participant = this.findParticipant(
+        room,
+        request.participantId,
+        request.token,
+        request.sessionId
+      )
+      if (!participant) return this.json({ error: "unauthorized" }, 401)
+      participant.sessionId = request.newSessionId
+      participant.connected = false
+      participant.connectionNonce = undefined
+      participant.fileChannelReady = false
+      participant.tracks = []
+      participant.lastSeenAt = Date.now()
+      await this.saveRoom(room)
+      return this.json({
+        ok: true,
+        expiresAt: room.expiresAt,
+        botEnabled: room.botEnabled ?? false,
+      })
     }
 
     const participant = this.findParticipant(

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -107,6 +107,7 @@ export function useSfuChatRoom(
   const pendingRemoteTrackRef = useRef<{
     peerId: string
     kind: "audio" | "video"
+    sessionId: string
   } | null>(null)
   const negotiationQueueRef = useRef(Promise.resolve())
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -119,8 +120,10 @@ export function useSfuChatRoom(
   const mediaReconnectRef = useRef<(() => Promise<void>) | null>(null)
   const localFileChannelRef = useRef<RTCDataChannel | null>(null)
   const remoteFileChannelsRef = useRef(new Map<string, RTCDataChannel>())
+  const remoteFileChannelIdsRef = useRef(new Map<string, number>())
   const dataChannelsRef = useRef(new Set<RTCDataChannel>())
   const dataChannelIdsRef = useRef(new Set<number>())
+  const localFileChannelIdRef = useRef<number | null>(null)
   const localTrackMidsRef = useRef(new Map<string, string>())
   const incomingFilesRef = useRef(new Map<string, IncomingFileTransfer>())
   const objectUrlsRef = useRef(new Set<string>())
@@ -224,6 +227,8 @@ export function useSfuChatRoom(
         // The SFU session may already be gone during network recovery.
       } finally {
         dataChannelIdsRef.current.clear()
+        localFileChannelIdRef.current = null
+        remoteFileChannelIdsRef.current.clear()
       }
     },
     [apiRequest, roomName]
@@ -323,6 +328,37 @@ export function useSfuChatRoom(
     },
     []
   )
+
+  const resetRemoteParticipant = useCallback((participantId: string) => {
+    for (const key of subscribedTracksRef.current) {
+      if (key.startsWith(`${participantId}:`))
+        subscribedTracksRef.current.delete(key)
+    }
+
+    const channel = remoteFileChannelsRef.current.get(participantId)
+    if (channel) {
+      channel.close()
+      dataChannelsRef.current.delete(channel)
+    }
+    remoteFileChannelsRef.current.delete(participantId)
+    const channelId = remoteFileChannelIdsRef.current.get(participantId)
+    if (channelId !== undefined) dataChannelIdsRef.current.delete(channelId)
+    remoteFileChannelIdsRef.current.delete(participantId)
+    incomingFilesRef.current.delete(participantId)
+
+    remoteAudioStreamsRef.current
+      .get(participantId)
+      ?.getTracks()
+      .forEach((track) => track.stop())
+    remoteScreenStreamsRef.current
+      .get(participantId)
+      ?.getTracks()
+      .forEach((track) => track.stop())
+    remoteAudioStreamsRef.current.delete(participantId)
+    remoteScreenStreamsRef.current.delete(participantId)
+    if (pendingRemoteTrackRef.current?.peerId === participantId)
+      pendingRemoteTrackRef.current = null
+  }, [])
 
   const handleFileChannelMessage = useCallback(
     (channelKey: string, peerId: string, name: string, event: MessageEvent) => {
@@ -453,6 +489,7 @@ export function useSfuChatRoom(
     channel.binaryType = "arraybuffer"
     channel.bufferedAmountLowThreshold = FILE_BUFFER_LOW_WATER_MARK
     localFileChannelRef.current = channel
+    localFileChannelIdRef.current = channelId
     dataChannelReadyRef.current = true
   }, [apiRequest, roomName])
 
@@ -506,6 +543,7 @@ export function useSfuChatRoom(
         )
       )
       remoteFileChannelsRef.current.set(channelKey, channel)
+      remoteFileChannelIdsRef.current.set(channelKey, channelId)
       await waitForDataChannelOpen(channel)
       channel.send("ack")
     },
@@ -589,13 +627,24 @@ export function useSfuChatRoom(
       const session = sessionRef.current
       const pc = peerConnectionRef.current
       if (!session || !pc) return
-      const key = `${participant.id}:${track.trackName}`
+      const key = `${participant.id}:${participant.sessionId}:${track.trackName}`
       if (subscribedTracksRef.current.has(key)) return
+      if (
+        participantMapRef.current.get(participant.id)?.sessionId !==
+        participant.sessionId
+      )
+        return
       subscribedTracksRef.current.add(key)
       await enqueueNegotiation(async () => {
+        if (
+          participantMapRef.current.get(participant.id)?.sessionId !==
+          participant.sessionId
+        )
+          return
         pendingRemoteTrackRef.current = {
           peerId: participant.id,
           kind: track.kind,
+          sessionId: participant.sessionId,
         }
         const response = await apiRequest("tracks", {
           room: roomName,
@@ -632,6 +681,11 @@ export function useSfuChatRoom(
     (state: SfuRoomState) => {
       roomStateRef.current = state
       setBotEnabled(state.botEnabled === true)
+      for (const participant of state.participants) {
+        const previous = participantMapRef.current.get(participant.id)
+        if (previous && previous.sessionId !== participant.sessionId)
+          resetRemoteParticipant(participant.id)
+      }
       participantMapRef.current = new Map(
         state.participants.map((participant) => [
           participant.id,
@@ -653,7 +707,12 @@ export function useSfuChatRoom(
           void subscribeFileChannel(fullParticipant)
       }
     },
-    [rebuildParticipants, subscribeFileChannel, subscribeTrack]
+    [
+      rebuildParticipants,
+      resetRemoteParticipant,
+      subscribeFileChannel,
+      subscribeTrack,
+    ]
   )
 
   const createPeerConnection = useCallback(() => {
@@ -664,6 +723,13 @@ export function useSfuChatRoom(
     pc.ontrack = (event) => {
       const pending = pendingRemoteTrackRef.current
       if (!pending) return
+      if (
+        participantMapRef.current.get(pending.peerId)?.sessionId !==
+        pending.sessionId
+      ) {
+        pendingRemoteTrackRef.current = null
+        return
+      }
       const stream = event.streams[0] ?? new MediaStream([event.track])
       if (pending.kind === "video")
         remoteScreenStreamsRef.current.set(pending.peerId, stream)
@@ -711,21 +777,32 @@ export function useSfuChatRoom(
         message.type === "trackPublished" &&
         message.participant?.track
       ) {
-        const current = participantMapRef.current.get(
-          message.participant.id as string
-        )
-        if (current) {
-          current.tracks = [...current.tracks, message.participant.track]
-        } else if (
-          message.participant.id &&
-          message.participant.name &&
-          message.participant.sessionId
+        const participantId = message.participant.id
+        const incomingSessionId = message.participant.sessionId
+        if (!participantId) return
+        const current = participantMapRef.current.get(participantId)
+        if (
+          current &&
+          incomingSessionId &&
+          current.sessionId !== incomingSessionId
         ) {
-          participantMapRef.current.set(message.participant.id, {
-            id: message.participant.id,
+          resetRemoteParticipant(participantId)
+          current.sessionId = incomingSessionId
+          current.tracks = [message.participant.track]
+        } else if (current) {
+          current.tracks = [
+            ...current.tracks.filter(
+              (track) =>
+                track.trackName !== message.participant!.track!.trackName
+            ),
+            message.participant.track,
+          ]
+        } else if (message.participant.name && incomingSessionId) {
+          participantMapRef.current.set(participantId, {
+            id: participantId,
             name: message.participant.name,
             kind: message.participant.kind ?? "human",
-            sessionId: message.participant.sessionId,
+            sessionId: incomingSessionId,
             muted: false,
             connected: true,
             tracks: [message.participant.track],
@@ -734,9 +811,7 @@ export function useSfuChatRoom(
             token: "",
           })
         }
-        const participant = participantMapRef.current.get(
-          message.participant.id as string
-        )
+        const participant = participantMapRef.current.get(participantId)
         rebuildParticipants()
         if (participant)
           void subscribeTrack(participant, message.participant.track)
@@ -789,6 +864,7 @@ export function useSfuChatRoom(
   }, [
     applyRoomState,
     rebuildParticipants,
+    resetRemoteParticipant,
     sendSocketMessage,
     subscribeFileChannel,
     subscribeTrack,
@@ -818,6 +894,7 @@ export function useSfuChatRoom(
         for (const channel of remoteFileChannelsRef.current.values())
           channel.close()
         remoteFileChannelsRef.current.clear()
+        remoteFileChannelIdsRef.current.clear()
         peerConnectionRef.current?.close()
         peerConnectionRef.current = null
         dataChannelReadyRef.current = false
@@ -958,6 +1035,7 @@ export function useSfuChatRoom(
     void start()
 
     const remoteFileChannels = remoteFileChannelsRef.current
+    const remoteFileChannelIds = remoteFileChannelIdsRef.current
     const incomingFiles = incomingFilesRef.current
     const objectUrls = objectUrlsRef.current
     const dataChannels = dataChannelsRef.current
@@ -1000,6 +1078,8 @@ export function useSfuChatRoom(
       dataChannels.clear()
       for (const channel of remoteFileChannels.values()) channel.close()
       remoteFileChannels.clear()
+      remoteFileChannelIds.clear()
+      localFileChannelIdRef.current = null
       incomingFiles.clear()
       for (const url of objectUrls) URL.revokeObjectURL(url)
       objectUrls.clear()

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -52,20 +52,35 @@ interface SfuServerMessage {
   error?: string
 }
 
-const roomMessageToMessage = (message: SfuMessage): Message => ({
-  peerId: message.peerId,
-  name: message.name,
-  type: message.type === "action" ? "action" : "text",
-  text: message.text,
-  actionType: message.actionType as ActionType | undefined,
-  actionPayload: message.actionPayload,
-})
+const roomMessageToMessage = (message: SfuMessage): Message => {
+  if (message.type === "text" && message.text?.startsWith("__bot:")) {
+    try {
+      const payload = JSON.parse(message.text.slice(6)) as { text?: unknown }
+      return {
+        peerId: "luna-ai",
+        name: "Luna · AI",
+        type: "bot",
+        text: typeof payload.text === "string" ? payload.text : "",
+      }
+    } catch {
+      // Fall through and render malformed bot messages as normal text.
+    }
+  }
+  return {
+    peerId: message.peerId,
+    name: message.name,
+    type: message.type === "action" ? "action" : "text",
+    text: message.text,
+    actionType: message.actionType as ActionType | undefined,
+    actionPayload: message.actionPayload,
+  }
+}
 
 export function useSfuChatRoom(
   roomName: string,
   nickName: string,
   roomType: "audio" | "screenshare",
-  _enableBot?: boolean,
+  enableBot?: boolean,
   enabled = true
 ) {
   const [participants, setParticipants] = useState<UserInfo[]>([])
@@ -76,6 +91,7 @@ export function useSfuChatRoom(
     useState<ConnectionStatus>("connecting")
   const [timeLeft, setTimeLeft] = useState(2 * 60 * 60)
   const [resolvedRoomType] = useState<"audio" | "screenshare">(roomType)
+  const [botEnabled, setBotEnabled] = useState(false)
 
   const sessionRef = useRef<SfuSession | null>(null)
   const roomStateRef = useRef<SfuRoomState | null>(null)
@@ -95,8 +111,17 @@ export function useSfuChatRoom(
   const negotiationQueueRef = useRef(Promise.resolve())
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const reconnectAttemptsRef = useRef(0)
+  const mediaReconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
+  const mediaReconnectAttemptsRef = useRef(0)
+  const mediaReconnectPromiseRef = useRef<Promise<void> | null>(null)
+  const mediaReconnectRef = useRef<(() => Promise<void>) | null>(null)
   const localFileChannelRef = useRef<RTCDataChannel | null>(null)
   const remoteFileChannelsRef = useRef(new Map<string, RTCDataChannel>())
+  const dataChannelsRef = useRef(new Set<RTCDataChannel>())
+  const dataChannelIdsRef = useRef(new Set<number>())
+  const localTrackMidsRef = useRef(new Map<string, string>())
   const incomingFilesRef = useRef(new Map<string, IncomingFileTransfer>())
   const objectUrlsRef = useRef(new Set<string>())
   const fileSendQueueRef = useRef(Promise.resolve())
@@ -166,7 +191,8 @@ export function useSfuChatRoom(
   )
 
   const apiRequest = useCallback(async (path: string, body: object) => {
-    const method = path === "renegotiate" ? "PUT" : "POST"
+    const method =
+      path === "renegotiate" || path.endsWith("/close") ? "PUT" : "POST"
     const response = await fetch(`/api/sfu/${path}`, {
       method,
       headers: { "Content-Type": "application/json" },
@@ -181,6 +207,27 @@ export function useSfuChatRoom(
     const raw = await response.text()
     return (raw ? JSON.parse(raw) : {}) as SfuApiResponse
   }, [])
+
+  const closeDataChannels = useCallback(
+    async (session: SfuSession | null = sessionRef.current) => {
+      if (!session || dataChannelIdsRef.current.size === 0) return
+      const dataChannels = [...dataChannelIdsRef.current].map((id) => ({ id }))
+      try {
+        await apiRequest("datachannels/close", {
+          room: roomName,
+          participantId: session.participantId,
+          token: session.participantToken,
+          sessionId: session.sessionId,
+          dataChannels,
+        })
+      } catch {
+        // The SFU session may already be gone during network recovery.
+      } finally {
+        dataChannelIdsRef.current.clear()
+      }
+    },
+    [apiRequest, roomName]
+  )
 
   const waitForDataChannelOpen = useCallback(
     (channel: RTCDataChannel): Promise<void> => {
@@ -346,6 +393,7 @@ export function useSfuChatRoom(
     if (!pc || !session) throw new Error("SFU session is not ready")
 
     const serverEvents = pc.createDataChannel("server-events")
+    dataChannelsRef.current.add(serverEvents)
     serverEvents.addEventListener("message", () => undefined)
     const offer = await pc.createOffer()
     await pc.setLocalDescription(offer)
@@ -400,6 +448,8 @@ export function useSfuChatRoom(
       id: channelId,
       ordered: true,
     })
+    dataChannelsRef.current.add(channel)
+    dataChannelIdsRef.current.add(channelId)
     channel.binaryType = "arraybuffer"
     channel.bufferedAmountLowThreshold = FILE_BUFFER_LOW_WATER_MARK
     localFileChannelRef.current = channel
@@ -444,6 +494,8 @@ export function useSfuChatRoom(
         id: channelId,
         ordered: true,
       })
+      dataChannelsRef.current.add(channel)
+      dataChannelIdsRef.current.add(channelId)
       channel.binaryType = "arraybuffer"
       channel.addEventListener("message", (event) =>
         handleFileChannelMessage(
@@ -492,7 +544,42 @@ export function useSfuChatRoom(
         if (response.sessionDescription) {
           await pc.setRemoteDescription(response.sessionDescription)
         }
+        localTrackMidsRef.current.set(trackName, transceiver.mid)
       })
+    },
+    [apiRequest, enqueueNegotiation, roomName]
+  )
+
+  const closePublishedTrack = useCallback(
+    async (trackName: string) => {
+      const pc = peerConnectionRef.current
+      const session = sessionRef.current
+      const mid = localTrackMidsRef.current.get(trackName)
+      if (!pc || !session || !mid) return
+      const transceiver = pc.getTransceivers().find((item) => item.mid === mid)
+      if (transceiver) pc.removeTrack(transceiver.sender)
+      try {
+        await enqueueNegotiation(async () => {
+          const offer = await pc.createOffer()
+          await pc.setLocalDescription(offer)
+          const response = await apiRequest("tracks/close", {
+            room: roomName,
+            participantId: session.participantId,
+            token: session.participantToken,
+            sessionId: session.sessionId,
+            tracks: [{ mid, trackName }],
+            sessionDescription: {
+              type: offer.type,
+              sdp: offer.sdp,
+            },
+            force: true,
+          })
+          if (response.sessionDescription)
+            await pc.setRemoteDescription(response.sessionDescription)
+        })
+      } finally {
+        localTrackMidsRef.current.delete(trackName)
+      }
     },
     [apiRequest, enqueueNegotiation, roomName]
   )
@@ -544,6 +631,7 @@ export function useSfuChatRoom(
   const applyRoomState = useCallback(
     (state: SfuRoomState) => {
       roomStateRef.current = state
+      setBotEnabled(state.botEnabled === true)
       participantMapRef.current = new Map(
         state.participants.map((participant) => [
           participant.id,
@@ -567,6 +655,35 @@ export function useSfuChatRoom(
     },
     [rebuildParticipants, subscribeFileChannel, subscribeTrack]
   )
+
+  const createPeerConnection = useCallback(() => {
+    const pc = new RTCPeerConnection({
+      iceServers: [{ urls: "stun:stun.cloudflare.com:3478" }],
+    })
+    peerConnectionRef.current = pc
+    pc.ontrack = (event) => {
+      const pending = pendingRemoteTrackRef.current
+      if (!pending) return
+      const stream = event.streams[0] ?? new MediaStream([event.track])
+      if (pending.kind === "video")
+        remoteScreenStreamsRef.current.set(pending.peerId, stream)
+      else remoteAudioStreamsRef.current.set(pending.peerId, stream)
+      pendingRemoteTrackRef.current = null
+      rebuildParticipants()
+    }
+    pc.onconnectionstatechange = () => {
+      if (pc.connectionState === "connected") {
+        mediaReconnectAttemptsRef.current = 0
+        setConnectionStatus("connected")
+      } else if (
+        pc.connectionState === "failed" ||
+        pc.connectionState === "disconnected"
+      ) {
+        void mediaReconnectRef.current?.()
+      }
+    }
+    return pc
+  }, [rebuildParticipants])
 
   const connectWebSocket = useCallback(() => {
     const session = sessionRef.current
@@ -656,6 +773,7 @@ export function useSfuChatRoom(
     socket.onerror = () => socket.close()
     socket.onclose = () => {
       if (closingRef.current) return
+      if (socket !== websocketRef.current) return
       setConnectionStatus("reconnecting")
       const attempt = reconnectAttemptsRef.current++
       if (attempt >= 5) {
@@ -676,69 +794,159 @@ export function useSfuChatRoom(
     subscribeTrack,
   ])
 
-  useEffect(() => {
-    if (!enabled || !roomName || !nickName) return
-    closingRef.current = false
-    const pc = new RTCPeerConnection({
-      iceServers: [{ urls: "stun:stun.cloudflare.com:3478" }],
-    })
-    peerConnectionRef.current = pc
-    pc.ontrack = (event) => {
-      const pending = pendingRemoteTrackRef.current
-      if (!pending) return
-      const stream = event.streams[0] ?? new MediaStream([event.track])
-      if (pending.kind === "video")
-        remoteScreenStreamsRef.current.set(pending.peerId, stream)
-      else remoteAudioStreamsRef.current.set(pending.peerId, stream)
-      pendingRemoteTrackRef.current = null
-      rebuildParticipants()
-    }
-    pc.onconnectionstatechange = () => {
-      if (pc.connectionState === "failed") setConnectionStatus("reconnecting")
-    }
+  const connectMediaSession = useCallback(
+    async (reconnecting: boolean) => {
+      const previousSession = sessionRef.current
+      if (reconnecting && !previousSession)
+        throw new Error("SFU session is not ready")
 
-    const start = async () => {
-      try {
+      if (reconnecting) {
+        if (reconnectTimerRef.current) {
+          clearTimeout(reconnectTimerRef.current)
+          reconnectTimerRef.current = null
+        }
+        const oldSocket = websocketRef.current
+        if (oldSocket) {
+          oldSocket.onclose = null
+          oldSocket.onerror = null
+          oldSocket.close()
+          websocketRef.current = null
+        }
+        await closeDataChannels(previousSession)
+        for (const channel of dataChannelsRef.current) channel.close()
+        dataChannelsRef.current.clear()
+        for (const channel of remoteFileChannelsRef.current.values())
+          channel.close()
+        remoteFileChannelsRef.current.clear()
+        peerConnectionRef.current?.close()
+        peerConnectionRef.current = null
+        dataChannelReadyRef.current = false
+        localTrackMidsRef.current.clear()
+        subscribedTracksRef.current.clear()
+        remoteAudioStreamsRef.current.clear()
+        remoteScreenStreamsRef.current.clear()
+        pendingRemoteTrackRef.current = null
+      }
+
+      let audioTrack = localAudioTrackRef.current
+      if (!audioTrack) {
         const media = await navigator.mediaDevices.getUserMedia({
           audio: true,
           video: false,
         })
-        const audioTrack = media.getAudioTracks()[0]
+        audioTrack = media.getAudioTracks()[0] ?? null
         if (!audioTrack) throw new Error("No microphone track available")
         localAudioTrackRef.current = audioTrack
-        pc.addTrack(audioTrack, media)
-        rebuildParticipants()
-        const response = await fetch("/api/sfu/session", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            room: roomName,
-            name: nickName,
-            kind: "human",
-            turnstileToken: sessionStorage.getItem("ts_token") ?? undefined,
-          }),
-        })
-        if (!response.ok) {
-          const data = (await response.json().catch(() => ({}))) as {
-            error?: string
-          }
-          if (response.status === 403) sessionStorage.removeItem("ts_token")
-          throw new Error(data.error || "Unable to create SFU session")
+      }
+
+      const pc = createPeerConnection()
+      pc.addTrack(audioTrack, new MediaStream([audioTrack]))
+      const screenTrack = localScreenTrackRef.current
+      if (screenTrack && screenTrack.readyState === "live")
+        pc.addTrack(screenTrack, new MediaStream([screenTrack]))
+      rebuildParticipants()
+
+      const body: Record<string, unknown> = {
+        room: roomName,
+        name: nickName,
+        kind: "human",
+        enableBot: enableBot === true,
+        turnstileToken: sessionStorage.getItem("ts_token") ?? undefined,
+      }
+      if (reconnecting && previousSession) {
+        body.reconnect = {
+          participantId: previousSession.participantId,
+          participantToken: previousSession.participantToken,
+          sessionId: previousSession.sessionId,
         }
-        const session = (await response.json()) as SfuSessionResponse
-        sessionRef.current = { ...session, room: roomName }
-        sessionStorage.removeItem("ts_token")
-        expiresAtRef.current = session.expiresAt
-        setTimeLeft(
-          Math.max(0, Math.floor((session.expiresAt - Date.now()) / 1000))
-        )
-        await establishDataChannelTransport()
+      }
+      const response = await fetch("/api/sfu/session", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      })
+      if (!response.ok) {
+        const data = (await response.json().catch(() => ({}))) as {
+          error?: string
+        }
+        if (response.status === 403) sessionStorage.removeItem("ts_token")
+        throw new Error(data.error || "Unable to create SFU session")
+      }
+      const session = (await response.json()) as SfuSessionResponse
+      sessionRef.current = { ...session, room: roomName }
+      setBotEnabled(session.botEnabled === true)
+      sessionStorage.removeItem("ts_token")
+      expiresAtRef.current = session.expiresAt
+      setTimeLeft(
+        Math.max(0, Math.floor((session.expiresAt - Date.now()) / 1000))
+      )
+      await establishDataChannelTransport()
+      await publishTrack(audioTrack, "audio", `audio-${session.participantId}`)
+      if (screenTrack && screenTrack.readyState === "live") {
         await publishTrack(
-          audioTrack,
-          "audio",
-          `audio-${session.participantId}`
+          screenTrack,
+          "video",
+          localScreenTrackNameRef.current
         )
-        connectWebSocket()
+      }
+      connectWebSocket()
+    },
+    [
+      closeDataChannels,
+      connectWebSocket,
+      createPeerConnection,
+      enableBot,
+      establishDataChannelTransport,
+      nickName,
+      publishTrack,
+      rebuildParticipants,
+      roomName,
+    ]
+  )
+
+  const reconnectMedia = useCallback(async () => {
+    if (closingRef.current || mediaReconnectPromiseRef.current) return
+    const attempt = mediaReconnectAttemptsRef.current++
+    if (attempt >= 5) {
+      setError("SFU media connection lost. Reload to start a new session.")
+      setConnectionStatus("failed")
+      return
+    }
+    const promise = (async () => {
+      setConnectionStatus("reconnecting")
+      try {
+        await connectMediaSession(true)
+        mediaReconnectAttemptsRef.current = 0
+        setError("")
+      } catch (err) {
+        if (attempt >= 4) {
+          setError(
+            err instanceof Error
+              ? err.message
+              : "Unable to reconnect to SFU media"
+          )
+          setConnectionStatus("failed")
+          return
+        }
+        mediaReconnectTimerRef.current = setTimeout(() => {
+          void mediaReconnectRef.current?.()
+        }, Math.min(1000 * 2 ** attempt, 8000))
+      }
+    })()
+    mediaReconnectPromiseRef.current = promise
+    try {
+      await promise
+    } finally {
+      mediaReconnectPromiseRef.current = null
+    }
+  }, [connectMediaSession])
+
+  useEffect(() => {
+    if (!enabled || !roomName || !nickName) return
+    closingRef.current = false
+    const start = async () => {
+      try {
+        await connectMediaSession(false)
       } catch (err) {
         setError(
           err instanceof Error ? err.message : "Unable to connect to SFU"
@@ -746,11 +954,14 @@ export function useSfuChatRoom(
         setConnectionStatus("failed")
       }
     }
+    mediaReconnectRef.current = reconnectMedia
     void start()
 
     const remoteFileChannels = remoteFileChannelsRef.current
     const incomingFiles = incomingFilesRef.current
     const objectUrls = objectUrlsRef.current
+    const dataChannels = dataChannelsRef.current
+    const localTrackMids = localTrackMidsRef.current
 
     const countdown = setInterval(() => {
       if (!expiresAtRef.current) return
@@ -776,28 +987,35 @@ export function useSfuChatRoom(
       closingRef.current = true
       clearInterval(countdown)
       if (reconnectTimerRef.current) clearTimeout(reconnectTimerRef.current)
+      if (mediaReconnectTimerRef.current)
+        clearTimeout(mediaReconnectTimerRef.current)
+      void closeDataChannels(sessionRef.current)
       sendSocketMessage({ type: "leave" })
       websocketRef.current?.close()
       localAudioTrackRef.current?.stop()
       localScreenTrackRef.current?.stop()
       localFileChannelRef.current?.close()
       localFileChannelRef.current = null
+      for (const channel of dataChannels) channel.close()
+      dataChannels.clear()
       for (const channel of remoteFileChannels.values()) channel.close()
       remoteFileChannels.clear()
       incomingFiles.clear()
       for (const url of objectUrls) URL.revokeObjectURL(url)
       objectUrls.clear()
       dataChannelReadyRef.current = false
+      localTrackMids.clear()
+      mediaReconnectRef.current = null
       peerConnectionRef.current?.close()
       peerConnectionRef.current = null
     }
   }, [
-    connectWebSocket,
-    establishDataChannelTransport,
+    closeDataChannels,
+    connectMediaSession,
     enabled,
+    enableBot,
     nickName,
-    publishTrack,
-    rebuildParticipants,
+    reconnectMedia,
     roomName,
     sendSocketMessage,
   ])
@@ -816,9 +1034,15 @@ export function useSfuChatRoom(
     if (!pc || !session) return
     if (localScreenTrackRef.current) {
       const trackName = localScreenTrackNameRef.current
-      localScreenTrackRef.current.stop()
+      const track = localScreenTrackRef.current
+      track.onended = null
+      try {
+        await closePublishedTrack(trackName)
+      } catch {
+        sendSocketMessage({ type: "unpublish", trackName })
+      }
+      track.stop()
       localScreenTrackRef.current = null
-      sendSocketMessage({ type: "unpublish", trackName })
       rebuildParticipants()
       return
     }
@@ -834,12 +1058,17 @@ export function useSfuChatRoom(
       pc.addTrack(track, display)
       track.onended = () => {
         if (localScreenTrackRef.current === track) {
-          localScreenTrackRef.current = null
-          sendSocketMessage({
-            type: "unpublish",
-            trackName: localScreenTrackNameRef.current,
-          })
-          rebuildParticipants()
+          void closePublishedTrack(localScreenTrackNameRef.current)
+            .catch(() => {
+              sendSocketMessage({
+                type: "unpublish",
+                trackName: localScreenTrackNameRef.current,
+              })
+            })
+            .finally(() => {
+              localScreenTrackRef.current = null
+              rebuildParticipants()
+            })
         }
       }
       rebuildParticipants()
@@ -849,7 +1078,12 @@ export function useSfuChatRoom(
         err instanceof Error ? err.message : "Screen sharing was not started"
       )
     }
-  }, [publishTrack, rebuildParticipants, sendSocketMessage])
+  }, [
+    closePublishedTrack,
+    publishTrack,
+    rebuildParticipants,
+    sendSocketMessage,
+  ])
 
   const sendTextMessage = useCallback(
     (text: string) => {
@@ -929,7 +1163,7 @@ export function useSfuChatRoom(
     expiryWarning,
     connectionStatus,
     resolvedRoomType,
-    botEnabled: false,
+    botEnabled,
     timeLeft,
   }
 }

--- a/app/src/pages/api/bot.ts
+++ b/app/src/pages/api/bot.ts
@@ -3,18 +3,12 @@ import type { NextApiRequest, NextApiResponse } from "next"
 
 import { isAllowedOrigin } from "@common/origin"
 
-interface RoomRecord {
-  meetingId: string
-  createdAt: number
-  roomType: "audio" | "screenshare"
-  botEnabled?: boolean
-}
-
 const ROOM_MAX_AGE_MS = 2 * 60 * 60 * 1000
 
 interface Env {
   ROOMS_KV: KVNamespace
   BOT_SESSION: DurableObjectNamespace
+  SFU_ROOM?: DurableObjectNamespace
 }
 
 const RATE_LIMIT_WINDOW_S = 3600
@@ -30,6 +24,26 @@ async function checkRateLimit(ip: string, env: Env): Promise<boolean> {
     expirationTtl: RATE_LIMIT_WINDOW_S,
   })
   return true
+}
+
+async function getSfuRoomStatus(
+  room: string,
+  env: Env
+): Promise<{ botEnabled: boolean; createdAt: number } | null> {
+  if (!env.SFU_ROOM) return null
+  const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(room))
+  const response = await stub.fetch("https://room/control", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "bot-status" }),
+  })
+  if (!response.ok) return null
+  const status = (await response.json()) as {
+    botEnabled?: boolean
+    createdAt?: number
+  }
+  if (typeof status.createdAt !== "number") return null
+  return { botEnabled: status.botEnabled === true, createdAt: status.createdAt }
 }
 
 export default async function handler(
@@ -85,22 +99,20 @@ export default async function handler(
       return res.status(400).json({ error: "input too long" })
     }
 
-    const roomRaw = await cfEnv.ROOMS_KV.get(`room:${room.trim()}`)
-    if (!roomRaw) {
-      return res.status(404).json({ error: "room not found" })
-    }
-    const roomRecord: RoomRecord = JSON.parse(roomRaw)
-    if (Date.now() - roomRecord.createdAt > ROOM_MAX_AGE_MS) {
+    const roomName = room.trim()
+    const sfuRoom = await getSfuRoomStatus(roomName, cfEnv)
+    if (!sfuRoom) return res.status(404).json({ error: "room not found" })
+    if (Date.now() - sfuRoom.createdAt > ROOM_MAX_AGE_MS) {
       return res.status(410).json({ error: "room expired" })
     }
-    if (!roomRecord.botEnabled) {
+    if (!sfuRoom.botEnabled) {
       return res
         .status(403)
         .json({ error: "AI assistant not enabled for this room" })
     }
 
     const id = cfEnv.BOT_SESSION.idFromName(
-      `room:${roomRecord.meetingId}:${roomRecord.createdAt}`
+      `sfu:${roomName}:${sfuRoom.createdAt}`
     )
     const stub = cfEnv.BOT_SESSION.get(id)
     const doRes = await stub.fetch("https://bot/", {

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -6,6 +6,7 @@ import {
   randomName,
   saveRoomToLocalStorage,
   umamiEvent,
+  trackAnalyticsEvent,
   hashRoom,
 } from "../common/utils"
 import Header from "../components/Header"
@@ -32,6 +33,10 @@ export default function Home() {
         sessionStorage.setItem("enable_bot", enableBot ? "1" : "0")
       }
       const roomType = screenShare ? "screenshare" : "audio"
+      trackAnalyticsEvent("RoomJoinAttempted", {
+        roomType,
+        botEnabled: enableBot,
+      })
       umamiEvent("RoomJoin", { type: roomType, roomHash: hashRoom(roomName) })
       const url =
         "/room?id=" +
@@ -46,6 +51,7 @@ export default function Home() {
       const url =
         window.location.origin + "/room?id=" + encodeURIComponent(roomName)
       navigator.clipboard.writeText(url)
+      trackAnalyticsEvent("InviteLinkCopied", { surface: "landing" })
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     }

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -171,7 +171,34 @@ export async function handleSfuRequest(
       return badRequest("invalid_room")
     if (!name || name.length > MAX_NAME_LENGTH)
       return badRequest("invalid_name")
-    if (!(await verifyTurnstile(body.turnstileToken, env))) {
+
+    const reconnect =
+      body.reconnect && typeof body.reconnect === "object"
+        ? (body.reconnect as Record<string, unknown>)
+        : null
+    const reconnectParticipantId =
+      typeof reconnect?.participantId === "string"
+        ? reconnect.participantId
+        : ""
+    const reconnectToken =
+      typeof reconnect?.participantToken === "string"
+        ? reconnect.participantToken
+        : ""
+    const reconnectSessionId =
+      typeof reconnect?.sessionId === "string" ? reconnect.sessionId : ""
+    const isReconnect = Boolean(
+      reconnectParticipantId && reconnectToken && reconnectSessionId
+    )
+    if (isReconnect) {
+      const auth = await authorize(
+        env,
+        room,
+        reconnectParticipantId,
+        reconnectToken,
+        reconnectSessionId
+      )
+      if (!auth.ok) return auth
+    } else if (!(await verifyTurnstile(body.turnstileToken, env))) {
       return json({ error: "verification_failed" }, 403)
     }
 
@@ -184,28 +211,43 @@ export async function handleSfuRequest(
     const session = (await sessionResponse.json()) as { sessionId?: string }
     if (!session.sessionId) return json({ error: "sfu_session_invalid" }, 502)
 
-    const participantId = crypto.randomUUID()
-    const participantToken = crypto.randomUUID()
-    const registerResponse = await roomControl(env, room, {
-      action: "register",
-      participant: {
-        id: participantId,
-        name,
-        kind,
-        sessionId: session.sessionId,
-        muted: false,
-        tracks: [],
-        joinedAt: Date.now(),
-        token: participantToken,
-      },
-    })
-    if (!registerResponse.ok) return registerResponse
-    const registered = (await registerResponse.json()) as { expiresAt?: number }
+    const participantId = isReconnect
+      ? reconnectParticipantId
+      : crypto.randomUUID()
+    const participantToken = isReconnect ? reconnectToken : crypto.randomUUID()
+    const roomResponse = isReconnect
+      ? await roomControl(env, room, {
+          action: "reconnect",
+          participantId,
+          token: participantToken,
+          sessionId: reconnectSessionId,
+          newSessionId: session.sessionId,
+        })
+      : await roomControl(env, room, {
+          action: "register",
+          enableBot: body.enableBot === true,
+          participant: {
+            id: participantId,
+            name,
+            kind,
+            sessionId: session.sessionId,
+            muted: false,
+            tracks: [],
+            joinedAt: Date.now(),
+            token: participantToken,
+          },
+        })
+    if (!roomResponse.ok) return roomResponse
+    const registered = (await roomResponse.json()) as {
+      expiresAt?: number
+      botEnabled?: boolean
+    }
     const result: SfuSessionResponse = {
       participantId,
       participantToken,
       sessionId: session.sessionId,
       expiresAt: registered.expiresAt ?? Date.now() + 2 * 60 * 60 * 1000,
+      botEnabled: registered.botEnabled === true,
     }
     return json(result)
   }
@@ -226,23 +268,26 @@ export async function handleSfuRequest(
     const requestedTracks = Array.isArray(body.tracks)
       ? (body.tracks as Array<Record<string, unknown>>)
       : []
-    const remoteTrack = requestedTracks.find(
-      (track) => track.location === "remote"
-    )
-    const auth = await authorize(
-      env,
-      room,
-      participantId,
-      token,
-      sessionId,
-      typeof remoteTrack?.sessionId === "string"
-        ? remoteTrack.sessionId
-        : undefined,
-      typeof remoteTrack?.trackName === "string"
-        ? remoteTrack.trackName
-        : undefined
-    )
+    const auth = await authorize(env, room, participantId, token, sessionId)
     if (!auth.ok) return auth
+    for (const remoteTrack of requestedTracks.filter(
+      (track) => track.location === "remote"
+    )) {
+      const remoteAuth = await authorize(
+        env,
+        room,
+        participantId,
+        token,
+        sessionId,
+        typeof remoteTrack.sessionId === "string"
+          ? remoteTrack.sessionId
+          : undefined,
+        typeof remoteTrack.trackName === "string"
+          ? remoteTrack.trackName
+          : undefined
+      )
+      if (!remoteAuth.ok) return remoteAuth
+    }
 
     const upstreamBody =
       route === "tracks"
@@ -282,8 +327,67 @@ export async function handleSfuRequest(
     })
   }
 
-  if (route === "datachannels/establish" || route === "datachannels/new") {
-    if (request.method !== "POST")
+  if (route === "tracks/close") {
+    if (request.method !== "PUT")
+      return json({ error: "method_not_allowed" }, 405)
+    const body = await readBody(request)
+    if (!body) return badRequest("invalid_json")
+    const room = typeof body.room === "string" ? body.room : ""
+    const participantId =
+      typeof body.participantId === "string" ? body.participantId : ""
+    const token = typeof body.token === "string" ? body.token : ""
+    const sessionId = typeof body.sessionId === "string" ? body.sessionId : ""
+    const tracks = Array.isArray(body.tracks)
+      ? body.tracks.filter(
+          (track): track is Record<string, unknown> =>
+            Boolean(track) && typeof track === "object"
+        )
+      : []
+    if (!room || !participantId || !token || !sessionId || !tracks.length)
+      return badRequest("missing_track")
+    if (tracks.some((track) => typeof track.mid !== "string"))
+      return badRequest("invalid_track")
+    const auth = await authorize(env, room, participantId, token, sessionId)
+    if (!auth.ok) return auth
+    const upstream = await realtimeRequest(
+      env,
+      `/sessions/${encodeURIComponent(sessionId)}/tracks/close`,
+      {
+        method: "PUT",
+        body: JSON.stringify({
+          tracks: tracks.map((track) => ({ mid: track.mid })),
+          sessionDescription: body.sessionDescription,
+          force: body.force === true,
+        }),
+      }
+    )
+    const responseBody = await upstream.text()
+    if (!upstream.ok)
+      return new Response(responseBody, { status: upstream.status })
+    for (const track of tracks) {
+      if (typeof track.trackName !== "string") continue
+      await roomControl(env, room, {
+        action: "unpublish",
+        participantId,
+        token,
+        trackName: track.trackName,
+      })
+    }
+    return new Response(responseBody, {
+      status: upstream.status,
+      headers: { "Content-Type": "application/json" },
+    })
+  }
+
+  if (
+    route === "datachannels/establish" ||
+    route === "datachannels/new" ||
+    route === "datachannels/close"
+  ) {
+    if (
+      (route === "datachannels/close" && request.method !== "PUT") ||
+      (route !== "datachannels/close" && request.method !== "POST")
+    )
       return json({ error: "method_not_allowed" }, 405)
     const body = await readBody(request)
     if (!body) return badRequest("invalid_json")
@@ -307,6 +411,56 @@ export async function handleSfuRequest(
         : undefined
     )
     if (!auth.ok) return auth
+    if (route === "datachannels/close") {
+      const dataChannels = Array.isArray(body.dataChannels)
+        ? body.dataChannels.filter(
+            (channel): channel is Record<string, unknown> =>
+              Boolean(channel) && typeof channel === "object"
+          )
+        : []
+      if (
+        !dataChannels.length ||
+        dataChannels.some(
+          (channel) =>
+            typeof channel.id !== "number" ||
+            (channel.sessionId !== undefined &&
+              typeof channel.sessionId !== "string")
+        )
+      )
+        return badRequest("invalid_data_channel")
+      for (const channel of dataChannels) {
+        if (typeof channel.sessionId !== "string") continue
+        const channelAuth = await authorize(
+          env,
+          room,
+          participantId,
+          token,
+          sessionId,
+          undefined,
+          undefined,
+          channel.sessionId
+        )
+        if (!channelAuth.ok) return channelAuth
+      }
+      const upstream = await realtimeRequest(
+        env,
+        `/sessions/${encodeURIComponent(sessionId)}/datachannels/close`,
+        {
+          method: "PUT",
+          body: JSON.stringify({
+            dataChannels: dataChannels.map((channel) => ({
+              id: channel.id,
+              sessionId: channel.sessionId,
+            })),
+          }),
+        }
+      )
+      const responseBody = await upstream.text()
+      return new Response(responseBody, {
+        status: upstream.status,
+        headers: { "Content-Type": "application/json" },
+      })
+    }
     const upstreamBody =
       route === "datachannels/establish"
         ? {

--- a/app/src/sfu/types.ts
+++ b/app/src/sfu/types.ts
@@ -5,6 +5,7 @@ export type SfuTrackKind = "audio" | "video"
 export interface SfuTrack {
   trackName: string
   kind: SfuTrackKind
+  mid?: string
 }
 
 export interface SfuParticipant {
@@ -37,6 +38,7 @@ export interface SfuMessage {
 export interface SfuRoomState {
   createdAt: number
   expiresAt: number
+  botEnabled: boolean
   participants: Array<Omit<SfuParticipant, "token" | "connectionNonce">>
   messages: SfuMessage[]
 }
@@ -44,6 +46,7 @@ export interface SfuRoomState {
 export interface SfuRoomRecord {
   createdAt: number
   expiresAt: number
+  botEnabled: boolean
   participants: Record<string, SfuParticipant>
   messages: SfuMessage[]
 }
@@ -53,4 +56,5 @@ export interface SfuSessionResponse {
   participantToken: string
   sessionId: string
   expiresAt: number
+  botEnabled: boolean
 }


### PR DESCRIPTION
## Summary

- Restore Mixpanel/Zaraz forwarding while keeping Umami events.
- Make the Luna text assistant work on SFU room state and the bot Durable Object.
- Reconnect failed media sessions with a new Cloudflare SFU session while preserving participant identity.
- Validate every remote-track authorization request.
- Close published tracks and file DataChannels during lifecycle transitions.
- Preserve the production-only origin policy and keep legacy RealtimeKit compatibility out of the SFU path.

## Validation

- npx prettier --check .
- yarn type-check
- yarn lint --max-warnings 0
- yarn cf-build

Base branch: cf-sfu.