### PR TITLE
fix: restore sfu message and file readiness state

### DIFF
--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -368,13 +368,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     if (message.type === "datachannel-ready") {
       participant.fileChannelReady = true
       await this.saveRoom(room)
-      await this.broadcast({
-        type: "participantUpdated",
-        participant: {
-          id: participant.id,
-          fileChannelReady: true,
-        },
-      })
+      await this.broadcastState(room)
       return
     }
 

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -52,7 +52,10 @@ interface SfuServerMessage {
   error?: string
 }
 
-const roomMessageToMessage = (message: SfuMessage): Message => {
+const roomMessageToMessage = (
+  message: SfuMessage,
+  localParticipantId?: string
+): Message => {
   if (message.type === "text" && message.text?.startsWith("__bot:")) {
     try {
       const payload = JSON.parse(message.text.slice(6)) as { text?: unknown }
@@ -67,7 +70,8 @@ const roomMessageToMessage = (message: SfuMessage): Message => {
     }
   }
   return {
-    peerId: message.peerId,
+    peerId:
+      message.peerId === localParticipantId ? LOCAL_PEER_ID : message.peerId,
     name: message.name,
     type: message.type === "action" ? "action" : "text",
     text: message.text,
@@ -692,7 +696,12 @@ export function useSfuChatRoom(
           { ...participant, token: "" } as SfuParticipant,
         ])
       )
-      setMessages(state.messages.map(roomMessageToMessage))
+      const localParticipantId = sessionRef.current?.participantId
+      setMessages(
+        state.messages.map((message) =>
+          roomMessageToMessage(message, localParticipantId)
+        )
+      )
       expiresAtRef.current = state.expiresAt
       rebuildParticipants()
       const localId = sessionRef.current?.participantId
@@ -832,9 +841,10 @@ export function useSfuChatRoom(
           rebuildParticipants()
         }
       } else if (message.type === "message" && message.message) {
+        const localParticipantId = sessionRef.current?.participantId
         setMessages((previous) => [
           ...previous,
-          roomMessageToMessage(message.message!),
+          roomMessageToMessage(message.message!, localParticipantId),
         ])
       } else if (message.type === "expired") {
         setError(


### PR DESCRIPTION
## Summary

- map the current SFU participant UUID to LOCAL_PEER_ID for room snapshot and live text/action messages
- persist fileChannelReady and broadcast the full room state after datachannel-ready so join order cannot lose readiness
- preserve the existing SFU DataChannel publisher/subscriber and waitForAck flow

## Validation

- Prettier
- ESLint
- TypeScript
- yarn cf-build

Manual Mac/iPhone file-order and Wi-Fi/mobile reconnect regression testing remains required after deployment.