### PR TITLE
feat: add text-only Agent room MCP

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,8 @@
 
 Free4Chat is a no-sign-up real-time voice, text, file, and screen-sharing chat app.
 
-- Live URL: https://free4.chat
+- Live URL: https://www.free4.chat
+- Canonical host: `www.free4.chat`; `free4.chat` redirects here at Cloudflare
 - Production branch: `cf-sfu`
 - Stack: Next.js 15 → Cloudflare Worker via `@opennextjs/cloudflare`
 - Media: browser WebRTC → Cloudflare Realtime SFU

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,9 @@ free4chat/
 │   │   ├── components/UserCard.tsx
 │   │   ├── components/TextChatCard.tsx
 │   ├── src/sfu/server.ts             # authenticated SFU API proxy
+│   ├── src/mcp/server.ts             # stateless MCP Agent room endpoint
+│   ├── src/room/types.ts             # transport-neutral room contracts
+│   ├── public/agent.md               # machine-readable Agent protocol
 │   ├── worker.ts                     # Worker entry and DO exports
 │   ├── wrangler.jsonc                # production Worker config
 │   └── .dev.vars.example
@@ -48,6 +51,14 @@ All `/api/sfu/*` requests require an `Origin` of `https://free4.chat` or `https:
 5. `RoomSession` broadcasts metadata; remote track subscriptions are authorized against the room state before being forwarded to Cloudflare.
 
 The SFU App ID is a deployment variable. `SFU_APP_SECRET` and `TURNSTILE_SECRET_KEY` are Worker secrets and must never be committed or sent to the browser.
+
+## Agent room protocol
+
+`/mcp` is a stateless MCP v2 endpoint built with `createMcpHandler` from `agents/mcp/server` and `McpServer` from `@modelcontextprotocol/server`. It exposes only `room_info`, `join_room`, `wait_for_events`, `send_text`, and `leave_room`. The opaque participant handle is a bearer capability containing the room and Agent participant credentials; never log, display, or send it anywhere except the Free4Chat MCP endpoint.
+
+Agents are first-class `kind: "agent"` participants with no `media` state. The `/api/sfu/session` route always creates `kind: "human"` participants and must reject Agent sessions. Keep MCP state stateless at the Worker boundary: room participant leases, message cursors, long-poll waiters, sequence numbers, and expiry belong in `RoomSession`. Do not expose a public arbitrary room-control endpoint, OAuth, accounts, R2, or server-side file persistence.
+
+Agent room capabilities are text-only in Phase 1a. `room_info` returns sanitized participant data and capabilities, never tokens, connection nonces, SFU session IDs, track IDs, DataChannel IDs, or message history. `wait_for_events` is a bounded long-poll and lease heartbeat (0–25 seconds); do not replace it with polling loops, queues, or a second Durable Object.
 
 ## DataChannel file transfer
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,7 +67,7 @@ The `/mcp` route uses `createMcpHandler` with a fresh MCP v2 server per request.
 The public room URL is:
 
 ```text
-https://free4.chat/room?id=<room-name>
+https://www.free4.chat/room?id=<room-name>
 ```
 
 `TurnstileGate` wraps the app in `_app.tsx`. The browser sends its session token to `/api/sfu/session`, and the Worker verifies it before creating an SFU session.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,12 +17,14 @@ yarn dev
 
 Required local values are documented in `app/.dev.vars.example`:
 
-| Variable | Description |
-| --- | --- |
-| `SFU_APP_ID` | Cloudflare Realtime SFU App ID |
+| Variable         | Description                        |
+| ---------------- | ---------------------------------- |
+| `SFU_APP_ID`     | Cloudflare Realtime SFU App ID     |
 | `SFU_APP_SECRET` | Cloudflare Realtime SFU App Secret |
 
 Turnstile is optional locally. Set `TURNSTILE_SECRET_KEY` when testing the production verification flow.
+
+The text-only Agent protocol does not require OAuth, an account, or another secret. The local endpoint is `http://localhost:3000/mcp`; native MCP clients may omit `Origin`, while browser clients are restricted to the production and local allowlists. See [`app/public/agent.md`](./app/public/agent.md) for the tool contract.
 
 ## Deployment
 
@@ -32,11 +34,11 @@ Push changes under `app/` to `cf-sfu` to run lint, type-check, build, and deploy
 
 Required GitHub Actions secrets:
 
-| Secret | Description |
-| --- | --- |
-| `CLOUDFLARE_API_TOKEN` | Cloudflare deployment token |
-| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare account ID |
-| `SFU_APP_ID` | Cloudflare Realtime SFU App ID |
+| Secret                           | Description                                  |
+| -------------------------------- | -------------------------------------------- |
+| `CLOUDFLARE_API_TOKEN`           | Cloudflare deployment token                  |
+| `CLOUDFLARE_ACCOUNT_ID`          | Cloudflare account ID                        |
+| `SFU_APP_ID`                     | Cloudflare Realtime SFU App ID               |
 | `NEXT_PUBLIC_TURNSTILE_SITE_KEY` | Public Turnstile site key used at build time |
 
 Worker runtime secrets are stored in Cloudflare, not git:
@@ -60,6 +62,8 @@ npx wrangler deploy \
 
 The browser connects directly to Cloudflare Realtime SFU for audio and screen sharing. `RoomSession` is a hibernating Durable Object for presence, mute state, text, reactions, resync, and room expiry. Files and images use chunked, reliable DataChannels and are never persisted by the application.
 
+The `/mcp` route uses `createMcpHandler` with a fresh MCP v2 server per request. The MCP layer is stateless: it encodes `{ room, participantId, participantToken }` in an opaque URL-safe participant handle, while the Durable Object owns the room participant lease, message cursor, long-poll waiters, and expiry alarm. Agents are first-class text-only participants (`kind: "agent"`) and never receive media/session/track identifiers. `room_info` is read-only; `join_room` may create a two-hour ephemeral room; `wait_for_events` is the lease heartbeat and is capped at 25 seconds.
+
 The public room URL is:
 
 ```text
@@ -78,11 +82,17 @@ free4chat/
 │   │   ├── components/               # Room UI, chat, Turnstile, participants
 │   │   ├── common/origin.ts          # Shared production/local origin policy
 │   │   ├── do/                       # RoomSession
+│   │   ├── mcp/server.ts             # Stateless MCP Agent room endpoint
+│   │   ├── room/types.ts              # Transport-neutral room contracts
 │   │   ├── hooks/useSfuChatRoom.ts   # SFU media and DataChannel transport
 │   │   └── sfu/                      # SFU Worker routes and types
 │   └── wrangler.jsonc
 └── .github/workflows/deploy-web.yml
 ```
+
+## MCP smoke test
+
+After starting the local app, connect an MCP Inspector or another MCP v2 client to `http://localhost:3000/mcp`, initialize it, list tools, and invoke `room_info`. To exercise the participant flow, invoke `join_room`, retain its participant handle privately, then call `wait_for_events` and `send_text`. Do not paste handles or local secrets into logs or issue reports.
 
 ## Future directions
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - 🔒 No accounts, no persistent data
 - ⏱️ Rooms automatically close after 2 hours
 - 🛡️ Cloudflare Turnstile bot protection
+- 🤖 Text-only Agent rooms through stateless MCP
 
 ## Privacy
 
@@ -29,7 +30,7 @@ free4chat is built around two principles: **no data outlives the conversation**,
 - Room presence, recent text/action messages, and track metadata are held by a per-room Durable Object while the room is active. Rooms expire after two hours and the room state is deleted.
 - Your nickname is saved in browser `localStorage` for convenience. Clear it anytime.
 
-The Worker authenticates the room and coordinates presence; audio and screen sharing flow through Cloudflare's media plane, while files stay in browser-to-browser DataChannels.
+The Worker authenticates the room and coordinates presence; audio and screen sharing flow through Cloudflare's media plane, while files stay in browser-to-browser DataChannels. Text-only Agents can join through the stateless [`/mcp`](https://free4.chat/mcp) endpoint. Agent room access is a room capability only: it does not expose local files, shell commands, or any tools on the Agent host. See [`app/public/agent.md`](./app/public/agent.md) for the machine-readable protocol.
 
 ## Tech Stack
 
@@ -39,6 +40,7 @@ The Worker authenticates the room and coordinates presence; audio and screen sha
 | API      | Next.js API routes deployed as Cloudflare Worker via `@opennextjs/cloudflare`        |
 | Storage  | Cloudflare KV (room metadata, rate limiting) + per-room Durable Object state         |
 | Media    | Cloudflare Realtime SFU (WebRTC, audio, data channels, screen sharing)               |
+| Agents   | Cloudflare Workers Agents SDK + MCP v2 (stateless text-only room participant)        |
 | Security | Cloudflare Turnstile (full-page bot challenge) + origin whitelist + KV rate limiting |
 
 ## Stack History

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # free4chat
 
-[free4.chat](https://free4.chat/) — real-time voice + text chat. No sign-up, no server to run. Open a room and talk.
+[www.free4.chat](https://www.free4.chat/) — real-time voice + text chat. No sign-up, no server to run. Open a room and talk.
 
 > ⚠️ Personal project / experimental. Use at your own risk.
 
@@ -30,7 +30,7 @@ free4chat is built around two principles: **no data outlives the conversation**,
 - Room presence, recent text/action messages, and track metadata are held by a per-room Durable Object while the room is active. Rooms expire after two hours and the room state is deleted.
 - Your nickname is saved in browser `localStorage` for convenience. Clear it anytime.
 
-The Worker authenticates the room and coordinates presence; audio and screen sharing flow through Cloudflare's media plane, while files stay in browser-to-browser DataChannels. Text-only Agents can join through the stateless [`/mcp`](https://free4.chat/mcp) endpoint. Agent room access is a room capability only: it does not expose local files, shell commands, or any tools on the Agent host. See [`app/public/agent.md`](./app/public/agent.md) for the machine-readable protocol.
+The Worker authenticates the room and coordinates presence; audio and screen sharing flow through Cloudflare's media plane, while files stay in browser-to-browser DataChannels. Text-only Agents can join through the stateless [`/mcp`](https://www.free4.chat/mcp) endpoint. Agent room access is a room capability only: it does not expose local files, shell commands, or any tools on the Agent host. See [`app/public/agent.md`](./app/public/agent.md) for the machine-readable protocol.
 
 ## Tech Stack
 

--- a/app/package.json
+++ b/app/package.json
@@ -16,11 +16,14 @@
     "prepare": "husky"
   },
   "dependencies": {
+    "@modelcontextprotocol/server": "2.0.0",
+    "agents": "0.21.0",
     "boring-avatars": "^1.7.0",
     "next": "15",
     "react": "19",
     "react-dom": "19",
-    "unique-names-generator": "^4.7.1"
+    "unique-names-generator": "^4.7.1",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240821.1",

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -1,0 +1,21 @@
+# Free4Chat Agent Room Protocol
+
+Free4Chat exposes a stateless MCP endpoint for text-only Agent participants:
+
+```text
+https://free4.chat/mcp
+```
+
+The MCP server provides five tools:
+
+- `room_info(roomId)`: inspect a room without joining.
+- `join_room(roomId, name)`: join as a text-only `agent` and receive an opaque participant handle.
+- `wait_for_events(participantHandle, cursor, timeoutSeconds)`: long-poll for text and action events.
+- `send_text(participantHandle, text)`: send text as the Agent.
+- `leave_room(participantHandle)`: leave and invalidate the handle.
+
+The handle is a bearer capability. Keep it private, pass it only to the Free4Chat MCP endpoint, and do not put it in prompts, logs, telemetry, or user-visible messages. It is not an MCP session ID and does not grant access to local files, shell commands, or other tools on the Agent host.
+
+Agents are room participants only. They have no microphone, screen-share, file DataChannel, or SFU media session. Joining a room grants access to that room's text/action protocol; it does not grant access to the local tools available to the Agent runtime.
+
+Rooms are ephemeral. A room can live for up to two hours, and an Agent participant must refresh its 90-second lease by calling `wait_for_events` or `send_text`. The long-poll cursor is monotonic; events older than the retained window are reported with `truncated: true`.

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -3,7 +3,7 @@
 Free4Chat exposes a stateless MCP endpoint for text-only Agent participants:
 
 ```text
-https://free4.chat/mcp
+https://www.free4.chat/mcp
 ```
 
 The MCP server provides five tools:

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -14,7 +14,7 @@ The MCP server provides five tools:
 - `send_text(participantHandle, text)`: send text as the Agent.
 - `leave_room(participantHandle)`: leave and invalidate the handle.
 
-The handle is a bearer capability. Keep it private, pass it only to the Free4Chat MCP endpoint, and do not put it in prompts, logs, telemetry, or user-visible messages. It is not an MCP session ID and does not grant access to local files, shell commands, or other tools on the Agent host.
+The handle is a bearer capability. Keep it secret and pass it only to the Free4Chat MCP endpoint. Never echo it in room messages, expose it to users, or send it to external logs or telemetry. It is not an MCP session ID and does not grant access to local files, shell commands, or other tools on the Agent host.
 
 Agents are room participants only. They have no microphone, screen-share, file DataChannel, or SFU media session. Joining a room grants access to that room's text/action protocol; it does not grant access to the local tools available to the Agent runtime.
 

--- a/app/src/common/types.tsx
+++ b/app/src/common/types.tsx
@@ -17,6 +17,7 @@ export type ActionType = "whiteboard" | "poll" | "vote" | "game" | "reaction"
 export interface Message {
   peerId: string
   name: string
+  kind?: "human" | "agent"
   type: MessageType
   text?: string
   fileLink?: string

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -650,7 +650,14 @@ export default function TextChatCard({
                 </div>
                 <div style={{ maxWidth: "72%" }}>
                   {!isSelf && (
-                    <p className="mb-1 ml-1 text-xs text-gray-400">{p.name}</p>
+                    <p className="mb-1 ml-1 text-xs text-gray-400">
+                      {p.name}
+                      {p.kind === "agent" && (
+                        <span className="ml-1 text-[10px] text-blue-300">
+                          🤖 Agent
+                        </span>
+                      )}
+                    </p>
                   )}
                   {p.type === "text" ? (
                     <div

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -88,6 +88,11 @@ export default function UserCard(user: UserCardProps) {
           <p className="mt-1.5 w-full truncate text-center text-xs text-white">
             {displayName}
           </p>
+          {user.kind === "agent" && (
+            <span className="mt-1 rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
+              🤖 Agent
+            </span>
+          )}
           {isSelf && (
             <div className="mt-1 flex gap-1">
               <button
@@ -225,7 +230,7 @@ export default function UserCard(user: UserCardProps) {
 
         <div className="mb-1 flex min-h-[18px] items-center justify-center gap-1">
           <span className="rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
-            {user.kind === "agent" ? "Agent" : "Human"}
+            {user.kind === "agent" ? "🤖 Agent" : "Human"}
           </span>
         </div>
 

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -1,16 +1,27 @@
 import { DurableObject } from "cloudflare:workers"
 
 import type {
-  SfuMessage,
-  SfuParticipant,
-  SfuRoomRecord,
-  SfuRoomState,
-  SfuTrack,
-} from "../sfu/types"
+  AgentEvent,
+  RoomCapabilities,
+  RoomMediaTrack,
+  RoomMessage,
+  RoomParticipant,
+  RoomRecord,
+  RoomState,
+} from "../room/types"
 
 const ROOM_MAX_AGE_MS = 2 * 60 * 60 * 1000
 const RECONNECT_GRACE_MS = 30 * 1000
+const AGENT_LEASE_MS = 90 * 1000
 const MAX_MESSAGES = 100
+
+const ROOM_CAPABILITIES: RoomCapabilities = {
+  text: true,
+  audio: true,
+  screenShare: true,
+  files: true,
+  agentText: true,
+}
 
 export interface RoomSessionEnv {
   SFU_ROOM: DurableObjectNamespace<RoomSession>
@@ -22,10 +33,34 @@ interface ConnectionAttachment {
   connectionNonce: string
 }
 
+interface StoredParticipant extends RoomParticipant {
+  sessionId?: string
+  muted?: boolean
+  fileChannelReady?: boolean
+  tracks?: RoomMediaTrack[]
+}
+
+interface StoredRoom
+  extends Omit<
+    RoomRecord,
+    "participants" | "messages" | "nextMessageSequence"
+  > {
+  participants: Record<string, StoredParticipant>
+  messages: Array<Omit<RoomMessage, "sequence"> & { sequence?: number }>
+  nextMessageSequence?: number
+}
+
+interface AgentWaiter {
+  participantId: string
+  cursor: number
+  resolve: (response: Response) => void
+  timer: ReturnType<typeof setTimeout>
+}
+
 type ControlRequest =
   | {
       action: "register"
-      participant: Omit<SfuParticipant, "connected" | "lastSeenAt">
+      participant: Omit<RoomParticipant, "connected" | "lastSeenAt">
     }
   | {
       action: "authorize"
@@ -47,7 +82,7 @@ type ControlRequest =
       action: "publish"
       participantId: string
       token: string
-      track: SfuTrack
+      track: RoomMediaTrack
     }
   | {
       action: "unpublish"
@@ -57,6 +92,29 @@ type ControlRequest =
     }
   | {
       action: "leave"
+      participantId: string
+      token: string
+    }
+  | { action: "room-info" }
+  | {
+      action: "agent-register"
+      participant: Omit<RoomParticipant, "connected" | "lastSeenAt">
+    }
+  | {
+      action: "agent-wait"
+      participantId: string
+      token: string
+      cursor: number
+      timeoutSeconds: number
+    }
+  | {
+      action: "agent-send-text"
+      participantId: string
+      token: string
+      text: string
+    }
+  | {
+      action: "agent-leave"
       participantId: string
       token: string
     }
@@ -75,15 +133,98 @@ type ClientMessage =
   | { type: "leave" }
 
 export class RoomSession extends DurableObject<RoomSessionEnv> {
-  private async loadRoom(): Promise<SfuRoomRecord | null> {
-    return this.ctx.storage.get<SfuRoomRecord>("room")
+  private readonly agentWaiters = new Map<string, Set<AgentWaiter>>()
+
+  private async loadRoom(): Promise<RoomRecord | null> {
+    const stored = await this.ctx.storage.get<StoredRoom>("room")
+    if (!stored) return null
+    const normalized = this.normalizeRoom(stored)
+    if (normalized.changed) await this.saveRoom(normalized.room)
+    return normalized.room
   }
 
-  private async saveRoom(room: SfuRoomRecord): Promise<void> {
+  private normalizeRoom(stored: StoredRoom): {
+    room: RoomRecord
+    changed: boolean
+  } {
+    let changed = false
+    const participants: Record<string, RoomParticipant> = {}
+
+    for (const [id, rawParticipant] of Object.entries(stored.participants)) {
+      const participant = { ...rawParticipant } as StoredParticipant
+      if (participant.kind === "agent") {
+        if (participant.media) {
+          delete participant.media
+          changed = true
+        }
+        if (participant.capabilities?.text !== true) {
+          participant.capabilities = { text: true }
+          changed = true
+        }
+        for (const key of [
+          "sessionId",
+          "muted",
+          "fileChannelReady",
+          "tracks",
+        ] as const) {
+          if (key in participant) {
+            delete participant[key]
+            changed = true
+          }
+        }
+      } else if (!participant.media && participant.sessionId) {
+        participant.media = {
+          sessionId: participant.sessionId,
+          muted: participant.muted === true,
+          fileChannelReady: participant.fileChannelReady === true,
+          tracks: participant.tracks ?? [],
+        }
+        delete participant.sessionId
+        delete participant.muted
+        delete participant.fileChannelReady
+        delete participant.tracks
+        changed = true
+      }
+      participants[id] = participant
+    }
+
+    let nextMessageSequence =
+      typeof stored.nextMessageSequence === "number" &&
+      Number.isSafeInteger(stored.nextMessageSequence) &&
+      stored.nextMessageSequence >= 0
+        ? stored.nextMessageSequence
+        : 0
+    const messages: RoomMessage[] = []
+    for (const rawMessage of stored.messages ?? []) {
+      const sequence =
+        typeof rawMessage.sequence === "number" &&
+        Number.isSafeInteger(rawMessage.sequence) &&
+        rawMessage.sequence > 0
+          ? rawMessage.sequence
+          : nextMessageSequence + 1
+      if (rawMessage.sequence !== sequence) changed = true
+      if (sequence > nextMessageSequence) nextMessageSequence = sequence
+      messages.push({ ...rawMessage, sequence })
+    }
+    if (stored.nextMessageSequence !== nextMessageSequence) changed = true
+
+    return {
+      room: {
+        createdAt: stored.createdAt,
+        expiresAt: stored.expiresAt,
+        participants,
+        messages,
+        nextMessageSequence,
+      },
+      changed,
+    }
+  }
+
+  private async saveRoom(room: RoomRecord): Promise<void> {
     await this.ctx.storage.put("room", room)
   }
 
-  private stateFor(room: SfuRoomRecord): SfuRoomState {
+  private stateFor(room: RoomRecord): RoomState {
     return {
       createdAt: room.createdAt,
       expiresAt: room.expiresAt,
@@ -97,15 +238,25 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
   }
 
+  private participantForInfo(participant: RoomParticipant) {
+    const {
+      token: _token,
+      connectionNonce: _nonce,
+      media: _media,
+      ...safeParticipant
+    } = participant
+    return safeParticipant
+  }
+
   private json(data: unknown, status = 200): Response {
     return Response.json(data, { status })
   }
 
-  private isExpired(room: SfuRoomRecord): boolean {
+  private isExpired(room: RoomRecord): boolean {
     return Date.now() >= room.expiresAt
   }
 
-  private async activeRoom(): Promise<SfuRoomRecord | null> {
+  private async activeRoom(): Promise<RoomRecord | null> {
     const room = await this.loadRoom()
     if (!room) return null
     if (this.isExpired(room)) {
@@ -115,8 +266,22 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     return room
   }
 
-  private async expireRoom(room: SfuRoomRecord): Promise<void> {
+  private async expireRoom(room: RoomRecord): Promise<void> {
     await this.ctx.storage.delete("room")
+    for (const waiterSet of this.agentWaiters.values()) {
+      for (const waiter of waiterSet) {
+        clearTimeout(waiter.timer)
+        waiter.resolve(
+          this.json({
+            events: [],
+            cursor: room.nextMessageSequence,
+            expiresAt: room.expiresAt,
+            expired: true,
+          })
+        )
+      }
+    }
+    this.agentWaiters.clear()
     for (const socket of this.ctx.getWebSockets()) {
       try {
         socket.send(JSON.stringify({ type: "expired" }))
@@ -140,7 +305,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
   }
 
   private async broadcastState(
-    room?: SfuRoomRecord,
+    room?: RoomRecord,
     except?: WebSocket
   ): Promise<void> {
     const current = room ?? (await this.activeRoom())
@@ -152,20 +317,201 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
   }
 
+  private async scheduleNextAlarm(room: RoomRecord): Promise<void> {
+    const deadlines = [room.expiresAt]
+    for (const participant of Object.values(room.participants)) {
+      if (participant.kind === "agent") {
+        deadlines.push(participant.lastSeenAt + AGENT_LEASE_MS)
+      } else if (!participant.connected) {
+        deadlines.push(participant.lastSeenAt + RECONNECT_GRACE_MS)
+      }
+    }
+    await this.ctx.storage.setAlarm(Math.min(...deadlines))
+  }
+
   private findParticipant(
-    room: SfuRoomRecord,
+    room: RoomRecord,
     participantId: string,
     token: string,
     sessionId?: string
-  ): SfuParticipant | null {
+  ): RoomParticipant | null {
     const participant = room.participants[participantId]
     if (!participant || participant.token !== token) return null
-    if (sessionId && participant.sessionId !== sessionId) return null
+    if (sessionId && participant.media?.sessionId !== sessionId) return null
     return participant
   }
 
+  private appendMessage(
+    room: RoomRecord,
+    message: Omit<RoomMessage, "sequence">
+  ): RoomMessage {
+    const roomMessage = {
+      ...message,
+      sequence: room.nextMessageSequence + 1,
+    }
+    room.nextMessageSequence = roomMessage.sequence
+    room.messages = [...room.messages, roomMessage].slice(-MAX_MESSAGES)
+    return roomMessage
+  }
+
+  private toAgentEvent(message: RoomMessage): AgentEvent {
+    return {
+      sequence: message.sequence,
+      type: message.type,
+      participant: {
+        id: message.peerId,
+        name: message.name,
+        kind: message.kind,
+      },
+      ...(message.text === undefined ? {} : { text: message.text }),
+      ...(message.actionType === undefined
+        ? {}
+        : { actionType: message.actionType }),
+      ...(message.actionPayload === undefined
+        ? {}
+        : { actionPayload: message.actionPayload }),
+      createdAt: message.createdAt,
+    }
+  }
+
+  private agentEvents(
+    room: RoomRecord,
+    participantId: string,
+    cursor: number
+  ): {
+    events: AgentEvent[]
+    cursor: number
+    expiresAt: number
+    truncated?: boolean
+  } {
+    const firstSequence = room.messages[0]?.sequence
+    const truncated = firstSequence !== undefined && cursor < firstSequence - 1
+    const effectiveCursor = truncated ? firstSequence - 1 : cursor
+    return {
+      events: room.messages
+        .filter(
+          (message) =>
+            message.sequence > effectiveCursor &&
+            message.peerId !== participantId
+        )
+        .map((message) => this.toAgentEvent(message)),
+      cursor: Math.max(cursor, room.nextMessageSequence),
+      expiresAt: room.expiresAt,
+      ...(truncated ? { truncated: true } : {}),
+    }
+  }
+
+  private finishWaiter(waiter: AgentWaiter, response: Response): void {
+    clearTimeout(waiter.timer)
+    const waiters = this.agentWaiters.get(waiter.participantId)
+    waiters?.delete(waiter)
+    if (waiters?.size === 0) this.agentWaiters.delete(waiter.participantId)
+    waiter.resolve(response)
+  }
+
+  private resolveAgentWaiters(room: RoomRecord): void {
+    for (const waiterSet of this.agentWaiters.values()) {
+      for (const waiter of [...waiterSet]) {
+        const result = this.agentEvents(
+          room,
+          waiter.participantId,
+          waiter.cursor
+        )
+        if (
+          result.events.length > 0 ||
+          result.cursor > waiter.cursor ||
+          result.truncated
+        ) {
+          this.finishWaiter(waiter, this.json(result))
+        }
+      }
+    }
+  }
+
+  private async waitForAgent(
+    request: Extract<ControlRequest, { action: "agent-wait" }>
+  ): Promise<Response> {
+    const room = await this.activeRoom()
+    if (!room) return this.json({ error: "room_expired" }, 410)
+    const participant = this.findParticipant(
+      room,
+      request.participantId,
+      request.token
+    )
+    if (!participant) return this.json({ error: "unauthorized" }, 401)
+    if (participant.kind !== "agent")
+      return this.json({ error: "agent_only" }, 403)
+
+    participant.lastSeenAt = Date.now()
+    await this.saveRoom(room)
+    await this.scheduleNextAlarm(room)
+
+    const result = this.agentEvents(room, participant.id, request.cursor)
+    if (
+      result.events.length > 0 ||
+      result.cursor > request.cursor ||
+      result.truncated ||
+      request.timeoutSeconds === 0
+    ) {
+      return this.json(result)
+    }
+
+    return new Promise<Response>((resolve) => {
+      const waiter: AgentWaiter = {
+        participantId: participant.id,
+        cursor: request.cursor,
+        resolve,
+        timer: setTimeout(() => {
+          const waiters = this.agentWaiters.get(participant.id)
+          waiters?.delete(waiter)
+          if (waiters?.size === 0) this.agentWaiters.delete(participant.id)
+          void this.activeRoom().then((current) => {
+            if (!current) {
+              resolve(
+                this.json({
+                  events: [],
+                  cursor: request.cursor,
+                  expiresAt: room.expiresAt,
+                  expired: true,
+                })
+              )
+              return
+            }
+            resolve(
+              this.json(
+                this.agentEvents(current, participant.id, request.cursor)
+              )
+            )
+          })
+        }, request.timeoutSeconds * 1000),
+      }
+      let waiters = this.agentWaiters.get(participant.id)
+      if (!waiters) {
+        waiters = new Set()
+        this.agentWaiters.set(participant.id, waiters)
+      }
+      waiters.add(waiter)
+    })
+  }
+
   private async handleControl(request: ControlRequest): Promise<Response> {
-    if (request.action === "register") {
+    if (request.action === "room-info") {
+      const room = await this.activeRoom()
+      return this.json({
+        exists: room !== null,
+        expiresAt: room?.expiresAt ?? null,
+        participants: room
+          ? Object.values(room.participants)
+              .filter((participant) => participant.connected)
+              .map((participant) => this.participantForInfo(participant))
+          : [],
+        capabilities: ROOM_CAPABILITIES,
+      })
+    }
+
+    if (request.action === "agent-wait") return this.waitForAgent(request)
+
+    if (request.action === "register" || request.action === "agent-register") {
       const now = Date.now()
       let room = await this.loadRoom()
       if (room && this.isExpired(room)) {
@@ -178,24 +524,105 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           expiresAt: now + ROOM_MAX_AGE_MS,
           participants: {},
           messages: [],
+          nextMessageSequence: 0,
         }
       }
-      const participant: SfuParticipant = {
+      const isAgent = request.action === "agent-register"
+      if (room.participants[request.participant.id])
+        return this.json({ error: "participant_exists" }, 409)
+      if (
+        (isAgent && request.participant.kind !== "agent") ||
+        (!isAgent &&
+          (request.participant.kind !== "human" || !request.participant.media))
+      ) {
+        return this.json({ error: "invalid_participant_kind" }, 400)
+      }
+      const participant: RoomParticipant = {
         ...request.participant,
-        connected: false,
+        connected: isAgent,
         lastSeenAt: now,
-        tracks: request.participant.tracks ?? [],
-        fileChannelReady: false,
+        ...(isAgent ? { capabilities: { text: true }, media: undefined } : {}),
       }
       room.participants[participant.id] = participant
       await this.saveRoom(room)
-      await this.ctx.storage.setAlarm(
-        Math.min(room.expiresAt, now + RECONNECT_GRACE_MS)
-      )
+      await this.scheduleNextAlarm(room)
+      if (isAgent) {
+        await this.broadcastState(room)
+        return this.json({
+          participant: this.participantForInfo(participant),
+          cursor: room.nextMessageSequence,
+          expiresAt: room.expiresAt,
+        })
+      }
       return this.json({
         state: this.stateFor(room),
         expiresAt: room.expiresAt,
       })
+    }
+
+    if (request.action === "agent-send-text") {
+      const room = await this.activeRoom()
+      if (!room) return this.json({ error: "room_expired" }, 410)
+      const participant = this.findParticipant(
+        room,
+        request.participantId,
+        request.token
+      )
+      if (!participant) return this.json({ error: "unauthorized" }, 401)
+      if (participant.kind !== "agent")
+        return this.json({ error: "agent_only" }, 403)
+      const text = request.text.trim()
+      if (!text) return this.json({ error: "text_required" }, 400)
+      participant.lastSeenAt = Date.now()
+      const roomMessage = this.appendMessage(room, {
+        id: crypto.randomUUID(),
+        peerId: participant.id,
+        name: participant.name,
+        kind: participant.kind,
+        type: "text",
+        text: text.slice(0, 4000),
+        createdAt: Date.now(),
+      })
+      await this.saveRoom(room)
+      await this.scheduleNextAlarm(room)
+      await this.broadcast({ type: "message", message: roomMessage })
+      this.resolveAgentWaiters(room)
+      return this.json({
+        sequence: roomMessage.sequence,
+        expiresAt: room.expiresAt,
+      })
+    }
+
+    if (request.action === "agent-leave") {
+      const room = await this.activeRoom()
+      if (!room) return this.json({ error: "room_expired" }, 410)
+      const participant = this.findParticipant(
+        room,
+        request.participantId,
+        request.token
+      )
+      if (!participant) return this.json({ error: "already_left" }, 404)
+      if (participant.kind !== "agent")
+        return this.json({ error: "agent_only" }, 403)
+      delete room.participants[participant.id]
+      await this.saveRoom(room)
+      const waiters = this.agentWaiters.get(participant.id)
+      if (waiters) {
+        for (const waiter of [...waiters]) {
+          this.finishWaiter(
+            waiter,
+            this.json({
+              events: [],
+              cursor: room.nextMessageSequence,
+              expiresAt: room.expiresAt,
+              left: true,
+            })
+          )
+        }
+      }
+      await this.broadcastState(room)
+      await this.scheduleNextAlarm(room)
+      return this.json({ ok: true })
     }
 
     const room = await this.activeRoom()
@@ -212,8 +639,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (request.trackSessionId && request.trackName) {
         const trackExists = Object.values(room.participants).some(
           (candidate) =>
-            candidate.sessionId === request.trackSessionId &&
-            candidate.tracks.some(
+            candidate.media?.sessionId === request.trackSessionId &&
+            candidate.media.tracks.some(
               (track) => track.trackName === request.trackName
             )
         )
@@ -222,7 +649,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (request.dataChannelSessionId) {
         const sessionExists = Object.values(room.participants).some(
           (candidate) =>
-            candidate.sessionId === request.dataChannelSessionId &&
+            candidate.media?.sessionId === request.dataChannelSessionId &&
             candidate.connected
         )
         if (!sessionExists)
@@ -238,18 +665,20 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         request.token,
         request.sessionId
       )
-      if (!participant) return this.json({ error: "unauthorized" }, 401)
-      participant.sessionId = request.newSessionId
+      if (!participant || !participant.media)
+        return this.json({ error: "unauthorized" }, 401)
+      participant.media = {
+        ...participant.media,
+        sessionId: request.newSessionId,
+        fileChannelReady: false,
+        tracks: [],
+      }
       participant.connected = false
       participant.connectionNonce = undefined
-      participant.fileChannelReady = false
-      participant.tracks = []
       participant.lastSeenAt = Date.now()
       await this.saveRoom(room)
-      return this.json({
-        ok: true,
-        expiresAt: room.expiresAt,
-      })
+      await this.scheduleNextAlarm(room)
+      return this.json({ ok: true, expiresAt: room.expiresAt })
     }
 
     const participant = this.findParticipant(
@@ -260,8 +689,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     if (!participant) return this.json({ error: "unauthorized" }, 401)
 
     if (request.action === "publish") {
-      participant.tracks = [
-        ...participant.tracks.filter(
+      if (!participant.media)
+        return this.json({ error: "media_unavailable" }, 400)
+      participant.media.tracks = [
+        ...participant.media.tracks.filter(
           (track) => track.trackName !== request.track.trackName
         ),
         request.track,
@@ -274,7 +705,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           id: participant.id,
           name: participant.name,
           kind: participant.kind,
-          sessionId: participant.sessionId,
+          sessionId: participant.media.sessionId,
           track: request.track,
         },
       })
@@ -282,7 +713,9 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     }
 
     if (request.action === "unpublish") {
-      participant.tracks = participant.tracks.filter(
+      if (!participant.media)
+        return this.json({ error: "media_unavailable" }, 400)
+      participant.media.tracks = participant.media.tracks.filter(
         (track) => track.trackName !== request.trackName
       )
       await this.saveRoom(room)
@@ -293,6 +726,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     delete room.participants[participant.id]
     await this.saveRoom(room)
     await this.broadcastState(room)
+    await this.scheduleNextAlarm(room)
     return this.json({ ok: true })
   }
 
@@ -312,7 +746,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       attachment.participantId,
       attachment.token
     )
-    if (!participant) {
+    if (!participant || participant.kind !== "human" || !participant.media) {
       socket.close(4003, "Unauthorized")
       return
     }
@@ -330,19 +764,13 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       return
     }
     if (message.type === "mute") {
-      participant.muted = message.muted
+      participant.media.muted = message.muted
       await this.saveRoom(room)
-      await this.broadcast({
-        type: "participantUpdated",
-        participant: {
-          id: participant.id,
-          muted: participant.muted,
-        },
-      })
+      await this.broadcastState(room)
       return
     }
     if (message.type === "unpublish") {
-      participant.tracks = participant.tracks.filter(
+      participant.media.tracks = participant.media.tracks.filter(
         (track) => track.trackName !== message.trackName
       )
       await this.saveRoom(room)
@@ -350,30 +778,30 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       return
     }
     if (message.type === "datachannel-ready") {
-      participant.fileChannelReady = true
+      participant.media.fileChannelReady = true
       await this.saveRoom(room)
       await this.broadcastState(room)
       return
     }
 
     if (message.type === "chat" && message.text.trim()) {
-      const roomMessage: SfuMessage = {
+      const roomMessage = this.appendMessage(room, {
         id: crypto.randomUUID(),
         peerId: participant.id,
         name: participant.name,
         kind: participant.kind,
         type: "text",
-        text: message.text.slice(0, 4000),
+        text: message.text.trim().slice(0, 4000),
         createdAt: Date.now(),
-      }
-      room.messages = [...room.messages, roomMessage].slice(-MAX_MESSAGES)
+      })
       await this.saveRoom(room)
       await this.broadcast({ type: "message", message: roomMessage })
+      this.resolveAgentWaiters(room)
       return
     }
 
     if (message.type === "action") {
-      const roomMessage: SfuMessage = {
+      const roomMessage = this.appendMessage(room, {
         id: crypto.randomUUID(),
         peerId: participant.id,
         name: participant.name,
@@ -382,10 +810,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         actionType: message.actionType,
         actionPayload: message.actionPayload,
         createdAt: Date.now(),
-      }
-      room.messages = [...room.messages, roomMessage].slice(-MAX_MESSAGES)
+      })
       await this.saveRoom(room)
       await this.broadcast({ type: "message", message: roomMessage })
+      this.resolveAgentWaiters(room)
     }
   }
 
@@ -401,7 +829,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       const room = await this.activeRoom()
       const participant =
         room && this.findParticipant(room, participantId, token)
-      if (!room || !participant)
+      if (
+        !room ||
+        !participant ||
+        participant.kind !== "human" ||
+        !participant.media
+      )
         return this.json({ error: "unauthorized" }, 401)
 
       const pair = new WebSocketPair()
@@ -468,9 +901,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     participant.lastSeenAt = Date.now()
     participant.connectionNonce = undefined
     await this.saveRoom(room)
-    await this.ctx.storage.setAlarm(
-      Math.min(room.expiresAt, Date.now() + RECONNECT_GRACE_MS)
-    )
+    await this.scheduleNextAlarm(room)
     await this.broadcastState(room)
   }
 
@@ -486,22 +917,38 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       await this.expireRoom(room)
       return
     }
+    let changed = false
     for (const [id, participant] of Object.entries(room.participants)) {
-      if (
+      const expiredHuman =
+        participant.kind === "human" &&
         !participant.connected &&
         participant.lastSeenAt + RECONNECT_GRACE_MS <= now
-      ) {
+      const expiredAgent =
+        participant.kind === "agent" &&
+        participant.lastSeenAt + AGENT_LEASE_MS <= now
+      if (expiredHuman || expiredAgent) {
         delete room.participants[id]
+        changed = true
+        const waiters = this.agentWaiters.get(id)
+        if (waiters) {
+          for (const waiter of [...waiters]) {
+            this.finishWaiter(
+              waiter,
+              this.json({
+                events: [],
+                cursor: room.nextMessageSequence,
+                expiresAt: room.expiresAt,
+                left: true,
+              })
+            )
+          }
+        }
       }
     }
-    await this.saveRoom(room)
-    await this.broadcastState(room)
-    const nextStale = Object.values(room.participants)
-      .filter((participant) => !participant.connected)
-      .map((participant) => participant.lastSeenAt + RECONNECT_GRACE_MS)
-      .sort((a, b) => a - b)[0]
-    if (nextStale)
-      await this.ctx.storage.setAlarm(Math.min(room.expiresAt, nextStale))
-    else await this.ctx.storage.setAlarm(room.expiresAt)
+    if (changed) {
+      await this.saveRoom(room)
+      await this.broadcastState(room)
+    }
+    await this.scheduleNextAlarm(room)
   }
 }

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -133,7 +133,9 @@ type ClientMessage =
   | { type: "leave" }
 
 export class RoomSession extends DurableObject<RoomSessionEnv> {
-  private readonly agentWaiters = new Map<string, Set<AgentWaiter>>()
+  // A participant has at most one outstanding long-poll. A null value is a
+  // short-lived reservation while the request refreshes its lease.
+  private readonly agentWaiters = new Map<string, AgentWaiter | null>()
 
   private async loadRoom(): Promise<RoomRecord | null> {
     const stored = await this.ctx.storage.get<StoredRoom>("room")
@@ -268,18 +270,17 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
 
   private async expireRoom(room: RoomRecord): Promise<void> {
     await this.ctx.storage.delete("room")
-    for (const waiterSet of this.agentWaiters.values()) {
-      for (const waiter of waiterSet) {
-        clearTimeout(waiter.timer)
-        waiter.resolve(
-          this.json({
-            events: [],
-            cursor: room.nextMessageSequence,
-            expiresAt: room.expiresAt,
-            expired: true,
-          })
-        )
-      }
+    for (const waiter of this.agentWaiters.values()) {
+      if (!waiter) continue
+      clearTimeout(waiter.timer)
+      waiter.resolve(
+        this.json({
+          events: [],
+          cursor: room.nextMessageSequence,
+          expiresAt: room.expiresAt,
+          expired: true,
+        })
+      )
     }
     this.agentWaiters.clear()
     for (const socket of this.ctx.getWebSockets()) {
@@ -384,9 +385,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     expiresAt: number
     truncated?: boolean
   } {
+    const serverCursor = room.nextMessageSequence
+    const clampedCursor = Math.min(Math.max(cursor, 0), serverCursor)
     const firstSequence = room.messages[0]?.sequence
-    const truncated = firstSequence !== undefined && cursor < firstSequence - 1
-    const effectiveCursor = truncated ? firstSequence - 1 : cursor
+    const truncated =
+      firstSequence !== undefined && clampedCursor < firstSequence - 1
+    const effectiveCursor = truncated ? firstSequence - 1 : clampedCursor
     return {
       events: room.messages
         .filter(
@@ -395,7 +399,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
             message.peerId !== participantId
         )
         .map((message) => this.toAgentEvent(message)),
-      cursor: Math.max(cursor, room.nextMessageSequence),
+      cursor: serverCursor,
       expiresAt: room.expiresAt,
       ...(truncated ? { truncated: true } : {}),
     }
@@ -403,27 +407,21 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
 
   private finishWaiter(waiter: AgentWaiter, response: Response): void {
     clearTimeout(waiter.timer)
-    const waiters = this.agentWaiters.get(waiter.participantId)
-    waiters?.delete(waiter)
-    if (waiters?.size === 0) this.agentWaiters.delete(waiter.participantId)
+    if (this.agentWaiters.get(waiter.participantId) === waiter)
+      this.agentWaiters.delete(waiter.participantId)
     waiter.resolve(response)
   }
 
   private resolveAgentWaiters(room: RoomRecord): void {
-    for (const waiterSet of this.agentWaiters.values()) {
-      for (const waiter of [...waiterSet]) {
-        const result = this.agentEvents(
-          room,
-          waiter.participantId,
-          waiter.cursor
-        )
-        if (
-          result.events.length > 0 ||
-          result.cursor > waiter.cursor ||
-          result.truncated
-        ) {
-          this.finishWaiter(waiter, this.json(result))
-        }
+    for (const waiter of this.agentWaiters.values()) {
+      if (!waiter) continue
+      const result = this.agentEvents(room, waiter.participantId, waiter.cursor)
+      if (
+        result.events.length > 0 ||
+        result.cursor > waiter.cursor ||
+        result.truncated
+      ) {
+        this.finishWaiter(waiter, this.json(result))
       }
     }
   }
@@ -441,57 +439,63 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     if (!participant) return this.json({ error: "unauthorized" }, 401)
     if (participant.kind !== "agent")
       return this.json({ error: "agent_only" }, 403)
+    if (this.agentWaiters.has(participant.id))
+      return this.json({ error: "wait_already_pending" }, 409)
 
-    participant.lastSeenAt = Date.now()
-    await this.saveRoom(room)
-    await this.scheduleNextAlarm(room)
+    this.agentWaiters.set(participant.id, null)
 
-    const result = this.agentEvents(room, participant.id, request.cursor)
-    if (
-      result.events.length > 0 ||
-      result.cursor > request.cursor ||
-      result.truncated ||
-      request.timeoutSeconds === 0
-    ) {
-      return this.json(result)
-    }
+    try {
+      participant.lastSeenAt = Date.now()
+      await this.saveRoom(room)
+      await this.scheduleNextAlarm(room)
 
-    return new Promise<Response>((resolve) => {
-      const waiter: AgentWaiter = {
-        participantId: participant.id,
-        cursor: request.cursor,
-        resolve,
-        timer: setTimeout(() => {
-          const waiters = this.agentWaiters.get(participant.id)
-          waiters?.delete(waiter)
-          if (waiters?.size === 0) this.agentWaiters.delete(participant.id)
-          void this.activeRoom().then((current) => {
-            if (!current) {
+      const result = this.agentEvents(room, participant.id, request.cursor)
+      const cursorWasAhead = request.cursor > room.nextMessageSequence
+      if (
+        cursorWasAhead ||
+        result.events.length > 0 ||
+        result.cursor > request.cursor ||
+        result.truncated ||
+        request.timeoutSeconds === 0
+      ) {
+        this.agentWaiters.delete(participant.id)
+        return this.json(result)
+      }
+
+      return new Promise<Response>((resolve) => {
+        const waiter: AgentWaiter = {
+          participantId: participant.id,
+          cursor: request.cursor,
+          resolve,
+          timer: setTimeout(() => {
+            if (this.agentWaiters.get(participant.id) !== waiter) return
+            this.agentWaiters.delete(participant.id)
+            void this.activeRoom().then((current) => {
+              if (!current) {
+                resolve(
+                  this.json({
+                    events: [],
+                    cursor: room.nextMessageSequence,
+                    expiresAt: room.expiresAt,
+                    expired: true,
+                  })
+                )
+                return
+              }
               resolve(
-                this.json({
-                  events: [],
-                  cursor: request.cursor,
-                  expiresAt: room.expiresAt,
-                  expired: true,
-                })
+                this.json(
+                  this.agentEvents(current, participant.id, request.cursor)
+                )
               )
-              return
-            }
-            resolve(
-              this.json(
-                this.agentEvents(current, participant.id, request.cursor)
-              )
-            )
-          })
-        }, request.timeoutSeconds * 1000),
-      }
-      let waiters = this.agentWaiters.get(participant.id)
-      if (!waiters) {
-        waiters = new Set()
-        this.agentWaiters.set(participant.id, waiters)
-      }
-      waiters.add(waiter)
-    })
+            })
+          }, request.timeoutSeconds * 1000),
+        }
+        this.agentWaiters.set(participant.id, waiter)
+      })
+    } catch (error) {
+      this.agentWaiters.delete(participant.id)
+      throw error
+    }
   }
 
   private async handleControl(request: ControlRequest): Promise<Response> {
@@ -606,19 +610,19 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         return this.json({ error: "agent_only" }, 403)
       delete room.participants[participant.id]
       await this.saveRoom(room)
-      const waiters = this.agentWaiters.get(participant.id)
-      if (waiters) {
-        for (const waiter of [...waiters]) {
-          this.finishWaiter(
-            waiter,
-            this.json({
-              events: [],
-              cursor: room.nextMessageSequence,
-              expiresAt: room.expiresAt,
-              left: true,
-            })
-          )
-        }
+      const waiter = this.agentWaiters.get(participant.id)
+      if (waiter) {
+        this.finishWaiter(
+          waiter,
+          this.json({
+            events: [],
+            cursor: room.nextMessageSequence,
+            expiresAt: room.expiresAt,
+            left: true,
+          })
+        )
+      } else {
+        this.agentWaiters.delete(participant.id)
       }
       await this.broadcastState(room)
       await this.scheduleNextAlarm(room)
@@ -929,19 +933,19 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (expiredHuman || expiredAgent) {
         delete room.participants[id]
         changed = true
-        const waiters = this.agentWaiters.get(id)
-        if (waiters) {
-          for (const waiter of [...waiters]) {
-            this.finishWaiter(
-              waiter,
-              this.json({
-                events: [],
-                cursor: room.nextMessageSequence,
-                expiresAt: room.expiresAt,
-                left: true,
-              })
-            )
-          }
+        const waiter = this.agentWaiters.get(id)
+        if (waiter) {
+          this.finishWaiter(
+            waiter,
+            this.json({
+              events: [],
+              cursor: room.nextMessageSequence,
+              expiresAt: room.expiresAt,
+              left: true,
+            })
+          )
+        } else {
+          this.agentWaiters.delete(id)
         }
       }
     }

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -65,6 +65,7 @@ const roomMessageToMessage = (
     peerId:
       message.peerId === localParticipantId ? LOCAL_PEER_ID : message.peerId,
     name: message.name,
+    kind: message.kind,
     type: message.type === "action" ? "action" : "text",
     text: message.text,
     actionType: message.actionType as ActionType | undefined,

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -47,7 +47,12 @@ interface SfuServerMessage {
     | "expired"
     | "error"
   state?: SfuRoomState
-  participant?: Partial<SfuParticipant> & { track?: SfuTrack }
+  participant?: Partial<SfuParticipant> & {
+    track?: SfuTrack
+    sessionId?: string
+    muted?: boolean
+    fileChannelReady?: boolean
+  }
   message?: SfuMessage
   error?: string
 }
@@ -134,7 +139,7 @@ export function useSfuChatRoom(
         room: roomName,
         peerId: LOCAL_PEER_ID,
         muteState:
-          local?.muted ?? !(localAudioTrackRef.current?.enabled ?? true),
+          local?.media?.muted ?? !(localAudioTrackRef.current?.enabled ?? true),
         audioStream: localAudioTrackRef.current
           ? new MediaStream([localAudioTrackRef.current])
           : null,
@@ -146,7 +151,7 @@ export function useSfuChatRoom(
     }
     for (const participant of state?.participants ?? []) {
       if (participant.id === localId) continue
-      const hasScreenShare = participant.tracks.some(
+      const hasScreenShare = (participant.media?.tracks ?? []).some(
         (track) => track.kind === "video"
       )
       list.push({
@@ -154,7 +159,7 @@ export function useSfuChatRoom(
         kind: participant.kind,
         room: roomName,
         peerId: participant.id,
-        muteState: participant.muted,
+        muteState: participant.media?.muted,
         audioStream: remoteAudioStreamsRef.current.get(participant.id) ?? null,
         screenShareEnabled: hasScreenShare,
         screenShareStream:
@@ -490,10 +495,11 @@ export function useSfuChatRoom(
         !pc ||
         !session ||
         participant.id === session.participantId ||
-        !participant.fileChannelReady ||
+        !participant.media?.fileChannelReady ||
         remoteFileChannelsRef.current.has(participant.id)
       )
         return
+      const media = participant.media
       const channelKey = participant.id
       const fileChannelName = `files-${participant.id}`
       const response = await apiRequest("datachannels/new", {
@@ -501,11 +507,11 @@ export function useSfuChatRoom(
         participantId: session.participantId,
         token: session.participantToken,
         sessionId: session.sessionId,
-        publisherSessionId: participant.sessionId,
+        publisherSessionId: media.sessionId,
         dataChannels: [
           {
             location: "remote",
-            sessionId: participant.sessionId,
+            sessionId: media.sessionId,
             dataChannelName: fileChannelName,
             ordered: true,
             waitForAck: true,
@@ -615,25 +621,26 @@ export function useSfuChatRoom(
     async (participant: SfuParticipant, track: SfuTrack) => {
       const session = sessionRef.current
       const pc = peerConnectionRef.current
-      if (!session || !pc) return
-      const key = `${participant.id}:${participant.sessionId}:${track.trackName}`
+      const media = participant.media
+      if (!session || !pc || !media) return
+      const key = `${participant.id}:${media.sessionId}:${track.trackName}`
       if (subscribedTracksRef.current.has(key)) return
       if (
-        participantMapRef.current.get(participant.id)?.sessionId !==
-        participant.sessionId
+        participantMapRef.current.get(participant.id)?.media?.sessionId !==
+        media.sessionId
       )
         return
       subscribedTracksRef.current.add(key)
       await enqueueNegotiation(async () => {
         if (
-          participantMapRef.current.get(participant.id)?.sessionId !==
-          participant.sessionId
+          participantMapRef.current.get(participant.id)?.media?.sessionId !==
+          media.sessionId
         )
           return
         pendingRemoteTrackRef.current = {
           peerId: participant.id,
           kind: track.kind,
-          sessionId: participant.sessionId,
+          sessionId: media.sessionId,
         }
         const response = await apiRequest("tracks", {
           room: roomName,
@@ -643,7 +650,7 @@ export function useSfuChatRoom(
           tracks: [
             {
               location: "remote",
-              sessionId: participant.sessionId,
+              sessionId: media.sessionId,
               trackName: track.trackName,
             },
           ],
@@ -671,7 +678,11 @@ export function useSfuChatRoom(
       roomStateRef.current = state
       for (const participant of state.participants) {
         const previous = participantMapRef.current.get(participant.id)
-        if (previous && previous.sessionId !== participant.sessionId)
+        if (
+          previous?.media &&
+          participant.media &&
+          previous.media.sessionId !== participant.media.sessionId
+        )
           resetRemoteParticipant(participant.id)
       }
       participantMapRef.current = new Map(
@@ -693,10 +704,10 @@ export function useSfuChatRoom(
         if (participant.id === localId) continue
         const fullParticipant = participantMapRef.current.get(participant.id)
         if (!fullParticipant) continue
-        for (const track of participant.tracks) {
+        for (const track of participant.media?.tracks ?? []) {
           void subscribeTrack(fullParticipant, track)
         }
-        if (fullParticipant.fileChannelReady)
+        if (fullParticipant.media?.fileChannelReady)
           void subscribeFileChannel(fullParticipant)
       }
     },
@@ -717,7 +728,7 @@ export function useSfuChatRoom(
       const pending = pendingRemoteTrackRef.current
       if (!pending) return
       if (
-        participantMapRef.current.get(pending.peerId)?.sessionId !==
+        participantMapRef.current.get(pending.peerId)?.media?.sessionId !==
         pending.sessionId
       ) {
         pendingRemoteTrackRef.current = null
@@ -777,14 +788,21 @@ export function useSfuChatRoom(
         if (
           current &&
           incomingSessionId &&
-          current.sessionId !== incomingSessionId
+          current.media?.sessionId !== incomingSessionId
         ) {
           resetRemoteParticipant(participantId)
-          current.sessionId = incomingSessionId
-          current.tracks = [message.participant.track]
+          if (current.media) {
+            current.media = {
+              ...current.media,
+              sessionId: incomingSessionId,
+              fileChannelReady: false,
+              tracks: [message.participant.track],
+            }
+          }
         } else if (current) {
-          current.tracks = [
-            ...current.tracks.filter(
+          if (!current.media) return
+          current.media.tracks = [
+            ...current.media.tracks.filter(
               (track) =>
                 track.trackName !== message.participant!.track!.trackName
             ),
@@ -795,10 +813,13 @@ export function useSfuChatRoom(
             id: participantId,
             name: message.participant.name,
             kind: message.participant.kind ?? "human",
-            sessionId: incomingSessionId,
-            muted: false,
             connected: true,
-            tracks: [message.participant.track],
+            media: {
+              sessionId: incomingSessionId,
+              muted: false,
+              fileChannelReady: false,
+              tracks: [message.participant.track],
+            },
             joinedAt: Date.now(),
             lastSeenAt: Date.now(),
             token: "",
@@ -815,12 +836,18 @@ export function useSfuChatRoom(
         const participant = participantMapRef.current.get(
           message.participant.id
         )
-        if (participant && typeof message.participant.muted === "boolean") {
-          participant.muted = message.participant.muted
+        if (
+          participant?.media &&
+          typeof message.participant.muted === "boolean"
+        ) {
+          participant.media.muted = message.participant.muted
           rebuildParticipants()
         }
-        if (participant && message.participant.fileChannelReady === true) {
-          participant.fileChannelReady = true
+        if (
+          participant?.media &&
+          message.participant.fileChannelReady === true
+        ) {
+          participant.media.fileChannelReady = true
           void subscribeFileChannel(participant)
           rebuildParticipants()
         }

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -120,6 +120,8 @@ async function roomControl(
 function controlError(result: ControlResult): string {
   if (result.data.error === "room_expired") return "room_expired"
   if (result.data.error === "already_left") return "already_left"
+  if (result.data.error === "wait_already_pending")
+    return "wait_already_pending"
   if (result.status === 401) return "invalid_participant_handle"
   if (result.status === 403) return "agent_only"
   return "room_unavailable"

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -1,0 +1,304 @@
+import { McpServer, type McpRequestContext } from "@modelcontextprotocol/server"
+import { createMcpHandler, getMcpAuthContext } from "agents/mcp/server"
+import { z } from "zod"
+
+import type { RoomSession } from "../do/RoomSession"
+
+const MAX_ROOM_LENGTH = 64
+const MAX_NAME_LENGTH = 32
+const MAX_TEXT_LENGTH = 4000
+const JOIN_RATE_LIMIT = 10
+const JOIN_RATE_WINDOW_S = 60
+
+const MCP_HOSTNAMES = [
+  "free4.chat",
+  "www.free4.chat",
+  "localhost",
+  "127.0.0.1",
+  "[::1]",
+]
+
+export interface McpEnv {
+  SFU_ROOM: DurableObjectNamespace<RoomSession>
+  ROOMS_KV: KVNamespace
+}
+
+interface AgentHandle {
+  room: string
+  participantId: string
+  participantToken: string
+}
+
+interface ControlResult {
+  ok: boolean
+  status: number
+  data: Record<string, unknown>
+}
+
+function toolResult(data: unknown, isError = false) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data) }],
+    ...(isError ? { isError: true } : {}),
+  }
+}
+
+function toolError(error: string) {
+  return toolResult({ error }, true)
+}
+
+function encodeHandle(handle: AgentHandle): string {
+  const bytes = new TextEncoder().encode(JSON.stringify(handle))
+  let binary = ""
+  for (const byte of bytes) binary += String.fromCharCode(byte)
+  return btoa(binary)
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "")
+}
+
+function decodeHandle(value: string): AgentHandle | null {
+  try {
+    const padded = value.replaceAll("-", "+").replaceAll("_", "/")
+    const binary = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4))
+    const bytes = Uint8Array.from(binary, (character) =>
+      character.charCodeAt(0)
+    )
+    const candidate = JSON.parse(
+      new TextDecoder().decode(bytes)
+    ) as Partial<AgentHandle>
+    if (
+      typeof candidate.room !== "string" ||
+      typeof candidate.participantId !== "string" ||
+      typeof candidate.participantToken !== "string" ||
+      !candidate.room ||
+      !candidate.participantId ||
+      !candidate.participantToken ||
+      candidate.room.length > MAX_ROOM_LENGTH
+    )
+      return null
+    return {
+      room: candidate.room,
+      participantId: candidate.participantId,
+      participantToken: candidate.participantToken,
+    }
+  } catch {
+    return null
+  }
+}
+
+function envFromAuthContext(): McpEnv {
+  const candidate = getMcpAuthContext()?.props.env
+  if (
+    !candidate ||
+    typeof candidate !== "object" ||
+    !("SFU_ROOM" in candidate) ||
+    !("ROOMS_KV" in candidate)
+  ) {
+    throw new Error("MCP environment is unavailable")
+  }
+  return candidate as McpEnv
+}
+
+async function roomControl(
+  env: McpEnv,
+  room: string,
+  body: Record<string, unknown>
+): Promise<ControlResult> {
+  const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(room))
+  const response = await stub.fetch("https://room/control", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  const data = (await response.json().catch(() => ({}))) as Record<
+    string,
+    unknown
+  >
+  return { ok: response.ok, status: response.status, data }
+}
+
+function controlError(result: ControlResult): string {
+  if (result.data.error === "room_expired") return "room_expired"
+  if (result.data.error === "already_left") return "already_left"
+  if (result.status === 401) return "invalid_participant_handle"
+  if (result.status === 403) return "agent_only"
+  return "room_unavailable"
+}
+
+async function allowJoin(
+  env: McpEnv,
+  request: Request | undefined
+): Promise<boolean> {
+  const ip = request?.headers.get("CF-Connecting-IP") || "unknown"
+  const key = `mcp:join:rl:${ip}`
+  const raw = await env.ROOMS_KV.get(key)
+  const count = raw ? Number.parseInt(raw, 10) : 0
+  if (count >= JOIN_RATE_LIMIT) return false
+  await env.ROOMS_KV.put(key, String(count + 1), {
+    expirationTtl: JOIN_RATE_WINDOW_S,
+  })
+  return true
+}
+
+function createMcpServer(context: McpRequestContext) {
+  const env = envFromAuthContext()
+  const server = new McpServer({
+    name: "free4chat-agent-room",
+    version: "1.0.0",
+  })
+
+  server.registerTool(
+    "room_info",
+    {
+      description:
+        "Inspect a Free4Chat room without joining. Returns sanitized participants and capabilities, never room history or media identifiers.",
+      inputSchema: {
+        roomId: z.string().trim().min(1).max(MAX_ROOM_LENGTH),
+      },
+    },
+    async ({ roomId }) => {
+      const result = await roomControl(env, roomId, { action: "room-info" })
+      return result.ok ? toolResult(result.data) : toolError("room_unavailable")
+    }
+  )
+
+  server.registerTool(
+    "join_room",
+    {
+      description:
+        "Join a Free4Chat room as a text-only Agent. The returned participant handle is a capability and must be kept private.",
+      inputSchema: {
+        roomId: z.string().trim().min(1).max(MAX_ROOM_LENGTH),
+        name: z.string().trim().min(1).max(MAX_NAME_LENGTH),
+      },
+    },
+    async ({ roomId, name }) => {
+      if (!(await allowJoin(env, context.requestInfo)))
+        return toolError("rate_limited")
+      const participantId = crypto.randomUUID()
+      const participantToken = crypto.randomUUID()
+      const result = await roomControl(env, roomId, {
+        action: "agent-register",
+        participant: {
+          id: participantId,
+          name,
+          kind: "agent",
+          joinedAt: Date.now(),
+          token: participantToken,
+          capabilities: { text: true },
+        },
+      })
+      if (!result.ok) return toolError(controlError(result))
+      return toolResult({
+        participant: result.data.participant,
+        participantHandle: encodeHandle({
+          room: roomId,
+          participantId,
+          participantToken,
+        }),
+        cursor: result.data.cursor,
+        expiresAt: result.data.expiresAt,
+      })
+    }
+  )
+
+  server.registerTool(
+    "wait_for_events",
+    {
+      description:
+        "Wait for new text or action events in the room. The cursor advances across the Agent's own messages too.",
+      inputSchema: {
+        participantHandle: z.string().min(1),
+        cursor: z.number().int().min(0).default(0),
+        timeoutSeconds: z.number().int().min(0).max(25).default(20),
+      },
+    },
+    async ({ participantHandle, cursor, timeoutSeconds }) => {
+      const handle = decodeHandle(participantHandle)
+      if (!handle) return toolError("invalid_participant_handle")
+      const result = await roomControl(env, handle.room, {
+        action: "agent-wait",
+        participantId: handle.participantId,
+        token: handle.participantToken,
+        cursor,
+        timeoutSeconds,
+      })
+      return result.ok
+        ? toolResult(result.data)
+        : toolError(controlError(result))
+    }
+  )
+
+  server.registerTool(
+    "send_text",
+    {
+      description: "Send one text message to the room as the joined Agent.",
+      inputSchema: {
+        participantHandle: z.string().min(1),
+        text: z.string().trim().min(1).max(MAX_TEXT_LENGTH),
+      },
+    },
+    async ({ participantHandle, text }) => {
+      const handle = decodeHandle(participantHandle)
+      if (!handle) return toolError("invalid_participant_handle")
+      const result = await roomControl(env, handle.room, {
+        action: "agent-send-text",
+        participantId: handle.participantId,
+        token: handle.participantToken,
+        text,
+      })
+      return result.ok
+        ? toolResult(result.data)
+        : toolError(controlError(result))
+    }
+  )
+
+  server.registerTool(
+    "leave_room",
+    {
+      description:
+        "Leave the room and invalidate the Agent participant handle.",
+      inputSchema: {
+        participantHandle: z.string().min(1),
+      },
+    },
+    async ({ participantHandle }) => {
+      const handle = decodeHandle(participantHandle)
+      if (!handle) return toolError("invalid_participant_handle")
+      const result = await roomControl(env, handle.room, {
+        action: "agent-leave",
+        participantId: handle.participantId,
+        token: handle.participantToken,
+      })
+      return result.ok
+        ? toolResult(result.data)
+        : toolError(controlError(result))
+    }
+  )
+
+  return server
+}
+
+export function handleMcpRequest(
+  request: Request,
+  env: McpEnv,
+  ctx: ExecutionContext
+): Promise<Response> {
+  const handler = createMcpHandler(createMcpServer, {
+    route: "/mcp",
+    allowedHostnames: MCP_HOSTNAMES,
+    allowedOriginHostnames: MCP_HOSTNAMES,
+    // CORS response headers are broad for browser-based MCP inspectors; the
+    // explicit origin allowlist above still rejects untrusted browser Origins.
+    corsOptions: {
+      origin: "*",
+      methods: "POST, OPTIONS",
+      headers: "Content-Type, Accept, MCP-Protocol-Version",
+      maxAge: 86400,
+    },
+    legacy: "reject",
+    responseMode: "json",
+    authContext: { props: { env } },
+  })
+  return handler(request, env, ctx)
+}

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -1,0 +1,83 @@
+export type ParticipantKind = "human" | "agent"
+
+export type RoomMediaTrackKind = "audio" | "video"
+
+export interface RoomMediaTrack {
+  trackName: string
+  kind: RoomMediaTrackKind
+  mid?: string
+}
+
+export interface RoomMediaState {
+  sessionId: string
+  muted: boolean
+  fileChannelReady: boolean
+  tracks: RoomMediaTrack[]
+}
+
+export interface AgentCapabilities {
+  text: true
+}
+
+export interface RoomParticipant {
+  id: string
+  name: string
+  kind: ParticipantKind
+  connected: boolean
+  joinedAt: number
+  lastSeenAt: number
+  connectionNonce?: string
+  token: string
+  capabilities?: AgentCapabilities
+  media?: RoomMediaState
+}
+
+export interface RoomMessage {
+  id: string
+  peerId: string
+  name: string
+  kind: ParticipantKind
+  type: "text" | "action"
+  text?: string
+  actionType?: string
+  actionPayload?: Record<string, string>
+  createdAt: number
+  sequence: number
+}
+
+export interface RoomState {
+  createdAt: number
+  expiresAt: number
+  participants: Array<Omit<RoomParticipant, "token" | "connectionNonce">>
+  messages: RoomMessage[]
+}
+
+export interface RoomRecord {
+  createdAt: number
+  expiresAt: number
+  participants: Record<string, RoomParticipant>
+  messages: RoomMessage[]
+  nextMessageSequence: number
+}
+
+export interface RoomCapabilities {
+  text: true
+  audio: true
+  screenShare: true
+  files: true
+  agentText: true
+}
+
+export interface AgentEvent {
+  sequence: number
+  type: "text" | "action"
+  participant: {
+    id: string
+    name: string
+    kind: ParticipantKind
+  }
+  text?: string
+  actionType?: string
+  actionPayload?: Record<string, string>
+  createdAt: number
+}

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -1,4 +1,4 @@
-import type { SfuSessionResponse, SfuTrack, ParticipantKind } from "./types"
+import type { SfuSessionResponse, SfuTrack } from "./types"
 import { isAllowedOrigin } from "../common/origin"
 import type { RoomSession } from "../do/RoomSession"
 
@@ -166,7 +166,7 @@ export async function handleSfuRequest(
     if (!body) return badRequest("invalid_json")
     const room = typeof body.room === "string" ? body.room.trim() : ""
     const name = typeof body.name === "string" ? body.name.trim() : ""
-    const kind: ParticipantKind = body.kind === "agent" ? "agent" : "human"
+    if (body.kind === "agent") return badRequest("agent_sessions_not_supported")
     if (!room || room.length > MAX_ROOM_LENGTH)
       return badRequest("invalid_room")
     if (!name || name.length > MAX_NAME_LENGTH)
@@ -228,10 +228,13 @@ export async function handleSfuRequest(
           participant: {
             id: participantId,
             name,
-            kind,
-            sessionId: session.sessionId,
-            muted: false,
-            tracks: [],
+            kind: "human",
+            media: {
+              sessionId: session.sessionId,
+              muted: false,
+              fileChannelReady: false,
+              tracks: [],
+            },
             joinedAt: Date.now(),
             token: participantToken,
           },

--- a/app/src/sfu/types.ts
+++ b/app/src/sfu/types.ts
@@ -1,52 +1,20 @@
-export type ParticipantKind = "human" | "agent"
+export type {
+  ParticipantKind,
+  RoomMessage as SfuMessage,
+  RoomParticipant as SfuParticipant,
+  RoomRecord as SfuRoomRecord,
+  RoomState as SfuRoomState,
+  RoomMediaTrack as SfuTrack,
+} from "../room/types"
 
 export type SfuTrackKind = "audio" | "video"
 
-export interface SfuTrack {
-  trackName: string
-  kind: SfuTrackKind
-  mid?: string
-}
-
-export interface SfuParticipant {
+export interface SfuPublishedTrackParticipant {
   id: string
   name: string
-  kind: ParticipantKind
+  kind: import("../room/types").ParticipantKind
   sessionId: string
-  muted: boolean
-  connected: boolean
-  fileChannelReady?: boolean
-  tracks: SfuTrack[]
-  joinedAt: number
-  lastSeenAt: number
-  connectionNonce?: string
-  token: string
-}
-
-export interface SfuMessage {
-  id: string
-  peerId: string
-  name: string
-  kind: ParticipantKind
-  type: "text" | "action"
-  text?: string
-  actionType?: string
-  actionPayload?: Record<string, string>
-  createdAt: number
-}
-
-export interface SfuRoomState {
-  createdAt: number
-  expiresAt: number
-  participants: Array<Omit<SfuParticipant, "token" | "connectionNonce">>
-  messages: SfuMessage[]
-}
-
-export interface SfuRoomRecord {
-  createdAt: number
-  expiresAt: number
-  participants: Record<string, SfuParticipant>
-  messages: SfuMessage[]
+  track: import("../room/types").RoomMediaTrack
 }
 
 export interface SfuSessionResponse {

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -9,7 +9,7 @@
     "noEmit": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -2,12 +2,17 @@
 import { default as handler } from "./.open-next/worker.js"
 
 import { handleSfuRequest } from "./src/sfu/server"
+import { handleMcpRequest } from "./src/mcp/server"
 
 export { RoomSession } from "./src/do/RoomSession"
 
 export default {
   async fetch(request, env, ctx) {
-    if (new URL(request.url).pathname.startsWith("/api/sfu/")) {
+    const pathname = new URL(request.url).pathname
+    if (pathname === "/mcp") {
+      return handleMcpRequest(request, env, ctx)
+    }
+    if (pathname.startsWith("/api/sfu/")) {
       return handleSfuRequest(request, env)
     }
     return handler.fetch(request, env, ctx)

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -805,6 +805,168 @@
   resolved "https://registry.yarnpkg.com/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz#802f6a50f6b6589063ef63ba8acdee86fcb9f395"
   integrity sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==
 
+"@babel/code-frame@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-8.0.0.tgz#f374ea9392011ffecf223805dd0d9315606e5bbf"
+  integrity sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^8.0.0"
+    js-tokens "^10.0.0"
+
+"@babel/generator@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-8.0.0.tgz#24b7b53a74fa8e74cc2377e054fecef4dcdada96"
+  integrity sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==
+  dependencies:
+    "@babel/parser" "^8.0.0"
+    "@babel/types" "^8.0.0"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    "@types/jsesc" "^2.5.0"
+    jsesc "^3.0.2"
+
+"@babel/helper-annotate-as-pure@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-8.0.0.tgz#e094d0ea95f319cdc399fe25ec82e4b3dddb8461"
+  integrity sha512-NSpMkMsvvZqzThJ0p1B02cbtA2ObEyfBvq950bmNkyxsxvcxwhvvCB036rKhlEnuBBo30bOrk13u3FzlKSoRrw==
+  dependencies:
+    "@babel/types" "^8.0.0"
+
+"@babel/helper-create-class-features-plugin@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-8.0.1.tgz#d8c5f55a3741a5f7d526bb4bfc361805601ef954"
+  integrity sha512-++t3ZktzlLmASAxIlxeXQK9Z2YwUafYGYcvGBFevqOqt16HozVHStUoQvWD09fzAZOb/uJGpUTBuGK41AJAuOA==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^8.0.0"
+    "@babel/helper-member-expression-to-functions" "^8.0.0"
+    "@babel/helper-optimise-call-expression" "^8.0.0"
+    "@babel/helper-replace-supers" "^8.0.1"
+    "@babel/helper-skip-transparent-expression-wrappers" "^8.0.0"
+    "@babel/traverse" "^8.0.0"
+    semver "^7.7.3"
+
+"@babel/helper-globals@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-globals/-/helper-globals-8.0.0.tgz#c93789d6c1c2f1b65a97a07515c471a049559bf1"
+  integrity sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==
+
+"@babel/helper-member-expression-to-functions@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-8.0.0.tgz#c097e24f7aeb60ab08966ef6c2127fc8ee32449e"
+  integrity sha512-xkXrMbtk87Gk7+oKBVmBc6EORg/Qwx++AHESldmHkpvG8wgccdhJJFwrzqlF382Fk8wfXhJHWE/g/43QvEGNPQ==
+  dependencies:
+    "@babel/traverse" "^8.0.0"
+    "@babel/types" "^8.0.0"
+
+"@babel/helper-optimise-call-expression@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-8.0.0.tgz#dc1118493494fbfc3bb24b490550673908a99b6c"
+  integrity sha512-3W6satvtPuCUkUx63S2jMoW9EQNYkADgs1HTfufmL7gCmAulHMKupA/12WNz4A0GMMFn/YnWWwqOT9IZrJHQjg==
+  dependencies:
+    "@babel/types" "^8.0.0"
+
+"@babel/helper-plugin-utils@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-8.0.1.tgz#d1c9d8ae225902c597deac8c79ace4227feac8af"
+  integrity sha512-3PKFgjTyPlhFhorfP+SjKQxLViIL++zWjFOO4hGriYU+Bsm983DxEM1JmDRJVWXV0O9npu+xXRqz7Pbd3mh70g==
+
+"@babel/helper-replace-supers@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-8.0.1.tgz#c9b23aba6b9aff16cacac135052e790cde8d7d5b"
+  integrity sha512-B1SZADIcy3tmH8CmWvj4SHi/oAPom4UL3uknTc2QRNsPVLFk/sPnZvQL/8kj7Y5omvjMqie0vklvs6XM4OLW5Q==
+  dependencies:
+    "@babel/helper-member-expression-to-functions" "^8.0.0"
+    "@babel/helper-optimise-call-expression" "^8.0.0"
+    "@babel/traverse" "^8.0.0"
+
+"@babel/helper-skip-transparent-expression-wrappers@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-8.0.0.tgz#27a6db3fb4ed17d2b32dbb69c4b30be346d8e8a6"
+  integrity sha512-xmCA9kP3IhySsqhzwIdWGlDN/1A4cCKNBO/uwZx/3YzmDoMePwno2Q5/Bq0q+tYaKbeF940YiKV/kaW8Mzvpjw==
+  dependencies:
+    "@babel/traverse" "^8.0.0"
+    "@babel/types" "^8.0.0"
+
+"@babel/helper-string-parser@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-8.0.0.tgz#4d47d9ad35d0f5bd7d202b348bf558328a347977"
+  integrity sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==
+
+"@babel/helper-validator-identifier@^8.0.0", "@babel/helper-validator-identifier@^8.0.4":
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-8.0.4.tgz#60e427a9be7a101af52f14588def2dad8a9f9881"
+  integrity sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==
+
+"@babel/parser@^8.0.0", "@babel/parser@^8.0.4":
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-8.0.4.tgz#244e21ca23ab54c6f5373af2122cb3a618f9dd39"
+  integrity sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==
+  dependencies:
+    "@babel/types" "^8.0.4"
+
+"@babel/plugin-proposal-decorators@^8.0.2":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-8.0.2.tgz#6adfcc236c53a77d9bab33813b8799b2c55a04e5"
+  integrity sha512-+C6O6KKXU7BBq1GNaIkFJxrALUVGRcr+WeWm4OcuRl3h+l/CmNfcTLMrT2Lm3uvGBimBH/8pEBRrXJFLoO67Gg==
+  dependencies:
+    "@babel/helper-create-class-features-plugin" "^8.0.1"
+    "@babel/helper-plugin-utils" "^8.0.1"
+    "@babel/plugin-syntax-decorators" "^8.0.1"
+
+"@babel/plugin-syntax-decorators@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-8.0.1.tgz#e32484d8b60b7b1fdf588ecde6e8e605d355ae52"
+  integrity sha512-NI+0S/6MvR6GlcQFwjDZ+WIc2qvG6TXN534lYs9llNldwW4b7Dh6KTtk030FA0xWdYGs4t1lWo+OEWN8wGB+Nw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^8.0.1"
+
+"@babel/runtime-corejs3@^7.26.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz#2030fda34f3433647818660093751fb1ca2debf0"
+  integrity sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==
+  dependencies:
+    core-js-pure "^3.48.0"
+
+"@babel/runtime@^7.26.0":
+  version "7.29.7"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.7.tgz#12022450c45a4da6d8d8287b18a4ff2ddb23f768"
+  integrity sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==
+
+"@babel/template@^8.0.0":
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-8.0.0.tgz#18c12626b0d6d23a0443771655864ed7566a3452"
+  integrity sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==
+  dependencies:
+    "@babel/code-frame" "^8.0.0"
+    "@babel/parser" "^8.0.0"
+    "@babel/types" "^8.0.0"
+
+"@babel/traverse@^8.0.0":
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-8.0.4.tgz#71fc3f8861a4548e7f2938fdecac73e25d1db1ed"
+  integrity sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==
+  dependencies:
+    "@babel/code-frame" "^8.0.0"
+    "@babel/generator" "^8.0.0"
+    "@babel/helper-globals" "^8.0.0"
+    "@babel/parser" "^8.0.4"
+    "@babel/template" "^8.0.0"
+    "@babel/types" "^8.0.4"
+    obug "^2.1.1"
+
+"@babel/types@^8.0.0", "@babel/types@^8.0.4":
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-8.0.4.tgz#8c208701320c9f0323b5b6a233d093e52c1e3b41"
+  integrity sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==
+  dependencies:
+    "@babel/helper-string-parser" "^8.0.0"
+    "@babel/helper-validator-identifier" "^8.0.4"
+
+"@cfworker/json-schema@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@cfworker/json-schema/-/json-schema-4.1.1.tgz#4a2a3947ee9fa7b7c24be981422831b8674c3be6"
+  integrity sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==
+
 "@cloudflare/kv-asset-handler@0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz#d448d971aca78c04c39432a862298fb77f295527"
@@ -904,6 +1066,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz#815b39267f9bffd3407ea6c376ac32946e24f8d2"
   integrity sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==
 
+"@esbuild/aix-ppc64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz#bf6e10303bcf2e7c686975fa52f937ec2728d8bc"
+  integrity sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==
+
 "@esbuild/android-arm64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.4.tgz#d11d4fc299224e729e2190cacadbcc00e7a9fd67"
@@ -913,6 +1080,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz#19b882408829ad8e12b10aff2840711b2da361e8"
   integrity sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==
+
+"@esbuild/android-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz#0c6246bc8d2c4d172aac2db3fb1190d72bd65504"
+  integrity sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==
 
 "@esbuild/android-arm@0.25.4":
   version "0.25.4"
@@ -924,6 +1096,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.27.3.tgz#90be58de27915efa27b767fcbdb37a4470627d7b"
   integrity sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==
 
+"@esbuild/android-arm@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.2.tgz#2d84ece6a4e2684d92be26ee13d42757d831c381"
+  integrity sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==
+
 "@esbuild/android-x64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.4.tgz#18ddde705bf984e8cd9efec54e199ac18bc7bee1"
@@ -933,6 +1110,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.27.3.tgz#d7dcc976f16e01a9aaa2f9b938fbec7389f895ac"
   integrity sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==
+
+"@esbuild/android-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.2.tgz#fc38d4d6358d8dc1cf53f09f7589fe436eb64801"
+  integrity sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==
 
 "@esbuild/darwin-arm64@0.25.4":
   version "0.25.4"
@@ -944,6 +1126,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz#9f6cac72b3a8532298a6a4493ed639a8988e8abd"
   integrity sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==
 
+"@esbuild/darwin-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz#f83afeeac1d7dac01c7a2fd012b3e451a0591fcc"
+  integrity sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==
+
 "@esbuild/darwin-x64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.4.tgz#e6813fdeba0bba356cb350a4b80543fbe66bf26f"
@@ -953,6 +1140,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz#ac61d645faa37fd650340f1866b0812e1fb14d6a"
   integrity sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==
+
+"@esbuild/darwin-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz#510147c055a795588dbbe14fd6b1b8ad0a2f30de"
+  integrity sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==
 
 "@esbuild/freebsd-arm64@0.25.4":
   version "0.25.4"
@@ -964,6 +1156,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz#b8625689d73cf1830fe58c39051acdc12474ea1b"
   integrity sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==
 
+"@esbuild/freebsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz#093b9200ecf0b115ba4e5e248a7485c9c5f8bd5e"
+  integrity sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==
+
 "@esbuild/freebsd-x64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.4.tgz#91da08db8bd1bff5f31924c57a81dab26e93a143"
@@ -973,6 +1170,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz#07be7dd3c9d42fe0eccd2ab9f9ded780bc53bead"
   integrity sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==
+
+"@esbuild/freebsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz#0be22b6df925d213e841ea87123af5df80b0faf7"
+  integrity sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==
 
 "@esbuild/linux-arm64@0.25.4":
   version "0.25.4"
@@ -984,6 +1186,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz#bf31918fe5c798586460d2b3d6c46ed2c01ca0b6"
   integrity sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==
 
+"@esbuild/linux-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz#1bdbc651cda9ba9995c53ed9c71ceaa65094762d"
+  integrity sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==
+
 "@esbuild/linux-arm@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.4.tgz#9b93c3e54ac49a2ede6f906e705d5d906f6db9e8"
@@ -993,6 +1200,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz#28493ee46abec1dc3f500223cd9f8d2df08f9d11"
   integrity sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==
+
+"@esbuild/linux-arm@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz#beb12ad72b84f72d28488cc1b8ee9f7eb141d753"
+  integrity sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==
 
 "@esbuild/linux-ia32@0.25.4":
   version "0.25.4"
@@ -1004,6 +1216,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz#750752a8b30b43647402561eea764d0a41d0ee29"
   integrity sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==
 
+"@esbuild/linux-ia32@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz#b81f9d55529b45c206a46a138214b1aa6879696b"
+  integrity sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==
+
 "@esbuild/linux-loong64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.4.tgz#b0840a2707c3fc02eec288d3f9defa3827cd7a87"
@@ -1013,6 +1230,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz#a5a92813a04e71198c50f05adfaf18fc1e95b9ed"
   integrity sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==
+
+"@esbuild/linux-loong64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz#598667241a04c99b76ed6ef940ac50038c419f98"
+  integrity sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==
 
 "@esbuild/linux-mips64el@0.25.4":
   version "0.25.4"
@@ -1024,6 +1246,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz#deb45d7fd2d2161eadf1fbc593637ed766d50bb1"
   integrity sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==
 
+"@esbuild/linux-mips64el@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz#1c51eb9cea903f53d97b5af3b1841db70f5596ca"
+  integrity sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==
+
 "@esbuild/linux-ppc64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.4.tgz#64f4ae0b923d7dd72fb860b9b22edb42007cf8f5"
@@ -1033,6 +1260,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz#6f39ae0b8c4d3d2d61a65b26df79f6e12a1c3d78"
   integrity sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==
+
+"@esbuild/linux-ppc64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz#63dd61f17ceb31a81227f413feac8a71bc2c51f2"
+  integrity sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==
 
 "@esbuild/linux-riscv64@0.25.4":
   version "0.25.4"
@@ -1044,6 +1276,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz#4c5c19c3916612ec8e3915187030b9df0b955c1d"
   integrity sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==
 
+"@esbuild/linux-riscv64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz#3763b08fde5cf25ab1facb8e7752edfe45fbfc27"
+  integrity sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==
+
 "@esbuild/linux-s390x@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.4.tgz#1466876e0aa3560c7673e63fdebc8278707bc750"
@@ -1053,6 +1290,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz#9ed17b3198fa08ad5ccaa9e74f6c0aff7ad0156d"
   integrity sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==
+
+"@esbuild/linux-s390x@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz#1a137ff293a82906eb3176385bd7e8e0e5cfb7cb"
+  integrity sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==
 
 "@esbuild/linux-x64@0.25.4":
   version "0.25.4"
@@ -1064,6 +1306,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz#12383dcbf71b7cf6513e58b4b08d95a710bf52a5"
   integrity sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==
 
+"@esbuild/linux-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz#268b36211c146ca54f8fe12c578a8d6ef8979485"
+  integrity sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==
+
 "@esbuild/netbsd-arm64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.4.tgz#02e483fbcbe3f18f0b02612a941b77be76c111a4"
@@ -1073,6 +1320,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz#dd0cb2fa543205fcd931df44f4786bfcce6df7d7"
   integrity sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==
+
+"@esbuild/netbsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz#22571ad951d62bb6accc82d8d1fad5c8c1ac0ba1"
+  integrity sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==
 
 "@esbuild/netbsd-x64@0.25.4":
   version "0.25.4"
@@ -1084,6 +1336,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz#028ad1807a8e03e155153b2d025b506c3787354b"
   integrity sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==
 
+"@esbuild/netbsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz#42fcc57297eb0a0ca3f5fc475291f4c1a3f7c0de"
+  integrity sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==
+
 "@esbuild/openbsd-arm64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.4.tgz#f272c2f41cfea1d91b93d487a51b5c5ca7a8c8c4"
@@ -1093,6 +1350,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz#e3c16ff3490c9b59b969fffca87f350ffc0e2af5"
   integrity sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==
+
+"@esbuild/openbsd-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz#9eb32af104ac3dacf4edca01f596664aab0c73ef"
+  integrity sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==
 
 "@esbuild/openbsd-x64@0.25.4":
   version "0.25.4"
@@ -1104,10 +1366,20 @@
   resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz#c5a4693fcb03d1cbecbf8b422422468dfc0d2a8b"
   integrity sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==
 
+"@esbuild/openbsd-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz#febed2402d6088225e91f20fb4ce2522ad0a4efd"
+  integrity sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==
+
 "@esbuild/openharmony-arm64@0.27.3":
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz#082082444f12db564a0775a41e1991c0e125055e"
   integrity sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==
+
+"@esbuild/openharmony-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz#85641c3d466428bfbccea5f21c26836663fef5ce"
+  integrity sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==
 
 "@esbuild/sunos-x64@0.25.4":
   version "0.25.4"
@@ -1119,6 +1391,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz#5ab036c53f929e8405c4e96e865a424160a1b537"
   integrity sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==
 
+"@esbuild/sunos-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz#a736f9d8962481045fc4c3e54f5479f22c870fb4"
+  integrity sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==
+
 "@esbuild/win32-arm64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.4.tgz#b4dbcb57b21eeaf8331e424c3999b89d8951dc88"
@@ -1128,6 +1405,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz#38de700ef4b960a0045370c171794526e589862e"
   integrity sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==
+
+"@esbuild/win32-arm64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz#ee5ab40fad186201b652a33f8a5eb149e9e42532"
+  integrity sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==
 
 "@esbuild/win32-ia32@0.25.4":
   version "0.25.4"
@@ -1139,6 +1421,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz#451b93dc03ec5d4f38619e6cd64d9f9eff06f55c"
   integrity sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==
 
+"@esbuild/win32-ia32@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz#c40d28a6d99a127da6711f2afd74b11cb63b06a7"
+  integrity sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==
+
 "@esbuild/win32-x64@0.25.4":
   version "0.25.4"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.4.tgz#0b17ec8a70b2385827d52314c1253160a0b9bacc"
@@ -1148,6 +1435,11 @@
   version "0.27.3"
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz#0eaf705c941a218a43dba8e09f1df1d6cd2f1f17"
   integrity sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==
+
+"@esbuild/win32-x64@0.28.2":
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz#b21affb804cc167c133d95f45b3a1dc1323b9a87"
+  integrity sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
@@ -1364,7 +1656,7 @@
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-9.0.0.tgz#4d0a3f127058043bf2e7ee169eaf30ed901302f3"
   integrity sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==
 
-"@jridgewell/gen-mapping@^0.3.2", "@jridgewell/gen-mapping@^0.3.5":
+"@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.2", "@jridgewell/gen-mapping@^0.3.5":
   version "0.3.13"
   resolved "https://registry.yarnpkg.com/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz#6342a19f44347518c93e43b1ac69deb3c4656a1f"
   integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
@@ -1398,13 +1690,28 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
   resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz#db15d6781c931f3a251a3dac39501c98a6082fd0"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@modelcontextprotocol/core@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/core/-/core-2.0.0.tgz#c918a4c6aef22a7c59dfb0aabc2a82c187cce157"
+  integrity sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==
+  dependencies:
+    zod "^4.2.0"
+
+"@modelcontextprotocol/server@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@modelcontextprotocol/server/-/server-2.0.0.tgz#4fae5ccb8f7925ed9a6bf6595bb3b58617063ffd"
+  integrity sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==
+  dependencies:
+    "@modelcontextprotocol/core" "2.0.0"
+    zod "^4.2.0"
 
 "@napi-rs/wasm-runtime@^0.2.11":
   version "0.2.12"
@@ -1603,6 +1910,13 @@
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@poppinss/exception/-/exception-1.2.3.tgz#b713855e6c9fe2110fea0949455c50828145e64a"
   integrity sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==
+
+"@rolldown/plugin-babel@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@rolldown/plugin-babel/-/plugin-babel-0.2.3.tgz#94f2c897285160aab1a7cfe827cbca1b7233e4f4"
+  integrity sha512-+zEk16yGlz1F9STiRr6uG9hmIXb6nprjLczV/htGptYuLoCuxb+itZ03RKCEeOhBpDDd1NU7qF6x1VLMUp62bw==
+  dependencies:
+    picomatch "^4.0.4"
 
 "@rtsao/scc@^1.1.0":
   version "1.1.0"
@@ -1970,6 +2284,11 @@
   dependencies:
     tslib "^2.4.0"
 
+"@types/jsesc@^2.5.0":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@types/jsesc/-/jsesc-2.5.1.tgz#c34defc608ec94b68dc6a12a581b440942c6d503"
+  integrity sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -2245,6 +2564,23 @@ agentkeepalive@^4.2.1:
   integrity sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==
   dependencies:
     humanize-ms "^1.2.1"
+
+agents@0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/agents/-/agents-0.21.0.tgz#4c375aa2ad81390c21680361fda03396293617ab"
+  integrity sha512-8A048JJFMog7t68NrIQOT9CGcQ9O+h8NpP/Udw2kd4fAHvDn2T/+3Do85XT+xGj2VpciGbW+58RwLpVM9AA9eA==
+  dependencies:
+    "@babel/plugin-proposal-decorators" "^8.0.2"
+    "@cfworker/json-schema" "^4.1.1"
+    "@rolldown/plugin-babel" "^0.2.3"
+    cron-schedule "^6.0.0"
+    esbuild "^0.28.1"
+    mimetext "^3.0.28"
+    nanoid "^5.1.16"
+    partyserver "^0.5.9"
+    partysocket "1.3.0"
+    yaml "^2.9.0"
+    yargs "^18.0.0"
 
 ajv@^6.12.4:
   version "6.15.0"
@@ -2760,6 +3096,16 @@ cookie@^0.7.0, cookie@^0.7.1, cookie@^1.0.2:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
   integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
+core-js-pure@^3.48.0:
+  version "3.50.0"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.50.0.tgz#263313e83606cb527005885da5be36c0a28f65ef"
+  integrity sha512-6GP3Pxz4IKyWjAfa747vIu/jilB5z29JWROLqH/b+pXVcpgh6tM06ZIBwSuglgVqzDYURhOK6oEzTrG0bCHitA==
+
+cron-schedule@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cron-schedule/-/cron-schedule-6.0.0.tgz#62f4fa6a980c2c14f322deaaaeee4c27f9f0c84f"
+  integrity sha512-BoZaseYGXOo5j5HUwTaegIog3JJbuH4BbrY9A1ArLjXpy+RWb3mV28F/9Gv1dDA7E2L8kngWva4NWisnLTyfgQ==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -3157,6 +3503,38 @@ esbuild@0.27.3:
     "@esbuild/win32-ia32" "0.27.3"
     "@esbuild/win32-x64" "0.27.3"
 
+esbuild@^0.28.1:
+  version "0.28.2"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.28.2.tgz#0f43bd1bad955b72d24e2261e3abe5957ccf0816"
+  integrity sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.28.2"
+    "@esbuild/android-arm" "0.28.2"
+    "@esbuild/android-arm64" "0.28.2"
+    "@esbuild/android-x64" "0.28.2"
+    "@esbuild/darwin-arm64" "0.28.2"
+    "@esbuild/darwin-x64" "0.28.2"
+    "@esbuild/freebsd-arm64" "0.28.2"
+    "@esbuild/freebsd-x64" "0.28.2"
+    "@esbuild/linux-arm" "0.28.2"
+    "@esbuild/linux-arm64" "0.28.2"
+    "@esbuild/linux-ia32" "0.28.2"
+    "@esbuild/linux-loong64" "0.28.2"
+    "@esbuild/linux-mips64el" "0.28.2"
+    "@esbuild/linux-ppc64" "0.28.2"
+    "@esbuild/linux-riscv64" "0.28.2"
+    "@esbuild/linux-s390x" "0.28.2"
+    "@esbuild/linux-x64" "0.28.2"
+    "@esbuild/netbsd-arm64" "0.28.2"
+    "@esbuild/netbsd-x64" "0.28.2"
+    "@esbuild/openbsd-arm64" "0.28.2"
+    "@esbuild/openbsd-x64" "0.28.2"
+    "@esbuild/openharmony-arm64" "0.28.2"
+    "@esbuild/sunos-x64" "0.28.2"
+    "@esbuild/win32-arm64" "0.28.2"
+    "@esbuild/win32-ia32" "0.28.2"
+    "@esbuild/win32-x64" "0.28.2"
+
 escalade@^3.1.1, escalade@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.2.0.tgz#011a3f69856ba189dffa7dc8fcce99d2a87903e5"
@@ -3420,6 +3798,11 @@ etag@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
+
+event-target-polyfill@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/event-target-polyfill/-/event-target-polyfill-0.0.4.tgz#060ee66e85aaedc76b6fa66079782dcc11cba496"
+  integrity sha512-Gs6RLjzlLRdT8X9ZipJdIZI/Y6/HhRLyq9RdDlCsnpxr/+Nn6bU2EFGuC94GjxqhM+Nmij2Vcq98yoHrU8uNFQ==
 
 event-target-shim@^5.0.0:
   version "5.0.1"
@@ -4261,6 +4644,16 @@ jiti@^1.21.7:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.7.tgz#9dd81043424a3d28458b193d965f0d18a2300ba9"
   integrity sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==
 
+js-base64@^3.7.7:
+  version "3.9.3"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.9.3.tgz#77b34aa20a765d150be687fc348d59fe7d022188"
+  integrity sha512-uwYQp+VJ38FVvtim6qNbit6e9uT6dwWQ4Y1+H9TxhW5hcHjpHwoxlR0nMpqUmIFOmu4VqMxwdJA88gIVuZJQ/g==
+
+js-tokens@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-10.0.0.tgz#dffe7599b4a8bb7fe30aff8d0235234dffb79831"
+  integrity sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==
+
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -4272,6 +4665,11 @@ js-yaml@^4.1.0:
   integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
   dependencies:
     argparse "^2.0.1"
+
+jsesc@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
+  integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -4458,7 +4856,7 @@ mime-db@^1.54.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.12:
+mime-types@^2.1.12, mime-types@^2.1.35:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -4471,6 +4869,16 @@ mime-types@^3.0.0, mime-types@^3.0.2:
   integrity sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==
   dependencies:
     mime-db "^1.54.0"
+
+mimetext@^3.0.28:
+  version "3.0.28"
+  resolved "https://registry.yarnpkg.com/mimetext/-/mimetext-3.0.28.tgz#ffa6292cd13c0913b0783161cd93018203debc09"
+  integrity sha512-eQXpbNrtxLCjUtiVbR/qR09dbPgZ2o+KR1uA7QKqGhbn8QV7HIL16mXXsobBL4/8TqoYh1us31kfz+dNfCev9g==
+  dependencies:
+    "@babel/runtime" "^7.26.0"
+    "@babel/runtime-corejs3" "^7.26.0"
+    js-base64 "^3.7.7"
+    mime-types "^2.1.35"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -4577,6 +4985,11 @@ nanoid@^3.3.11:
   version "3.3.12"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.12.tgz#ab3d912e217a6d0a514f00a72a16543a28982c05"
   integrity sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==
+
+nanoid@^5.1.16, nanoid@^5.1.9:
+  version "5.1.16"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-5.1.16.tgz#fe345c0a1f9007c32fbb5c139e1208bfd3f41ef7"
+  integrity sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==
 
 napi-postinstall@^0.3.0:
   version "0.3.4"
@@ -4741,6 +5154,11 @@ obliterator@^1.6.1:
   resolved "https://registry.yarnpkg.com/obliterator/-/obliterator-1.6.1.tgz#dea03e8ab821f6c4d96a299e17aef6a3af994ef3"
   integrity sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==
 
+obug@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/obug/-/obug-2.1.4.tgz#9090d8a548a522517915d2aa6aae907197ac6cf8"
+  integrity sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==
+
 on-finished@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.4.1.tgz#58c8c44116e54845ad57f14ab10b03533184ac3f"
@@ -4827,6 +5245,20 @@ parseurl@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
+
+partyserver@^0.5.9:
+  version "0.5.10"
+  resolved "https://registry.yarnpkg.com/partyserver/-/partyserver-0.5.10.tgz#ead5f52df1b66e712a7b4c9b1bfcbf2959e4b793"
+  integrity sha512-t2B3mhTL1IOxCsj8rZgn4TxTuub7oLhypjc1/fGPNsbgnn9OsHms6uR3QEd5bFJ/7xrFo771j3DdUlll8cxgBg==
+  dependencies:
+    nanoid "^5.1.9"
+
+partysocket@1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/partysocket/-/partysocket-1.3.0.tgz#154e993404c878b7dbb3890f355f63960872936b"
+  integrity sha512-1zToNyolZFK/7nuAw/K2bZrNzFqaZyRoCEkS+9vG6WSC5ikrN6qWRe96q6ImU51uptz2r+dAwSkwhJVdQi4LiA==
+  dependencies:
+    event-target-polyfill "^0.0.4"
 
 path-exists@^4.0.0:
   version "4.0.0"
@@ -6084,7 +6516,7 @@ y18n@^5.0.5:
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
 
-yaml@^2.7.0, yaml@^2.8.1:
+yaml@^2.7.0, yaml@^2.8.1, yaml@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
   integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==
@@ -6129,3 +6561,8 @@ youch@4.1.0-beta.10:
     "@speed-highlight/core" "^1.2.7"
     cookie "^1.0.2"
     youch-core "^0.3.3"
+
+zod@4.4.3, zod@^4.2.0:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-4.4.3.tgz#b680f172885d18bbebf21a834ea25e55a1bbf356"
+  integrity sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==


### PR DESCRIPTION
## Summary

Implements Issue #63 Phase 1a as a new stateless MCP path on top of the existing SFU room protocol.

- Adds `/mcp` using Cloudflare Agents SDK `createMcpHandler` and MCP v2.
- Adds `room_info`, `join_room`, `wait_for_events`, `send_text`, and `leave_room`.
- Makes Agents first-class text-only participants with opaque capability handles and 90-second leases.
- Adds monotonic room message cursors, bounded long-poll waiters, unified Durable Object expiry alarms, and lazy migration for active legacy room records.
- Separates transport-neutral room types from SFU-specific types while preserving browser media reconnect, track rollover, and DataChannel behavior.
- Adds `app/public/agent.md` plus README, development, and agent guidance.
- Keeps `/api/sfu/session` human-only and does not add OAuth, accounts, R2, or server-side file persistence.

## Validation

- `yarn install --frozen-lockfile`
- `yarn prettier --check .`
- `yarn lint`
- `yarn type-check`
- `yarn cf-build`
- `npx wrangler deploy --dry-run --outdir /tmp/free4chat-agent-dry-run-final`
- Local MCP v2 smoke: `server/discover`, `tools/list`, `room_info`, `join_room`, `send_text`, `wait_for_events`, and `leave_room`; capability handles were kept private and redacted from output.

No production deployment was performed. This PR targets `cf-sfu` and is intentionally not merged.