### PR TITLE
fix: preserve DataChannel files across room sync

### DIFF
--- a/app/src/common/messageReconciliation.ts
+++ b/app/src/common/messageReconciliation.ts
@@ -1,0 +1,20 @@
+import type { Message } from "./types"
+
+/**
+ * RoomState is authoritative for text/actions, while file messages are
+ * intentionally session-local DataChannel messages. Keep both sources in
+ * the rendered timeline without letting a state refresh discard files.
+ */
+export function mergeRoomAndEphemeralMessages(
+  roomMessages: Message[],
+  ephemeralMessages: Message[]
+): Message[] {
+  return [...roomMessages, ...ephemeralMessages]
+    .map((message, index) => ({ message, index }))
+    .sort((left, right) => {
+      const leftCreatedAt = left.message.createdAt ?? 0
+      const rightCreatedAt = right.message.createdAt ?? 0
+      return leftCreatedAt - rightCreatedAt || left.index - right.index
+    })
+    .map(({ message }) => message)
+}

--- a/app/src/common/types.tsx
+++ b/app/src/common/types.tsx
@@ -19,6 +19,10 @@ export interface Message {
   name: string
   kind?: "human" | "agent"
   type: MessageType
+  messageId?: string
+  createdAt?: number
+  sequence?: number
+  ephemeral?: boolean
   text?: string
   fileLink?: string
   fileName?: string

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
+import { mergeRoomAndEphemeralMessages } from "@common/messageReconciliation"
 import { ActionType, Message, UserInfo } from "@common/types"
 
 import type {
@@ -114,6 +115,9 @@ const roomMessageToMessage = (
     name: message.name,
     kind: message.kind,
     type: message.type === "action" ? "action" : "text",
+    messageId: message.id,
+    createdAt: message.createdAt,
+    sequence: message.sequence,
     text: message.text,
     actionType: message.actionType as ActionType | undefined,
     actionPayload: message.actionPayload,
@@ -169,6 +173,8 @@ export function useSfuChatRoom(
   const localTrackMidsRef = useRef(new Map<string, string>())
   const incomingFilesRef = useRef(new Map<string, IncomingFileTransfer>())
   const objectUrlsRef = useRef(new Set<string>())
+  const roomMessagesRef = useRef<Message[]>([])
+  const ephemeralMessagesRef = useRef<Message[]>([])
   const fileSendQueueRef = useRef(Promise.resolve())
   const dataChannelReadyRef = useRef(false)
   const closingRef = useRef(false)
@@ -346,29 +352,68 @@ export function useSfuChatRoom(
     []
   )
 
+  const replaceRoomMessages = useCallback((nextMessages: Message[]) => {
+    roomMessagesRef.current = nextMessages
+    setMessages(
+      mergeRoomAndEphemeralMessages(
+        roomMessagesRef.current,
+        ephemeralMessagesRef.current
+      )
+    )
+  }, [])
+
+  const appendRoomMessage = useCallback((message: Message) => {
+    roomMessagesRef.current = [...roomMessagesRef.current, message]
+    setMessages(
+      mergeRoomAndEphemeralMessages(
+        roomMessagesRef.current,
+        ephemeralMessagesRef.current
+      )
+    )
+  }, [])
+
+  const appendEphemeralMessage = useCallback((message: Message) => {
+    if (
+      message.messageId &&
+      ephemeralMessagesRef.current.some(
+        (existing) => existing.messageId === message.messageId
+      )
+    )
+      return
+    ephemeralMessagesRef.current = [
+      ...ephemeralMessagesRef.current,
+      { ...message, ephemeral: true },
+    ]
+    setMessages(
+      mergeRoomAndEphemeralMessages(
+        roomMessagesRef.current,
+        ephemeralMessagesRef.current
+      )
+    )
+  }, [])
+
   const addReceivedFileMessage = useCallback(
     (
       peerId: string,
       name: string,
-      file: Pick<IncomingFileTransfer, "name" | "mime" | "size">,
+      file: Pick<IncomingFileTransfer, "id" | "name" | "mime" | "size">,
       chunks: ArrayBuffer[]
     ) => {
       const blob = new Blob(chunks, { type: file.mime })
       const fileLink = URL.createObjectURL(blob)
       objectUrlsRef.current.add(fileLink)
-      setMessages((previous) => [
-        ...previous,
-        {
-          peerId,
-          name,
-          type: file.mime.startsWith("image/") ? "image" : "file",
-          fileLink,
-          fileName: file.name,
-          fileSize: file.size,
-        },
-      ])
+      appendEphemeralMessage({
+        peerId,
+        name,
+        type: file.mime.startsWith("image/") ? "image" : "file",
+        messageId: file.id,
+        createdAt: Date.now(),
+        fileLink,
+        fileName: file.name,
+        fileSize: file.size,
+      })
     },
-    []
+    [appendEphemeralMessage]
   )
 
   const resetRemoteParticipant = useCallback((participantId: string) => {
@@ -740,7 +785,7 @@ export function useSfuChatRoom(
         ])
       )
       const localParticipantId = sessionRef.current?.participantId
-      setMessages(
+      replaceRoomMessages(
         state.messages.map((message) =>
           roomMessageToMessage(message, localParticipantId)
         )
@@ -762,6 +807,7 @@ export function useSfuChatRoom(
     [
       rebuildParticipants,
       resetRemoteParticipant,
+      replaceRoomMessages,
       subscribeFileChannel,
       subscribeTrack,
     ]
@@ -901,10 +947,9 @@ export function useSfuChatRoom(
         }
       } else if (message.type === "message" && message.message) {
         const localParticipantId = sessionRef.current?.participantId
-        setMessages((previous) => [
-          ...previous,
-          roomMessageToMessage(message.message!, localParticipantId),
-        ])
+        appendRoomMessage(
+          roomMessageToMessage(message.message, localParticipantId)
+        )
       } else if (message.type === "expired") {
         setError(
           "This room has expired (2-hour limit). Please open a new room."
@@ -931,6 +976,7 @@ export function useSfuChatRoom(
       )
     }
   }, [
+    appendRoomMessage,
     applyRoomState,
     rebuildParticipants,
     resetRemoteParticipant,
@@ -1149,6 +1195,8 @@ export function useSfuChatRoom(
       incomingFiles.clear()
       for (const url of objectUrls) URL.revokeObjectURL(url)
       objectUrls.clear()
+      roomMessagesRef.current = []
+      ephemeralMessagesRef.current = []
       dataChannelReadyRef.current = false
       localTrackMids.clear()
       mediaReconnectRef.current = null
@@ -1274,17 +1322,16 @@ export function useSfuChatRoom(
         channel.send(JSON.stringify({ type: "file-end", id }))
         const fileLink = URL.createObjectURL(file)
         objectUrlsRef.current.add(fileLink)
-        setMessages((previous) => [
-          ...previous,
-          {
-            peerId: LOCAL_PEER_ID,
-            name: nickName,
-            type: mime.startsWith("image/") ? "image" : "file",
-            fileLink,
-            fileName: file.name,
-            fileSize: file.size,
-          },
-        ])
+        appendEphemeralMessage({
+          peerId: LOCAL_PEER_ID,
+          name: nickName,
+          type: mime.startsWith("image/") ? "image" : "file",
+          messageId: id,
+          createdAt: Date.now(),
+          fileLink,
+          fileName: file.name,
+          fileSize: file.size,
+        })
         const session = sessionRef.current
         const hasConnectedAgent = [...participantMapRef.current.values()].some(
           (participant) => participant.kind === "agent" && participant.connected
@@ -1317,7 +1364,13 @@ export function useSfuChatRoom(
       )
       return next
     },
-    [nickName, roomName, waitForDataChannelOpen, waitForSendCapacity]
+    [
+      appendEphemeralMessage,
+      nickName,
+      roomName,
+      waitForDataChannelOpen,
+      waitForSendCapacity,
+    ]
   )
 
   return {


### PR DESCRIPTION
## Summary

Human files and images are intentionally delivered through SFU DataChannels and are not included in the durable `RoomState.messages` snapshot. The Browser previously replaced its complete local message array whenever a room state arrived, so a later join/leave, mute, readiness, reconnect, or resync could make a visible DataChannel file bubble disappear.

This PR keeps the existing DataChannel architecture and adds a small client-side reconciliation boundary:

- durable RoomState text/actions are tracked separately from ephemeral DataChannel file/image messages;
- both sources are merged for rendering in chronological order;
- DataChannel transfer IDs become stable ephemeral message IDs, preventing duplicate bubbles;
- object URLs remain alive across room state refreshes and are revoked exactly once during hook cleanup;
- Agent attachment relay remains best-effort and independent of the Human-visible file bubble.

No server-side file persistence, R2, RoomSession redesign, SFU change, or Agent lifecycle work is included.

## Validation

- `cd app && yarn install --frozen-lockfile`
- `yarn prettier --check .`
- `yarn lint --max-warnings 0`
- `yarn type-check`
- `yarn cf-build`
- `npx wrangler deploy --dry-run`

All passed. The OpenNext build emitted the existing local Durable Object bundle warning; the production Worker bindings were listed successfully by dry-run. No deployment was performed.

Manual Mac/iPhone file regression remains the final browser acceptance step after review: both directions, participant join/leave, mute/unmute, Agent join/leave, reconnect/resync, generic files, images, text ordering, and no duplicate bubbles.
