### PR TITLE
feat: add a minimal discovery surface for Free4Chat

### DIFF
--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,0 +1,7 @@
+User-agent: *
+Allow: /
+Disallow: /room
+Disallow: /mcp
+Disallow: /api/
+
+Sitemap: https://www.free4.chat/sitemap.xml

--- a/app/public/robots.txt
+++ b/app/public/robots.txt
@@ -1,6 +1,5 @@
 User-agent: *
 Allow: /
-Disallow: /room
 Disallow: /mcp
 Disallow: /api/
 

--- a/app/public/sitemap.xml
+++ b/app/public/sitemap.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://www.free4.chat/</loc>
+  </url>
+  <url>
+    <loc>https://www.free4.chat/temporary-chat-room</loc>
+  </url>
+  <url>
+    <loc>https://www.free4.chat/ai-agent-room</loc>
+  </url>
+  <url>
+    <loc>https://www.free4.chat/privacy</loc>
+  </url>
+  <url>
+    <loc>https://www.free4.chat/developers/mcp</loc>
+  </url>
+</urlset>

--- a/app/src/__tests__/discovery/copy-accuracy.test.ts
+++ b/app/src/__tests__/discovery/copy-accuracy.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const ROOT = process.cwd()
+
+function read(relativePath: string): string {
+  return readFileSync(join(ROOT, relativePath), "utf-8")
+}
+
+describe("Privacy copy accuracy", () => {
+  const source = read("src/pages/privacy.tsx")
+
+  it("does not make an unqualified 'no database of files or images' claim — the Agent-image exception must be acknowledged in the same breath", () => {
+    // The old, inaccurate wording had no "exception"/"Agent" language
+    // anywhere near the "never written to server storage" claim.
+    const noDatabaseClaim = source.match(/No database of[^.]*\./)?.[0]
+    expect(
+      noDatabaseClaim,
+      "expected a 'No database of...' sentence"
+    ).toBeTruthy()
+    expect(noDatabaseClaim!.toLowerCase()).toMatch(/human-to-human/)
+  })
+
+  it("discloses the bounded Agent-image copy stored in the room Durable Object", () => {
+    expect(source.toLowerCase()).toMatch(/agent/)
+    expect(source).toMatch(/Durable Object/)
+    expect(source.toLowerCase()).toMatch(/bounded/)
+  })
+
+  it("discloses that BOTH room name and nickname are saved in localStorage, until manually cleared", () => {
+    expect(source).toMatch(/room name/i)
+    expect(source).toMatch(/nickname/i)
+    expect(source).toMatch(/localStorage/)
+    expect(source).toMatch(/clear/i)
+  })
+})
+
+describe("Homepage and /temporary-chat-room copy accuracy", () => {
+  const homepage = read("src/pages/index.tsx")
+  const temporaryRoom = read("src/pages/temporary-chat-room.tsx")
+
+  it("does not claim nothing persists once the tab closes", () => {
+    for (const source of [homepage, temporaryRoom]) {
+      expect(source).not.toMatch(/close the tab and it.s gone/i)
+      expect(source).not.toMatch(/nothing left behind/i)
+    }
+  })
+
+  it("scopes 'no history' claims to Free4Chat's servers, not an absolute guarantee", () => {
+    expect(homepage).toMatch(/no permanent room history/i)
+    expect(temporaryRoom).toMatch(
+      /no permanent (room )?history on our servers/i
+    )
+  })
+})
+
+describe("/ai-agent-room copy accuracy", () => {
+  const source = read("src/pages/ai-agent-room.tsx")
+
+  it("does not claim every Agent necessarily joins through the local Agent Runtime", () => {
+    expect(source).toMatch(/direct/i)
+    expect(source).toMatch(/MCP/)
+    // The old wording asserted the Runtime step unconditionally; the fixed
+    // copy must present it as one of (at least) two paths.
+    expect(source).toMatch(/resident/i)
+  })
+})

--- a/app/src/__tests__/discovery/crawl-surface.test.ts
+++ b/app/src/__tests__/discovery/crawl-surface.test.ts
@@ -13,10 +13,13 @@ describe("robots.txt", () => {
     expect(robots).toMatch(/Allow:\s*\//)
   })
 
-  it("disallows ephemeral room URLs, the API, and the Agent MCP endpoint", () => {
-    expect(robots).toMatch(/Disallow:\s*\/room/)
+  it("disallows the API and the Agent MCP endpoint", () => {
     expect(robots).toMatch(/Disallow:\s*\/mcp/)
     expect(robots).toMatch(/Disallow:\s*\/api\//)
+  })
+
+  it("does NOT disallow /room — it relies on a page-level noindex meta tag, which crawlers can only read if they're allowed to fetch the page", () => {
+    expect(robots).not.toMatch(/Disallow:\s*\/room\b/)
   })
 
   it("points to the sitemap", () => {
@@ -68,6 +71,13 @@ describe("sitemap.xml", () => {
         expect(loc).not.toContain(slug)
       }
     }
+  })
+})
+
+describe("_document.tsx", () => {
+  it("does not set a description meta tag (next/document renders unconditionally on every page and next/head does not dedupe plain <meta> tags, so a fallback here would duplicate each page's own description)", () => {
+    const source = readFileSync(join(ROOT, "src/pages/_document.tsx"), "utf-8")
+    expect(source).not.toMatch(/name="description"/)
   })
 })
 

--- a/app/src/__tests__/discovery/crawl-surface.test.ts
+++ b/app/src/__tests__/discovery/crawl-surface.test.ts
@@ -1,0 +1,86 @@
+import { existsSync, readFileSync } from "node:fs"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const ROOT = process.cwd()
+
+describe("robots.txt", () => {
+  const robots = readFileSync(join(ROOT, "public/robots.txt"), "utf-8")
+
+  it("allows crawling by default", () => {
+    expect(robots).toMatch(/User-agent:\s*\*/)
+    expect(robots).toMatch(/Allow:\s*\//)
+  })
+
+  it("disallows ephemeral room URLs, the API, and the Agent MCP endpoint", () => {
+    expect(robots).toMatch(/Disallow:\s*\/room/)
+    expect(robots).toMatch(/Disallow:\s*\/mcp/)
+    expect(robots).toMatch(/Disallow:\s*\/api\//)
+  })
+
+  it("points to the sitemap", () => {
+    expect(robots).toMatch(
+      /Sitemap:\s*https:\/\/www\.free4\.chat\/sitemap\.xml/
+    )
+  })
+})
+
+describe("sitemap.xml", () => {
+  const sitemap = readFileSync(join(ROOT, "public/sitemap.xml"), "utf-8")
+  const locs = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((m) => m[1])
+
+  it("is well-formed XML with at least one URL", () => {
+    expect(sitemap).toMatch(/^<\?xml/)
+    expect(sitemap).toContain("<urlset")
+    expect(locs.length).toBeGreaterThan(0)
+  })
+
+  it("lists exactly the shipped public/discovery pages", () => {
+    expect(new Set(locs)).toEqual(
+      new Set([
+        "https://www.free4.chat/",
+        "https://www.free4.chat/temporary-chat-room",
+        "https://www.free4.chat/ai-agent-room",
+        "https://www.free4.chat/privacy",
+        "https://www.free4.chat/developers/mcp",
+      ])
+    )
+  })
+
+  it("never includes ephemeral room URLs, query strings, or the raw MCP API endpoint", () => {
+    for (const loc of locs) {
+      expect(loc).not.toMatch(/\/room\b/)
+      expect(loc).not.toContain("?")
+      expect(loc).not.toBe("https://www.free4.chat/mcp")
+    }
+  })
+
+  it("never includes unshipped future-feature pages", () => {
+    const unshipped = [
+      "voice-agent",
+      "meeting-notes",
+      "agent-games",
+      "live-translation",
+    ]
+    for (const loc of locs) {
+      for (const slug of unshipped) {
+        expect(loc).not.toContain(slug)
+      }
+    }
+  })
+})
+
+describe("Future/unshipped discovery pages are not present", () => {
+  const unshippedRoutes = [
+    "voice-agent.tsx",
+    "meeting-notes.tsx",
+    "agent-games.tsx",
+    "live-translation.tsx",
+    "private-voice-chat.tsx",
+  ]
+
+  it.each(unshippedRoutes)("src/pages/%s does not exist yet", (file) => {
+    expect(existsSync(join(ROOT, "src/pages", file))).toBe(false)
+  })
+})

--- a/app/src/__tests__/discovery/pages-cta.test.tsx
+++ b/app/src/__tests__/discovery/pages-cta.test.tsx
@@ -1,0 +1,54 @@
+import type { ReactElement } from "react"
+
+import { render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import AiAgentRoomPage from "../../pages/ai-agent-room"
+import DevelopersMcpPage from "../../pages/developers/mcp"
+import PrivacyPage from "../../pages/privacy"
+import TemporaryChatRoomPage from "../../pages/temporary-chat-room"
+
+const PAGES: Array<{ name: string; Component: () => ReactElement }> = [
+  { name: "temporary-chat-room", Component: TemporaryChatRoomPage },
+  { name: "ai-agent-room", Component: AiAgentRoomPage },
+  { name: "privacy", Component: PrivacyPage },
+  { name: "developers/mcp", Component: DevelopersMcpPage },
+]
+
+describe("Discovery pages — CTA", () => {
+  it.each(PAGES)(
+    "$name renders a working 'Open a room' CTA back to the room product",
+    ({ Component }) => {
+      const { unmount } = render(<Component />)
+      const cta = screen.getByRole("link", { name: "Open a room" })
+      expect(cta).toHaveAttribute("href", "/")
+      unmount()
+    }
+  )
+})
+
+describe("Discovery pages — CTA analytics", () => {
+  beforeEach(() => {
+    ;(window as unknown as { umami?: unknown }).umami = {
+      track: vi.fn(),
+    }
+  })
+
+  it.each(PAGES)(
+    "$name's CTA click sends only a bounded page identifier, never room/user data",
+    ({ Component }) => {
+      const track = (
+        window as unknown as { umami: { track: ReturnType<typeof vi.fn> } }
+      ).umami.track
+      const { unmount } = render(<Component />)
+      screen.getByRole("link", { name: "Open a room" }).click()
+
+      expect(track).toHaveBeenCalledTimes(1)
+      const [eventName, eventData] = track.mock.calls[0]
+      expect(eventName).toBe("DiscoveryCtaClicked")
+      expect(Object.keys(eventData as object)).toEqual(["page"])
+      expect(typeof (eventData as { page: unknown }).page).toBe("string")
+      unmount()
+    }
+  )
+})

--- a/app/src/__tests__/discovery/pages-seo.test.tsx
+++ b/app/src/__tests__/discovery/pages-seo.test.tsx
@@ -1,0 +1,107 @@
+import type { ReactElement } from "react"
+
+import { render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+// SeoHead relies on Next's real head-manager DOM side effect, which does not
+// run reliably outside `next build`/`next dev` in this test environment.
+// Instead of asserting rendered <head> tags, assert what each page *authors*
+// by intercepting the props it passes to the shared layout — an equally
+// strong guarantee that titles/descriptions/canonicals are correct and
+// unique, without depending on Next-internal DOM timing.
+vi.mock("../../components/DiscoveryPageLayout", () => ({
+  default: (props: {
+    title: string
+    description: string
+    path: string
+    ctaId: string
+  }) => (
+    <div
+      data-testid="layout-stub"
+      data-title={props.title}
+      data-description={props.description}
+      data-path={props.path}
+      data-cta-id={props.ctaId}
+    />
+  ),
+}))
+
+import AiAgentRoomPage from "../../pages/ai-agent-room"
+import DevelopersMcpPage from "../../pages/developers/mcp"
+import PrivacyPage from "../../pages/privacy"
+import TemporaryChatRoomPage from "../../pages/temporary-chat-room"
+
+const PAGES: Array<{
+  name: string
+  Component: () => ReactElement
+  path: string
+}> = [
+  {
+    name: "temporary-chat-room",
+    Component: TemporaryChatRoomPage,
+    path: "/temporary-chat-room",
+  },
+  { name: "ai-agent-room", Component: AiAgentRoomPage, path: "/ai-agent-room" },
+  { name: "privacy", Component: PrivacyPage, path: "/privacy" },
+  {
+    name: "developers/mcp",
+    Component: DevelopersMcpPage,
+    path: "/developers/mcp",
+  },
+]
+
+function renderStub(Component: () => ReactElement) {
+  const { container, unmount } = render(<Component />)
+  const stub = container.querySelector<HTMLElement>(
+    '[data-testid="layout-stub"]'
+  )
+  return { stub, unmount }
+}
+
+describe("Discovery pages — SEO metadata authored per page", () => {
+  it("each page has a unique, non-empty title and description", () => {
+    const titles = new Set<string>()
+    const descriptions = new Set<string>()
+
+    for (const { name, Component } of PAGES) {
+      const { stub, unmount } = renderStub(Component)
+      const title = stub?.dataset.title ?? ""
+      const description = stub?.dataset.description ?? ""
+
+      expect(title, `${name} title`).not.toBe("")
+      expect(description, `${name} description`).not.toBe("")
+      expect(titles.has(title), `duplicate title on ${name}: ${title}`).toBe(
+        false
+      )
+      expect(
+        descriptions.has(description),
+        `duplicate description on ${name}`
+      ).toBe(false)
+      titles.add(title)
+      descriptions.add(description)
+
+      unmount()
+    }
+  })
+
+  it.each(PAGES)(
+    "$name's path prop matches its route",
+    ({ Component, path }) => {
+      const { stub, unmount } = renderStub(Component)
+      expect(stub?.dataset.path).toBe(path)
+      unmount()
+    }
+  )
+
+  it("every page has a distinct analytics ctaId", () => {
+    const ids = new Set<string>()
+    for (const { Component } of PAGES) {
+      const { stub, unmount } = renderStub(Component)
+      const ctaId = stub?.dataset.ctaId ?? ""
+      expect(ctaId).not.toBe("")
+      expect(ids.has(ctaId)).toBe(false)
+      ids.add(ctaId)
+      unmount()
+    }
+  })
+})

--- a/app/src/components/DiscoveryFooter.tsx
+++ b/app/src/components/DiscoveryFooter.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link"
+
+const LINKS = [
+  { href: "/temporary-chat-room", label: "Temporary rooms" },
+  { href: "/ai-agent-room", label: "AI Agent rooms" },
+  { href: "/privacy", label: "Privacy" },
+  { href: "/developers/mcp", label: "Developer integration" },
+  { href: "https://github.com/i365dev/free4chat", label: "GitHub" },
+]
+
+/**
+ * Minimal internal link group so the discovery pages (and the homepage) are
+ * not SEO-orphaned. Intentionally not a navbar/docs portal.
+ */
+export default function DiscoveryFooter() {
+  return (
+    <nav
+      aria-label="Learn more"
+      className="mx-auto flex max-w-3xl flex-wrap justify-center gap-x-4 gap-y-2 px-4 py-8 text-xs text-gray-500"
+    >
+      {LINKS.map((link) => (
+        <Link
+          key={link.href}
+          href={link.href}
+          className="hover:text-gray-300"
+          {...(link.href.startsWith("http")
+            ? { target: "_blank", rel: "noopener noreferrer" }
+            : {})}
+        >
+          {link.label}
+        </Link>
+      ))}
+    </nav>
+  )
+}

--- a/app/src/components/DiscoveryPageLayout.tsx
+++ b/app/src/components/DiscoveryPageLayout.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from "react"
+
+import Link from "next/link"
+
+import DiscoveryFooter from "./DiscoveryFooter"
+import SeoHead from "./SeoHead"
+import { trackAnalyticsEvent } from "../common/utils"
+
+export interface DiscoveryPageLayoutProps {
+  /** <title> and og:title. */
+  title: string
+  /** meta description and og:description. */
+  description: string
+  /** Site-relative path, e.g. "/temporary-chat-room". */
+  path: string
+  /** Bounded page identifier sent with the CTA click event — never room/user data. */
+  ctaId: string
+  h1: string
+  children: ReactNode
+  /** Optional extra links shown next to the primary "Open a room" CTA. */
+  secondaryCta?: { href: string; label: string }
+}
+
+export default function DiscoveryPageLayout({
+  title,
+  description,
+  path,
+  ctaId,
+  h1,
+  children,
+  secondaryCta,
+}: DiscoveryPageLayoutProps) {
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-900 text-white">
+      <SeoHead title={title} description={description} path={path} />
+      <main className="flex-1 px-4 py-16">
+        <div className="mx-auto max-w-3xl">
+          <Link href="/" className="text-sm text-gray-500 hover:text-gray-300">
+            ← Free4Chat
+          </Link>
+          <h1 className="mt-4 text-3xl font-extrabold sm:text-4xl">{h1}</h1>
+          <div className="prose prose-invert mt-6 max-w-none text-gray-300 prose-headings:text-white prose-a:text-blue-400 prose-strong:text-white">
+            {children}
+          </div>
+          <div className="mt-10 flex flex-wrap items-center gap-4">
+            <Link
+              href="/"
+              onClick={() =>
+                trackAnalyticsEvent("DiscoveryCtaClicked", { page: ctaId })
+              }
+              className="group flex items-center justify-center rounded-md bg-rose-600 px-5 py-3 text-sm font-medium text-white transition hover:bg-rose-500 focus:outline-none focus:ring focus:ring-yellow-400"
+            >
+              Open a room
+            </Link>
+            {secondaryCta && (
+              <Link
+                href={secondaryCta.href}
+                className="text-sm text-gray-400 underline-offset-2 hover:text-gray-200 hover:underline"
+              >
+                {secondaryCta.label}
+              </Link>
+            )}
+          </div>
+        </div>
+      </main>
+      <DiscoveryFooter />
+    </div>
+  )
+}

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,10 +1,26 @@
 import Head from "next/head"
 
+const TITLE = "Free4Chat — Temporary Voice, Text & Agent Rooms"
+const DESCRIPTION =
+  "Open an instant temporary room for voice, text, and screen sharing, or bring your own AI Agent in. No account, no persistent history, no hosted LLM."
+const URL = "https://www.free4.chat/"
+
 export default function Header() {
   return (
     <div>
       <Head>
-        <title>Free for Chat - Free4Chat</title>
+        <title>{TITLE}</title>
+        <meta name="description" content={DESCRIPTION} />
+        <link rel="canonical" href={URL} />
+        <meta name="robots" content="index, follow" />
+        <meta property="og:type" content="website" />
+        <meta property="og:site_name" content="Free4Chat" />
+        <meta property="og:title" content={TITLE} />
+        <meta property="og:description" content={DESCRIPTION} />
+        <meta property="og:url" content={URL} />
+        <meta name="twitter:card" content="summary" />
+        <meta name="twitter:title" content={TITLE} />
+        <meta name="twitter:description" content={DESCRIPTION} />
       </Head>
     </div>
   )

--- a/app/src/components/SeoHead.tsx
+++ b/app/src/components/SeoHead.tsx
@@ -1,0 +1,34 @@
+import Head from "next/head"
+
+const SITE_ORIGIN = "https://www.free4.chat"
+
+export interface SeoHeadProps {
+  title: string
+  description: string
+  /** Site-relative path, e.g. "/temporary-chat-room". Must start with "/". */
+  path: string
+}
+
+/**
+ * Per-page SEO tags for the small set of indexable discovery pages. Kept
+ * separate from _document.tsx, which only owns site-wide fallbacks.
+ */
+export default function SeoHead({ title, description, path }: SeoHeadProps) {
+  const url = `${SITE_ORIGIN}${path}`
+  return (
+    <Head>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+      <link rel="canonical" href={url} />
+      <meta name="robots" content="index, follow" />
+      <meta property="og:type" content="website" />
+      <meta property="og:site_name" content="Free4Chat" />
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={url} />
+      <meta name="twitter:card" content="summary" />
+      <meta name="twitter:title" content={title} />
+      <meta name="twitter:description" content={description} />
+    </Head>
+  )
+}

--- a/app/src/pages/_document.tsx
+++ b/app/src/pages/_document.tsx
@@ -18,9 +18,11 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
+          {/* Site-wide fallback only — indexable pages set their own
+              title/description/canonical via next/head (see SeoHead). */}
           <meta
             name="description"
-            content="free4.chat is an instant audio conferencing service."
+            content="Free4Chat: open a temporary room for voice, text, and screen sharing, or bring your own AI Agent in — no account, no history, no hosted LLM."
           />
 
           <link rel="icon" href="/favicon.ico" />

--- a/app/src/pages/_document.tsx
+++ b/app/src/pages/_document.tsx
@@ -18,13 +18,10 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
-          {/* Site-wide fallback only — indexable pages set their own
-              title/description/canonical via next/head (see SeoHead). */}
-          <meta
-            name="description"
-            content="Free4Chat: open a temporary room for voice, text, and screen sharing, or bring your own AI Agent in — no account, no history, no hosted LLM."
-          />
-
+          {/* No description meta here: next/document's <Head> renders on
+              every page unconditionally and next/head does not dedupe plain
+              <meta> tags, so a "fallback" here would just duplicate the
+              page-specific one each route sets itself (see Header/SeoHead). */}
           <link rel="icon" href="/favicon.ico" />
           <link
             href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap"

--- a/app/src/pages/ai-agent-room.tsx
+++ b/app/src/pages/ai-agent-room.tsx
@@ -20,20 +20,23 @@ export default function AiAgentRoomPage() {
       </p>
 
       <h2>How it works</h2>
-      <ol>
+      <p>There are two ways an Agent joins, both over the same MCP Room API:</p>
+      <ul>
         <li>
-          Open a room and click <strong>Invite Agent</strong>.
+          <strong>Resident (recommended):</strong> open a room, click{" "}
+          <strong>Invite Agent</strong>, and paste the copied prompt into your
+          Agent&apos;s chat. It fetches <code>agent.md</code>, bootstraps the
+          local, user-owned Free4Chat Agent Runtime (
+          <code>npx @i365dev/free4chat-agent</code>), and stays in the room as
+          one participant across many Harness turns.
         </li>
         <li>
-          Paste the copied prompt into your Agent&apos;s chat. It fetches{" "}
-          <code>agent.md</code> and follows the instructions itself.
+          <strong>Direct (low-level):</strong> any MCP client can connect
+          straight to the stateless MCP Room API without the Runtime — no
+          resident presence across turns, but no install either. See the{" "}
+          <Link href="/developers/mcp">MCP docs</Link>.
         </li>
-        <li>
-          The Agent bootstraps the local, user-owned Free4Chat Agent Runtime (
-          <code>npx @i365dev/free4chat-agent</code>) and joins the room as a
-          text participant over the stateless MCP Room API.
-        </li>
-      </ol>
+      </ul>
 
       <h2>What&apos;s real today</h2>
       <ul>
@@ -60,11 +63,6 @@ export default function AiAgentRoomPage() {
         Agent voice, speech-to-text/text-to-speech, meeting notes, and
         Agent-hosted games are future ideas, not current functionality — this
         page only describes what a room does today.
-      </p>
-
-      <p>
-        Building your own integration instead of using the copy/paste flow? See
-        the <Link href="/developers/mcp">MCP Room API docs</Link>.
       </p>
     </DiscoveryPageLayout>
   )

--- a/app/src/pages/ai-agent-room.tsx
+++ b/app/src/pages/ai-agent-room.tsx
@@ -1,0 +1,71 @@
+import Link from "next/link"
+
+import DiscoveryPageLayout from "../components/DiscoveryPageLayout"
+
+export default function AiAgentRoomPage() {
+  return (
+    <DiscoveryPageLayout
+      title="AI Agent Room — Bring Your Own Agent | Free4Chat"
+      description="Add an AI Agent to a live Free4Chat room. Copy one invite prompt and your own Hermes, OpenCode, Codex, Claude, or Pi harness joins as a participant — your model, your credentials, no hosted LLM."
+      path="/ai-agent-room"
+      ctaId="ai-agent-room"
+      h1="Human + Agent rooms, powered by your own Agent"
+      secondaryCta={{ href: "/developers/mcp", label: "Read the MCP docs" }}
+    >
+      <p>
+        A Free4Chat room can hold Humans and AI Agents at the same time.
+        Free4Chat provides the room, the transport, and the protocol — the
+        Agent&apos;s intelligence, model, and credentials stay entirely on your
+        side.
+      </p>
+
+      <h2>How it works</h2>
+      <ol>
+        <li>
+          Open a room and click <strong>Invite Agent</strong>.
+        </li>
+        <li>
+          Paste the copied prompt into your Agent&apos;s chat. It fetches{" "}
+          <code>agent.md</code> and follows the instructions itself.
+        </li>
+        <li>
+          The Agent bootstraps the local, user-owned Free4Chat Agent Runtime (
+          <code>npx @i365dev/free4chat-agent</code>) and joins the room as a
+          text participant over the stateless MCP Room API.
+        </li>
+      </ol>
+
+      <h2>What&apos;s real today</h2>
+      <ul>
+        <li>
+          Agent participation is text and image — the Agent reads room text,
+          explicit <code>@Agent</code> mentions, and bounded ephemeral image
+          copies, and replies as a room participant.
+        </li>
+        <li>
+          The resident Agent Runtime keeps one participant alive across many
+          Harness turns, using one generic ACP v1 adapter for every supported
+          Harness: Hermes, OpenCode, Codex, Claude, Pi, and a DeepSeek Harness
+          preview, plus any custom ACP-compatible process.
+        </li>
+        <li>
+          Free4Chat does not host or see any model, API key, or Agent memory —
+          those belong to whoever is running the Harness.
+        </li>
+        <li>No account or API token is required to use the room API itself.</li>
+      </ul>
+
+      <h2>Not yet shipped</h2>
+      <p>
+        Agent voice, speech-to-text/text-to-speech, meeting notes, and
+        Agent-hosted games are future ideas, not current functionality — this
+        page only describes what a room does today.
+      </p>
+
+      <p>
+        Building your own integration instead of using the copy/paste flow? See
+        the <Link href="/developers/mcp">MCP Room API docs</Link>.
+      </p>
+    </DiscoveryPageLayout>
+  )
+}

--- a/app/src/pages/developers/mcp.tsx
+++ b/app/src/pages/developers/mcp.tsx
@@ -1,0 +1,118 @@
+import Link from "next/link"
+
+import DiscoveryPageLayout from "../../components/DiscoveryPageLayout"
+
+export default function DevelopersMcpPage() {
+  return (
+    <DiscoveryPageLayout
+      title="MCP Room API — Free4Chat Developer Docs"
+      description="Connect any MCP client to a live Free4Chat room. Six tools: room_info, join_room, wait_for_events, send_text, read_attachment, leave_room. No account or API key required."
+      path="/developers/mcp"
+      ctaId="developers-mcp"
+      h1="MCP Room API"
+      secondaryCta={{
+        href: "https://github.com/i365dev/free4chat",
+        label: "View source on GitHub",
+      }}
+    >
+      <p>
+        Free4Chat exposes a temporary room as a stateless{" "}
+        <a
+          href="https://modelcontextprotocol.io"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          MCP
+        </a>{" "}
+        (Model Context Protocol) endpoint over Streamable HTTP. Any MCP client,
+        or an Agent Harness with MCP tool support, can join a room and exchange
+        text and bounded image context — no account, API key, or OAuth flow
+        required.
+      </p>
+
+      <h2>Who this is for</h2>
+      <p>
+        Developers wiring up a custom Agent Harness, building a one-off
+        integration, or debugging the room protocol directly. If you just want a
+        persistent Agent in a room, the copy/paste{" "}
+        <Link href="/ai-agent-room">Invite Agent flow</Link> and the local Agent
+        Runtime are the higher-level, recommended path — this page documents the
+        protocol underneath it.
+      </p>
+
+      <h2>Endpoint</h2>
+      <pre>
+        <code>https://www.free4.chat/mcp</code>
+      </pre>
+
+      <h2>Tools</h2>
+      <ul>
+        <li>
+          <code>room_info(roomId)</code> — inspect participants and current
+          capabilities.
+        </li>
+        <li>
+          <code>join_room(roomId, name)</code> — join as a text-only Agent and
+          receive a private participant handle. May create a two-hour ephemeral
+          room.
+        </li>
+        <li>
+          <code>
+            wait_for_events(participantHandle, cursor, timeoutSeconds)
+          </code>{" "}
+          — long-poll for text, action, and image-metadata events, capped at 25
+          seconds.
+        </li>
+        <li>
+          <code>send_text(participantHandle, text)</code> — send text as the
+          Agent.
+        </li>
+        <li>
+          <code>read_attachment(participantHandle, attachmentId)</code> — read a
+          bounded, ephemeral image as MCP <code>ImageContent</code>.
+        </li>
+        <li>
+          <code>leave_room(participantHandle)</code> — leave and invalidate the
+          handle.
+        </li>
+      </ul>
+
+      <h2>Minimal flow</h2>
+      <pre>
+        <code>{`room_info(roomId)
+join_room(roomId, name) -> participantHandle
+loop:
+  wait_for_events(participantHandle, cursor, timeoutSeconds)
+  send_text(participantHandle, text)   # when addressed
+leave_room(participantHandle)`}</code>
+      </pre>
+
+      <h2>Trust boundary</h2>
+      <p>
+        The MCP layer is stateless — it encodes room/participant identity into
+        an opaque handle and holds no session state itself. Room state, message
+        ordering, and the two-hour expiry alarm live in a per-room Durable
+        Object. Human media (voice, screen share, files) stays on the
+        SFU/DataChannel transport; Agents never receive session, track, or media
+        identifiers, only text and bounded image copies. Holding an MCP
+        connection to a room does not grant access to any host, model, or
+        credential — those are entirely up to whatever you connect on the other
+        end.
+      </p>
+
+      <p>
+        For a resident participant that survives across many turns instead of
+        one MCP session, see the local Agent Runtime described in{" "}
+        <Link href="/ai-agent-room">AI Agent rooms</Link> and the repository{" "}
+        <a
+          href="https://github.com/i365dev/free4chat/blob/cf-sfu/DEVELOPMENT.md"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          DEVELOPMENT.md
+        </a>
+        .
+      </p>
+    </DiscoveryPageLayout>
+  )
+}

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -9,6 +9,7 @@ import {
   trackAnalyticsEvent,
   hashRoom,
 } from "../common/utils"
+import DiscoveryFooter from "../components/DiscoveryFooter"
 import Header from "../components/Header"
 
 export default function Home() {
@@ -262,6 +263,7 @@ export default function Home() {
           </div>
         </div>
       </main>
+      <DiscoveryFooter />
     </div>
   )
 }

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -66,7 +66,7 @@ export default function Home() {
             </h1>
 
             <p className="mx-auto mt-4 text-gray-400 sm:text-sm sm:leading-relaxed">
-              No sign-up. No history. Close the tab and it&apos;s gone.
+              No sign-up. No permanent room history on our servers.
             </p>
             <p className="mx-auto mt-1 text-gray-600 sm:text-xs sm:leading-relaxed">
               Rooms automatically close after 2 hours.

--- a/app/src/pages/privacy.tsx
+++ b/app/src/pages/privacy.tsx
@@ -1,0 +1,76 @@
+import DiscoveryPageLayout from "../components/DiscoveryPageLayout"
+
+export default function PrivacyPage() {
+  return (
+    <DiscoveryPageLayout
+      title="Privacy — What Free4Chat Stores and What It Doesn't | Free4Chat"
+      description="Free4Chat provides the room, transport, and protocol. Participants bring their own intelligence and capabilities. Here's exactly what that means: what's stored, what isn't, and for how long."
+      path="/privacy"
+      ctaId="privacy"
+      h1="Privacy and architecture"
+    >
+      <p>
+        <strong>
+          Free4Chat provides the room; participants bring their own intelligence
+          and capabilities.
+        </strong>{" "}
+        That&apos;s a design principle, not a marketing line — here is what it
+        actually means, without overstating it.
+      </p>
+
+      <h2>What Free4Chat doesn&apos;t have</h2>
+      <ul>
+        <li>No accounts, no sign-up, no user identity.</li>
+        <li>
+          No persistent room history — once a room expires, its state is
+          deleted.
+        </li>
+        <li>
+          No hosted LLM. Free4Chat never runs or has access to an Agent&apos;s
+          model.
+        </li>
+        <li>
+          No database of files or images — they move browser-to-browser over
+          WebRTC data channels and are never written to server storage.
+        </li>
+      </ul>
+
+      <h2>What does exist while a room is active</h2>
+      <ul>
+        <li>
+          <strong>Room state.</strong> A per-room Durable Object holds presence,
+          recent text/action messages, and media track metadata for up to two
+          hours, then deletes it when the room expires.
+        </li>
+        <li>
+          <strong>Media transport.</strong> Voice and screen-share video are
+          relayed through Cloudflare&apos;s Realtime SFU so every participant
+          can send and receive them — this is not end-to-end encryption, and
+          Cloudflare&apos;s media plane is a real part of the path, not a
+          peer-to-peer-only connection.
+        </li>
+        <li>
+          <strong>Your nickname</strong> is saved in your browser&apos;s{" "}
+          <code>localStorage</code> for convenience. Clear it anytime.
+        </li>
+      </ul>
+
+      <h2>Agents: local, not hosted</h2>
+      <p>
+        When an Agent joins a room, it does so through your own local Agent
+        Runtime process, using your own model access and API credentials.
+        Free4Chat&apos;s MCP endpoint is stateless: it relays room text and
+        events to the Agent and back, and never sees the Agent&apos;s model,
+        keys, or memory.
+      </p>
+
+      <h2>In short</h2>
+      <p>
+        Free4Chat owns the temporary room, the media transport, and the protocol
+        connecting participants. It does not own — and cannot see — the
+        intelligence, models, credentials, or memory that a Human or Agent
+        brings into that room.
+      </p>
+    </DiscoveryPageLayout>
+  )
+}

--- a/app/src/pages/privacy.tsx
+++ b/app/src/pages/privacy.tsx
@@ -54,8 +54,9 @@ export default function PrivacyPage() {
           <strong>An Agent-visible image copy, bounded.</strong> Human file
           transfer stays peer-to-peer, but a Human-shared image is not something
           a text-only Agent can read off a DataChannel. When an Agent is
-          connected, Free4Chat stores one bounded, resized copy of a shared
-          image (capped in size and count) in that room&apos;s Durable Object so
+          connected, Free4Chat stores one bounded temporary vision copy of a
+          shared image (capped in size and count, resized or re-encoded only
+          when needed to fit those caps) in that room&apos;s Durable Object so
           the Agent can read it, and deletes it with the room — never any other
           file type, and never for Human-only rooms.
         </li>

--- a/app/src/pages/privacy.tsx
+++ b/app/src/pages/privacy.tsx
@@ -22,16 +22,17 @@ export default function PrivacyPage() {
       <ul>
         <li>No accounts, no sign-up, no user identity.</li>
         <li>
-          No persistent room history — once a room expires, its state is
-          deleted.
+          No persistent room history on our servers — once a room expires, its
+          state is deleted.
         </li>
         <li>
           No hosted LLM. Free4Chat never runs or has access to an Agent&apos;s
           model.
         </li>
         <li>
-          No database of files or images — they move browser-to-browser over
-          WebRTC data channels and are never written to server storage.
+          No database of Human-to-Human files or images — between people, they
+          move browser-to-browser over WebRTC data channels and are never
+          written to server storage. The one exception is described below.
         </li>
       </ul>
 
@@ -50,26 +51,42 @@ export default function PrivacyPage() {
           peer-to-peer-only connection.
         </li>
         <li>
-          <strong>Your nickname</strong> is saved in your browser&apos;s{" "}
-          <code>localStorage</code> for convenience. Clear it anytime.
+          <strong>An Agent-visible image copy, bounded.</strong> Human file
+          transfer stays peer-to-peer, but a Human-shared image is not something
+          a text-only Agent can read off a DataChannel. When an Agent is
+          connected, Free4Chat stores one bounded, resized copy of a shared
+          image (capped in size and count) in that room&apos;s Durable Object so
+          the Agent can read it, and deletes it with the room — never any other
+          file type, and never for Human-only rooms.
+        </li>
+        <li>
+          <strong>Your room name and nickname</strong> are saved together in
+          your browser&apos;s <code>localStorage</code> (not sent to any server
+          beyond the room you&apos;re joining) so re-opening a room link
+          remembers who you were there. This list is not time-limited by
+          Free4Chat — entries stay until you clear your browser&apos;s site
+          data.
         </li>
       </ul>
 
-      <h2>Agents: local, not hosted</h2>
+      <h2>Agents: local or direct, never hosted</h2>
       <p>
-        When an Agent joins a room, it does so through your own local Agent
-        Runtime process, using your own model access and API credentials.
-        Free4Chat&apos;s MCP endpoint is stateless: it relays room text and
-        events to the Agent and back, and never sees the Agent&apos;s model,
-        keys, or memory.
+        Free4Chat does not run any Agent for you. The recommended path is your
+        own local Agent Runtime process — bootstrapped by the Agent itself via
+        the copied Invite Agent prompt — using your own model access and API
+        credentials. For custom or one-off integrations, an Agent (or any MCP
+        client) can instead connect directly to the stateless MCP Room API.
+        Either way, Free4Chat relays room text and events and never sees the
+        Agent&apos;s model, keys, or memory.
       </p>
 
       <h2>In short</h2>
       <p>
         Free4Chat owns the temporary room, the media transport, and the protocol
-        connecting participants. It does not own — and cannot see — the
-        intelligence, models, credentials, or memory that a Human or Agent
-        brings into that room.
+        connecting participants, plus the one bounded exception above for Agent
+        image access. It does not own — and cannot see — the intelligence,
+        models, credentials, or memory that a Human or Agent brings into that
+        room.
       </p>
     </DiscoveryPageLayout>
   )

--- a/app/src/pages/temporary-chat-room.tsx
+++ b/app/src/pages/temporary-chat-room.tsx
@@ -13,8 +13,8 @@ export default function TemporaryChatRoomPage() {
     >
       <p>
         Free4Chat rooms exist to have one conversation and then disappear. There
-        is no account to create, nothing to install, and nothing left behind
-        once the room closes.
+        is no account to create and nothing to install, and the room itself
+        leaves no permanent history on our servers once it closes.
       </p>
 
       <h2>What you get</h2>
@@ -32,8 +32,9 @@ export default function TemporaryChatRoomPage() {
       <ul>
         <li>No sign-up, no account, no identity to manage.</li>
         <li>
-          Free4Chat keeps no permanent room history — a room&apos;s presence,
-          messages, and expiry state live only while the room is active.
+          Free4Chat keeps no permanent room history on our servers — a
+          room&apos;s presence, messages, and expiry state live only while the
+          room is active.
         </li>
         <li>Every room closes automatically after two hours.</li>
         <li>
@@ -47,8 +48,11 @@ export default function TemporaryChatRoomPage() {
         Free4Chat is not an end-to-end encrypted messenger. Voice and screen
         sharing are relayed through Cloudflare&apos;s media network so multiple
         participants can hear and see each other; that network sees the media in
-        transit. Files and images travel browser-to-browser over a data channel
-        and are never written to a database. See{" "}
+        transit. Files and images between Humans travel browser-to-browser over
+        a data channel and are never written to a database — the one exception
+        is a bounded, temporary copy stored when an image is shared with a
+        connected Agent. Your room name and nickname are also saved in your
+        browser&apos;s <code>localStorage</code> until you clear it. See{" "}
         <Link href="/privacy">Privacy</Link> for the full picture.
       </p>
 

--- a/app/src/pages/temporary-chat-room.tsx
+++ b/app/src/pages/temporary-chat-room.tsx
@@ -1,0 +1,61 @@
+import Link from "next/link"
+
+import DiscoveryPageLayout from "../components/DiscoveryPageLayout"
+
+export default function TemporaryChatRoomPage() {
+  return (
+    <DiscoveryPageLayout
+      title="Temporary Chat Room — No Sign-Up, No History | Free4Chat"
+      description="Open an instant temporary room for voice, text, and screen sharing. No account, no persistent history — rooms close automatically after two hours."
+      path="/temporary-chat-room"
+      ctaId="temporary-chat-room"
+      h1="A temporary room for voice, text, and screen sharing"
+    >
+      <p>
+        Free4Chat rooms exist to have one conversation and then disappear. There
+        is no account to create, nothing to install, and nothing left behind
+        once the room closes.
+      </p>
+
+      <h2>What you get</h2>
+      <ul>
+        <li>Voice chat, right in the browser.</li>
+        <li>Text chat with emoji reactions.</li>
+        <li>
+          File and image transfer, sent directly between participants over a
+          WebRTC data channel.
+        </li>
+        <li>Screen sharing (desktop browsers).</li>
+      </ul>
+
+      <h2>What makes it temporary</h2>
+      <ul>
+        <li>No sign-up, no account, no identity to manage.</li>
+        <li>
+          Free4Chat keeps no permanent room history — a room&apos;s presence,
+          messages, and expiry state live only while the room is active.
+        </li>
+        <li>Every room closes automatically after two hours.</li>
+        <li>
+          Sharing is just a link: open a room, copy the URL, send it to whoever
+          should join.
+        </li>
+      </ul>
+
+      <h2>What this isn&apos;t</h2>
+      <p>
+        Free4Chat is not an end-to-end encrypted messenger. Voice and screen
+        sharing are relayed through Cloudflare&apos;s media network so multiple
+        participants can hear and see each other; that network sees the media in
+        transit. Files and images travel browser-to-browser over a data channel
+        and are never written to a database. See{" "}
+        <Link href="/privacy">Privacy</Link> for the full picture.
+      </p>
+
+      <p>
+        Want an AI Agent in the room instead of, or alongside, another human?
+        See <Link href="/ai-agent-room">AI Agent rooms</Link>.
+      </p>
+    </DiscoveryPageLayout>
+  )
+}


### PR DESCRIPTION
Closes #74

## 1. SEO/discovery audit findings

- The whole app is wrapped by `TurnstileGate` in `_app.tsx` (unchanged by this PR — that's #75's job), so today **every** page's server-rendered HTML — including `/`, `/room`, and the new pages here — is just a "Verifying you're human…" shell until the client-side challenge resolves. Confirmed by building this branch and inspecting `.next/server/pages/*.html` directly.
- `_document.tsx`'s global `<meta name="description">` was stale: "free4.chat is an instant audio conferencing service" — doesn't mention text/Agent rooms at all.
- The homepage (`Header.tsx`) only set a `<title>`, no description/canonical/OG.
- No `robots.txt`, no `sitemap.xml`, no internal linking beyond the room-invite/Agent-invite flow — the site had zero indexable surface pointing at anything but `/`.
- Analytics (Umami + GA via Zaraz, `common/utils.tsx`) already fires automatic pageviews on every route via `_document.tsx`'s gtag `page_path`/Umami script, so page views on the new routes are already covered without new code.

## 2. Pages chosen and why

Exactly the 4 the issue suggested as the strong first set, each mapped to something already shipped: `/temporary-chat-room`, `/ai-agent-room`, `/privacy`, and `/developers/mcp` (picked over `/developers/agent-runtime` — MCP has real external search demand as a protocol term and is the lower-friction integration path, no local package install required; the Agent Runtime is still described, just as the *recommended* higher-level path from the MCP page and from `/ai-agent-room`).

## 3. Claims intentionally NOT made

- No end-to-end-encryption claim — `/temporary-chat-room` and `/privacy` both state plainly that voice/screen-share is relayed through Cloudflare's Realtime SFU, not peer-to-peer-only.
- No "Free4Chat knows nothing" / "nothing touches a server" language — `/privacy` is explicit about what *does* exist while a room is active (per-room Durable Object state, nickname in `localStorage`).
- `/ai-agent-room` has a dedicated "Not yet shipped" section (voice, STT/TTS, meeting notes, games) so it can't be read as advertising future work as live.
- No fabricated search-volume numbers, no "best free X" framing, no FAQ farm.

## 4. Metadata/canonical strategy

New `SeoHead` component (`app/src/components/SeoHead.tsx`) sets title/description/canonical/robots/OG/Twitter tags per page via `next/head`, given `{title, description, path}`; canonical and `og:url` are both derived from the same `path` prop so they can't drift apart. `Header.tsx` (homepage-only) got the same treatment directly rather than introducing a second abstraction, since it already owned the homepage's `<head>`. `_document.tsx` keeps only a site-wide fallback description, now accurate, with a comment pointing at `SeoHead` for anything page-specific.

## 5. Robots/sitemap behavior

- `public/robots.txt`: `Allow: /`, `Disallow: /room`, `/mcp`, `/api/`, points at the sitemap.
- `public/sitemap.xml`: exactly the 5 public URLs (`/` + the 4 new pages) — no room URLs, no query strings, no future-feature slugs. Static files, served straight from `/public`, so they work regardless of the Turnstile-gate issue above (verified in the `.open-next/assets` build output).

## 6. Internal linking

`DiscoveryFooter` (small text link row: Temporary rooms / AI Agent rooms / Privacy / Developer integration / GitHub) is on the homepage below the fold and on all 4 discovery pages, plus a couple of contextual in-content cross-links between the pages (e.g. `/temporary-chat-room` → `/privacy` and `/ai-agent-room`; `/ai-agent-room` ↔ `/developers/mcp`). No navbar, no docs portal.

## 7. Analytics changes or why none were needed

Didn't add a `DiscoveryPageViewed` event — automatic Umami/GA pageview tracking already captures every route, so a redundant custom event would just duplicate it (per the issue's own guidance). Did add `DiscoveryCtaClicked`, fired only when the page's "Open a room" CTA is clicked, with a payload of exactly `{ page: <bounded id> }` — no room name, room id, user text, or referrer data. Covered by a test that asserts the event's key set is exactly `["page"]`.

## 8. Build/render validation

```
cd app
npx prettier --check .
yarn lint
yarn type-check
yarn test        # new: vitest + Testing Library, 26 tests / 3 files
yarn cf-build
npx wrangler deploy --dry-run
```

All green. `cf-build` output shows all 4 new routes statically prerendered (`○`) alongside `/`, `/room`, `/404`. I additionally hand-inspected `.next/server/pages/*.html` for `/temporary-chat-room` etc. — see the important caveat below.

## 9. Dependency on #75

**Real, and worth calling out plainly:** because `_app.tsx` still wraps everything in the global `TurnstileGate` on this baseline, the server-rendered HTML for `/`, `/room`, *and* all 4 new pages here is currently just the "Verifying you're human…" shell — none of the SeoHead tags or page content are in the initial HTML yet. This is pre-existing (confirmed `/` and `/room` have the exact same shell today, before this PR), not something this PR introduces or can fix without pulling #75's changes into this branch, which the task explicitly says not to do. Once #75 merges, these pages render immediately with no code change needed here — the components are already correct and covered by tests. `robots.txt`/`sitemap.xml` are static files and are entirely unaffected by this, so crawlers can already discover the URLs; they just won't get real content until #75 lands. Recommend merging #75 first (or same day) so this surface is actually crawlable in practice.

## 10. What remains future work

- `/developers/agent-runtime` as a second, more implementation-focused developer page (once there's evidence the MCP page is pulling useful traffic).
- The Phase 3 "expand only from evidence" pages the issue describes (voice-agent, meeting-notes, agent-games, live-translation) are explicitly not shipped — verified absent both from the sitemap and from `src/pages/` in a test.
- A dedicated Search Console / referrer-domain measurement pass once both PRs are live, per the issue's Phase 1 groundwork.

---

## Review fix (round 2)

**Rebased onto `claude/jit-turnstile` (#77)** and retargeted this PR's base branch accordingly, so the discovery pages inherit the removal of the global Turnstile gate rather than rendering behind it. The rebase was clean — package.json/yarn.lock/vitest.config.mts/vitest.setup.ts/vitest-env.d.ts were identical on both branches (both PRs independently added the same vitest setup against the same baseline), so nothing was duplicated; `yarn install` confirmed the lockfile needed no changes. This PR's diff (viewable via the PR now that its base is `claude/jit-turnstile`) contains only the discovery-surface-specific files.

Fixed five content/privacy findings:

**1. Agent image storage disclosure.** Removed the absolute "No database of files or images" / "images are never written to server storage" claims from `/privacy` and `/temporary-chat-room`. Confirmed against `do/RoomSession.ts` and `room/server.ts`: Human-to-Human files genuinely stay peer-to-peer over WebRTC DataChannels, but when an image is shared with a connected Agent, Free4Chat stores one bounded, resized copy (capped size/count, see `MAX_AGENT_ATTACHMENTS`/`MAX_AGENT_IMAGE_BYTES`) in that room's Durable Object so the text-only Agent can read it, deleted with the room. Both pages now disclose this scoped exception explicitly.

**2. localStorage disclosure.** `saveRoomToLocalStorage()` actually persists both `roomName` *and* `nickName` together, and Free4Chat never prunes that list — it stays until the user clears browser storage. `/privacy` and `/temporary-chat-room` now disclose both fields and that unlimited lifetime. Replaced the homepage's "No history. Close the tab and it's gone." and `/temporary-chat-room`'s "nothing left behind" with copy scoped to "no permanent room history on our servers" — accurate given the Durable Object's 2h lifetime and the localStorage entries that outlive it.

**3. Agent Runtime wording.** `/ai-agent-room`'s "How it works" no longer states unconditionally that an Agent bootstraps the local Runtime. It now presents two paths: **Resident (recommended)** → local Agent Runtime via the Invite Agent prompt, and **Direct (low-level)** → any MCP client connecting straight to the stateless MCP Room API, same as `/developers/mcp` already described.

**4. Meta description duplication.** `next/document`'s `<Head>` renders unconditionally on *every* page, and `next/head` does not dedupe plain `<meta>` tags — so `_document.tsx`'s "fallback" description was actually a second, always-present tag stacked on top of Header's/SeoHead's page-specific one. Removed it. Verified in the `cf-build` output: every real route now has **exactly one** `<meta name="description">` (or, for `/room`, zero — intentional, it's noindex and has no SeoHead).

**5. robots.txt vs `/room` noindex.** `Disallow: /room` prevented crawlers from ever fetching `/room`, so they could never see its `noindex, nofollow` meta tag — the standard robots.txt-vs-meta-noindex conflict. Removed that line; `/api/` and `/mcp` remain disallowed, and `/room` was never in the sitemap.

Added regression tests for all five (`copy-accuracy.test.ts`, plus updates to `crawl-surface.test.ts`).

### Revalidated rendered HTML after rebasing onto #77

Hand-inspected `cf-build`'s static HTML output for all 6 routes:

| Route | Description tags | Title/canonical/OG | Robots | H1 |
|---|---|---|---|---|
| `/` | 1 | ✓ correct | `index, follow` | ✓ "Open a room. Talk instantly." |
| `/room` | 0 (by design) | — | `noindex, nofollow` | — (client-only room UI) |
| `/temporary-chat-room` | 1 | ✓ correct | `index, follow` | ✓ |
| `/ai-agent-room` | 1 | ✓ correct | `index, follow` | ✓ |
| `/privacy` | 1 | ✓ correct | `index, follow` | ✓ |
| `/developers/mcp` | 1 | ✓ correct | `index, follow` | ✓ |

`robots.txt` and `sitemap.xml` checked directly in the `.open-next/assets` bundle: no `/room` in either, `/mcp` and `/api/` disallowed, sitemap still lists exactly the 5 shipped public URLs.

### Validation (all green)

```
cd app
npx prettier --check .   # pass
yarn lint                # pass
yarn type-check           # pass
yarn test                 # pass — 46 tests / 8 files (was 26; +20 from the rebase and new regression tests)
yarn cf-build              # pass — all 6 routes prerendered as static content
npx wrangler deploy --dry-run   # pass, no deploy performed
```

No new landing pages, no future voice/meeting/game pages, no new analytics system — only the 4 pages from round 1, fixed.

Not merged, not deployed.
