### PR TITLE
fix: homepage layout regression and stale Cron Trigger

### DIFF
--- a/app/src/components/DiscoveryFooter.tsx
+++ b/app/src/components/DiscoveryFooter.tsx
@@ -16,7 +16,7 @@ export default function DiscoveryFooter() {
   return (
     <nav
       aria-label="Learn more"
-      className="mx-auto flex max-w-3xl flex-wrap justify-center gap-x-4 gap-y-2 px-4 py-8 text-xs text-gray-500"
+      className="mx-auto flex max-w-3xl flex-none flex-wrap justify-center gap-x-4 gap-y-2 px-4 py-4 text-xs text-gray-500"
     >
       {LINKS.map((link) => (
         <Link

--- a/app/src/components/RoomContent.test.tsx
+++ b/app/src/components/RoomContent.test.tsx
@@ -1,0 +1,144 @@
+import { act, render, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const mockUseSfuChatRoom = vi.fn()
+vi.mock("../hooks/useSfuChatRoom", () => ({
+  useSfuChatRoom: (...args: unknown[]) => mockUseSfuChatRoom(...args),
+}))
+
+import RoomContent from "./RoomContent"
+
+interface RenderOptions {
+  callback: (token: string) => void
+  "error-callback": () => boolean | void
+}
+
+function installMockTurnstile() {
+  let widgetCounter = 0
+  let lastOptions: RenderOptions | null = null
+  const render = vi.fn(
+    (_container: string | HTMLElement, options: Record<string, unknown>) => {
+      lastOptions = options as unknown as RenderOptions
+      widgetCounter += 1
+      return `widget-${widgetCounter}`
+    }
+  )
+  const execute = vi.fn()
+  const reset = vi.fn()
+  const remove = vi.fn()
+
+  window.turnstile = { render, execute, reset, remove }
+
+  return {
+    render,
+    execute,
+    reset,
+    remove,
+    fireSuccess: (token: string) => lastOptions?.callback(token),
+  }
+}
+
+const baseHookReturn = {
+  participants: [] as unknown[],
+  messages: [] as unknown[],
+  sendTextMessage: vi.fn(),
+  sendFileMessage: vi.fn(),
+  sendActionMessage: vi.fn(),
+  muteSelf: vi.fn(),
+  toggleScreenShare: vi.fn(),
+  retryVerification: vi.fn(),
+  error: "",
+  expiryWarning: "",
+  connectionStatus: "verifying" as string,
+  resolvedRoomType: "audio" as const,
+  timeLeft: 0,
+}
+
+describe("RoomContent — Turnstile widget lifecycle", () => {
+  let mock: ReturnType<typeof installMockTurnstile>
+
+  beforeEach(() => {
+    mock = installMockTurnstile()
+    mockUseSfuChatRoom.mockReset()
+    // jsdom doesn't implement scrollIntoView; TextChatCard calls it on
+    // every message-list update.
+    Element.prototype.scrollIntoView = vi.fn()
+  })
+
+  afterEach(() => {
+    delete (window as { turnstile?: unknown }).turnstile
+    vi.restoreAllMocks()
+  })
+
+  it("removes the widget as soon as verification succeeds, and the connected room UI carries no Turnstile residue", async () => {
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "verifying",
+      participants: [],
+    })
+
+    const { rerender, container, queryByText } = render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+
+    // The pre-connect screen mounts the bounded Turnstile container.
+    expect(queryByText(/verifying/i)).toBeInTheDocument()
+
+    // Grab the real requestToken the component wired up to useSfuChatRoom,
+    // and drive it the same way useSfuChatRoom would on a fresh join.
+    const options = mockUseSfuChatRoom.mock.calls[0]?.[3] as {
+      getTurnstileToken: () => Promise<string>
+    }
+    expect(options.getTurnstileToken).toBeInstanceOf(Function)
+
+    let tokenPromise: Promise<string> | undefined
+    act(() => {
+      tokenPromise = options.getTurnstileToken()
+    })
+    await waitFor(() => expect(mock.execute).toHaveBeenCalledTimes(1))
+    expect(mock.remove).not.toHaveBeenCalled()
+
+    act(() => {
+      mock.fireSuccess("token-1")
+    })
+    await expect(tokenPromise).resolves.toBe("token-1")
+
+    // The widget must be torn down the moment the token settles — before the
+    // component even transitions to the connected room UI.
+    await waitFor(() => expect(mock.remove).toHaveBeenCalledTimes(1))
+
+    // Now simulate useSfuChatRoom moving on to the connected room.
+    mockUseSfuChatRoom.mockReturnValue({
+      ...baseHookReturn,
+      connectionStatus: "connected",
+      participants: [
+        {
+          peerId: "local-peer",
+          name: "tester",
+          kind: "human",
+          room: "test-room",
+          muteState: false,
+          audioStream: null,
+          screenShareStream: null,
+          screenShareEnabled: false,
+        },
+      ],
+    })
+    rerender(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+
+    expect(queryByText(/verifying/i)).not.toBeInTheDocument()
+    expect(queryByText(/joining/i)).not.toBeInTheDocument()
+    // No second widget was ever rendered for the connected room, and nothing
+    // further was removed — the one widget's lifecycle is fully accounted
+    // for by the single success -> remove pair above.
+    expect(mock.render).toHaveBeenCalledTimes(1)
+    expect(mock.remove).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[id^="cf-chl-widget"]')).toBeNull()
+  })
+})

--- a/app/src/hooks/useTurnstile.test.tsx
+++ b/app/src/hooks/useTurnstile.test.tsx
@@ -84,7 +84,7 @@ describe("useTurnstile", () => {
     await expect(tokenPromise).resolves.toBe("token-1")
   })
 
-  it("never reuses a token: every requestToken() call resets first and returns a fresh value", async () => {
+  it("never reuses a token: every requestToken() call renders a fresh widget and returns a fresh value", async () => {
     const { result } = renderHook(() => useTurnstile())
     attachContainer(result)
 
@@ -108,13 +108,54 @@ describe("useTurnstile", () => {
     })
     await expect(second).resolves.toBe("token-2")
 
-    // The widget is rendered once and reused; every call resets it first so a
-    // consumed/stale token can never be handed back.
-    expect(mock.render).toHaveBeenCalledTimes(1)
+    // A settled widget is torn down immediately, so the second call renders
+    // a genuinely new widget rather than resetting the first one.
+    expect(mock.render).toHaveBeenCalledTimes(2)
     expect(mock.reset).toHaveBeenCalledTimes(2)
   })
 
-  it("rejects on error-callback and allows a fresh retry afterwards", async () => {
+  it("explicitly removes the widget as soon as a token is successfully obtained", async () => {
+    const { result } = renderHook(() => useTurnstile())
+    attachContainer(result)
+
+    act(() => {
+      void result.current.requestToken()
+    })
+    await waitFor(() => expect(mock.execute).toHaveBeenCalledTimes(1))
+    const widgetId = mock.getLastOptions() && mock.render.mock.results[0].value
+
+    expect(mock.remove).not.toHaveBeenCalled()
+    act(() => {
+      mock.fireSuccess("token-1")
+    })
+
+    await waitFor(() => expect(mock.remove).toHaveBeenCalledTimes(1))
+    expect(mock.remove).toHaveBeenCalledWith(widgetId)
+  })
+
+  it("clears the widget id on success so the next call always renders instead of reusing", async () => {
+    const { result } = renderHook(() => useTurnstile())
+    attachContainer(result)
+
+    act(() => {
+      void result.current.requestToken()
+    })
+    await waitFor(() => expect(mock.execute).toHaveBeenCalledTimes(1))
+    act(() => {
+      mock.fireSuccess("token-1")
+    })
+    await waitFor(() => expect(mock.remove).toHaveBeenCalledTimes(1))
+
+    act(() => {
+      void result.current.requestToken()
+    })
+    await waitFor(() => expect(mock.render).toHaveBeenCalledTimes(2))
+    const firstWidgetId = mock.render.mock.results[0].value
+    const secondWidgetId = mock.render.mock.results[1].value
+    expect(secondWidgetId).not.toBe(firstWidgetId)
+  })
+
+  it("rejects on error-callback, removes the failed widget, and renders a fresh one on retry", async () => {
     const { result } = renderHook(() => useTurnstile())
     attachContainer(result)
 
@@ -123,23 +164,27 @@ describe("useTurnstile", () => {
       failing = result.current.requestToken()
     })
     await waitFor(() => expect(mock.execute).toHaveBeenCalledTimes(1))
+    const failedWidgetId = mock.render.mock.results[0].value
     act(() => {
       mock.fireError()
     })
     await expect(failing).rejects.toThrow()
+    expect(mock.remove).toHaveBeenCalledWith(failedWidgetId)
 
     let retry: Promise<string> | undefined
     act(() => {
       retry = result.current.requestToken()
     })
     await waitFor(() => expect(mock.execute).toHaveBeenCalledTimes(2))
+    expect(mock.render).toHaveBeenCalledTimes(2)
+    expect(mock.render.mock.results[1].value).not.toBe(failedWidgetId)
     act(() => {
       mock.fireSuccess("token-after-retry")
     })
     await expect(retry).resolves.toBe("token-after-retry")
   })
 
-  it("rejects on expired-callback and on timeout-callback", async () => {
+  it("rejects on expired-callback and on timeout-callback, each renders a fresh widget next time", async () => {
     const { result } = renderHook(() => useTurnstile())
     attachContainer(result)
 
@@ -152,16 +197,19 @@ describe("useTurnstile", () => {
       mock.fireExpired()
     })
     await expect(expired).rejects.toThrow()
+    expect(mock.remove).toHaveBeenCalledTimes(1)
 
     let timedOut: Promise<string> | undefined
     act(() => {
       timedOut = result.current.requestToken()
     })
     await waitFor(() => expect(mock.execute).toHaveBeenCalledTimes(2))
+    expect(mock.render).toHaveBeenCalledTimes(2)
     act(() => {
       mock.fireTimeout()
     })
     await expect(timedOut).rejects.toThrow()
+    expect(mock.remove).toHaveBeenCalledTimes(2)
   })
 
   it("dedupes concurrent requestToken() calls into a single in-flight challenge", async () => {

--- a/app/src/hooks/useTurnstile.ts
+++ b/app/src/hooks/useTurnstile.ts
@@ -80,37 +80,55 @@ export function useTurnstile() {
   const mountedRef = useRef(true)
   const [status, setStatus] = useState<TurnstileStatus>("idle")
 
-  const settle = useCallback((token?: string, error?: Error) => {
-    const settlement = settlementRef.current
-    settlementRef.current = null
-    if (!settlement) return
-    if (!mountedRef.current) return
-    if (error) {
-      setStatus("error")
-      settlement.reject(error)
-    } else {
-      setStatus("idle")
-      settlement.resolve(token as string)
+  // Tears down the actual Cloudflare-owned widget UI (which is not
+  // guaranteed to live only inside our container element — Turnstile can
+  // position it as a body-level overlay) and clears the id so the next
+  // ensureWidget() call always renders a genuinely fresh widget rather than
+  // reusing one that has already settled.
+  const removeWidget = useCallback(() => {
+    const ts = window.turnstile
+    const widgetId = widgetIdRef.current
+    widgetIdRef.current = null
+    if (widgetId && ts) {
+      try {
+        ts.remove(widgetId)
+      } catch {
+        // The widget may already be gone (e.g. script never finished loading).
+      }
     }
   }, [])
+
+  const settle = useCallback(
+    (token?: string, error?: Error) => {
+      const settlement = settlementRef.current
+      settlementRef.current = null
+      if (!settlement) return
+      // Every settlement — success or failure — is terminal for this widget
+      // instance: a completed challenge must not linger visibly once the
+      // protected action has resolved, and a failed one must not be reused
+      // by a retry (see requestToken()'s reset-before-execute comment).
+      removeWidget()
+      if (!mountedRef.current) return
+      if (error) {
+        setStatus("error")
+        settlement.reject(error)
+      } else {
+        setStatus("idle")
+        settlement.resolve(token as string)
+      }
+    },
+    [removeWidget]
+  )
 
   useEffect(() => {
     mountedRef.current = true
     return () => {
       mountedRef.current = false
-      const ts = window.turnstile
-      if (widgetIdRef.current && ts) {
-        try {
-          ts.remove(widgetIdRef.current)
-        } catch {
-          // The widget may already be gone (e.g. script never finished loading).
-        }
-      }
-      widgetIdRef.current = null
+      removeWidget()
       settlementRef.current = null
       pendingRef.current = null
     }
-  }, [])
+  }, [removeWidget])
 
   const ensureWidget = useCallback(async (): Promise<string> => {
     if (widgetIdRef.current) return widgetIdRef.current

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -56,10 +56,10 @@ export default function Home() {
   }
 
   return (
-    <div>
+    <div className="bg-gray-900">
       <Header></Header>
-      <main className="bg-gray-900 text-white">
-        <div className="mx-auto h-screen max-w-screen-xl px-4 py-32 lg:flex lg:items-center">
+      <main className="flex h-screen flex-col bg-gray-900 text-white">
+        <div className="mx-auto max-w-screen-xl flex-1 overflow-y-auto px-4 py-12 lg:flex lg:items-center">
           <div className="slogan mx-auto max-w-3xl text-center">
             <h1 className="bg-gradient-to-r from-green-300 via-blue-500 to-purple-600 bg-clip-text text-3xl font-extrabold text-transparent sm:text-4xl">
               Open a room. Talk instantly.
@@ -262,8 +262,8 @@ export default function Home() {
             </p>
           </div>
         </div>
+        <DiscoveryFooter />
       </main>
-      <DiscoveryFooter />
     </div>
   )
 }

--- a/app/wrangler.jsonc
+++ b/app/wrangler.jsonc
@@ -14,6 +14,12 @@
     { "binding": "WORKER_SELF_REFERENCE", "service": "free4chat-realtime" }
   ],
   "observability": { "enabled": true },
+  // Explicitly empty: clears a stale Cron Trigger left over from the removed
+  // legacy RTK cleanup handler. Without this, wrangler deploy leaves
+  // whatever cron triggers already exist on the zone untouched, and
+  // Cloudflare keeps invoking a scheduled() handler this Worker no longer
+  // exports (per-room expiry is owned by each Durable Object's own alarm).
+  "triggers": { "crons": [] },
   "vars": {
     // The production App ID is injected by GitHub Actions at deploy time.
     "SFU_APP_ID": "set-during-deployment"


### PR DESCRIPTION
Found during #71 Phase 1 production acceptance testing (tested against `714747e`, the merged #78 discovery surface).

## 1. Homepage white background below the fold

The outer `<div>` in `index.tsx` set no background color, and `<main>` was `h-screen` (exactly one viewport tall). `DiscoveryFooter` (added by #78) rendered as a sibling *after* `</main>`, landing in unstyled space below the viewport-height main — showing the browser's default white instead of the dark theme.

Screenshot from the user during acceptance: https://github.com/i365dev/free4chat/issues/71 (production homepage, white strip below the footer links).

Discovery pages (`/privacy`, `/temporary-chat-room`, etc.) were *not* affected — `DiscoveryPageLayout`'s own wrapper already sets `bg-gray-900` on a `min-h-screen` container.

## 2. Homepage no longer fit in one screen

Adding the footer also pushed total page height past `100vh`, forcing a scroll to see it — breaking the "single lightweight action screen" homepage design this PR series has otherwise preserved (per #74's product principle: don't make the core room/homepage heavy).

**Fix:** `main` is now `flex h-screen flex-col`; the hero content takes `flex-1` (replacing a redundant nested `h-screen`); `DiscoveryFooter` moved inside `main` as the trailing flex child so it's pinned within the same viewport instead of extending past it. The outer wrapping `<div>` also gets an explicit `bg-gray-900` as a safety net regardless of content height. `DiscoveryFooter`'s own padding trimmed (`py-8` → `py-4`) to leave more room for the hero on typical laptop heights.

Verified locally via a dev server screenshot: homepage now renders with no white gap and no scroll at normal viewport sizes. No change to `/temporary-chat-room`, `/ai-agent-room`, `/privacy`, `/developers/mcp`, or `/room`.

## 3. Stale Cloudflare Cron Trigger

Also found during the same acceptance pass, via `wrangler tail` on production: a `*/30 * * * *` Cron Trigger was still firing against the Worker every 30 minutes — leftover from the removed legacy RTK cleanup handler — even though `worker.ts` no longer exports `scheduled()` and `wrangler.jsonc` no longer declared any `triggers`:

```
Error: Handler does not export a scheduled() function
```

Cloudflare doesn't clear a previously-registered Cron Trigger just because a later deploy's config omits the `triggers` field — it has to be explicitly set to clear it. Added `"triggers": { "crons": [] }` so the next deploy clears it. Per-room expiry already lives entirely in each Durable Object's own alarm and is unrelated to this cron, so this has no functional effect beyond stopping the recurring error log.

## 4. Turnstile widget not removed after a successful challenge

Also found during the same live acceptance pass: after a successful just-in-time Turnstile verification, the completed widget (green checkmark + Cloudflare branding) stayed visibly rendered in the top-left of the *connected* room UI, overlapping the room header.

**Root cause:** the widget's container `<div ref={turnstileContainerRef} />` only exists in `RoomContent`'s pre-connect branch and is swapped out of the DOM once `connectionStatus` becomes `"connected"`. But Turnstile's own widget UI is not guaranteed to live only as a DOM child of that container — it can position itself as a body-level overlay — so removing our container never took the widget with it. `useTurnstile`'s cleanup only ran `turnstile.remove()` on full hook/component unmount, which never happens here since `RoomContent` stays mounted across the status transition.

**Fix:** `useTurnstile`'s `settle()` now explicitly calls the official `turnstile.remove(widgetId)` API and clears the local widget id for *every* settlement — success or failure — not just on unmount. Since `ensureWidget()` already treats a null widget id as "render fresh," this also means any retry (client-side error, expired, timeout, or a server-side Siteverify rejection followed by "Try again") now always gets a genuinely new widget rather than reusing one that already fired a terminal event.

No change to server-side Siteverify, no token persistence, no restored global gate — still Managed + interaction-only, single-use tokens.

Added regression coverage in `useTurnstile.test.tsx` (widget explicitly removed on success; widget id cleared so the next call renders fresh, not reused; error/expired/timeout retries also render a fresh widget) and a new `RoomContent.test.tsx` driving the real `useTurnstile` hook through a mocked `useSfuChatRoom` to confirm end-to-end that `turnstile.remove()` fires before the connected room UI mounts, and that the connected UI carries no extra widget.

## Validation

```
cd app
npx prettier --check .    # pass
yarn lint                  # pass
yarn type-check            # pass
yarn test                  # pass — 49 tests / 9 files (3 net new: 2 in useTurnstile, 1 new RoomContent.test.tsx)
yarn cf-build               # pass — same 8 routes prerendered as static content
wrangler deploy --dry-run    # pass, no deploy performed
```

Not merged, not deployed. Requesting review before merge.
