### PR TITLE
fix: prevent stale web deployments from winning races

### DIFF
--- a/.github/scripts/check-deploy-freshness.sh
+++ b/.github/scripts/check-deploy-freshness.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Determines whether $1 (the commit currently being deployed) is still the
+# freshest DEPLOY-RELEVANT commit compared to $2 (cf-sfu's current HEAD).
+# Prints exactly "stale=true" or "stale=false" to stdout — nothing else.
+#
+# "Deploy-relevant" mirrors deploy-web.yml's own `on.push.paths` trigger
+# (app/** and this workflow file). That trigger is path-filtered, so a
+# commit that only touches e.g. README.md never starts its own deploy run.
+# Comparing raw SHA equality against cf-sfu's current tip is therefore
+# wrong: if a docs-only commit lands after the one being built, the build
+# is still the latest deploy-relevant state and must NOT be skipped —
+# only a commit that itself touches app/ or this workflow makes an
+# in-flight build stale (and that commit is guaranteed to have started
+# its own run to cover it).
+set -euo pipefail
+
+BUILT_SHA="${1:?usage: check-deploy-freshness.sh <built-sha> <latest-sha>}"
+LATEST_SHA="${2:?usage: check-deploy-freshness.sh <built-sha> <latest-sha>}"
+
+# Must match on.push.paths in deploy-web.yml exactly.
+DEPLOY_PATHS=("app" ".github/workflows/deploy-web.yml")
+
+if [ "$BUILT_SHA" = "$LATEST_SHA" ]; then
+  echo "stale=false"
+  exit 0
+fi
+
+# `git diff --quiet` exits 0 (no diff), 1 (diff found), or a higher code
+# (e.g. 128 for an unresolvable revision — bad fetch, corrupt shallow
+# clone, wrong SHA). Only 0/1 are meaningful results; anything else is a
+# tooling failure and must abort loudly, not get silently folded into
+# "stale=true" by an `if` that only distinguishes zero from non-zero.
+set +e
+git diff --quiet "$BUILT_SHA" "$LATEST_SHA" -- "${DEPLOY_PATHS[@]}"
+diff_status=$?
+set -e
+
+case "$diff_status" in
+  0) echo "stale=false" ;;
+  1) echo "stale=true" ;;
+  *)
+    echo "check-deploy-freshness: git diff failed unexpectedly (exit $diff_status) comparing $BUILT_SHA..$LATEST_SHA" >&2
+    exit 1
+    ;;
+esac

--- a/.github/scripts/check-deploy-freshness.test.sh
+++ b/.github/scripts/check-deploy-freshness.test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Deterministic scenario tests for check-deploy-freshness.sh. No network,
+# no GitHub Actions — each scenario builds a throwaway local git repo.
+#
+# Run: .github/scripts/check-deploy-freshness.test.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$SCRIPT_DIR/check-deploy-freshness.sh"
+FAIL=0
+
+# Emits results as it goes; caller checks $FAIL at the end. Every temp repo
+# is removed even if an assertion fails, so a bad run doesn't leave litter.
+check() {
+  local name="$1" expected="$2" actual="$3"
+  if [ "$actual" = "$expected" ]; then
+    echo "ok   - $name"
+  else
+    echo "FAIL - $name (expected '$expected', got '$actual')"
+    FAIL=1
+  fi
+}
+
+new_repo() {
+  local dir
+  dir="$(mktemp -d)"
+  git -C "$dir" init -q
+  git -C "$dir" config user.email test@example.com
+  git -C "$dir" config user.name test
+  mkdir -p "$dir/app" "$dir/.github/workflows"
+  echo "init" > "$dir/README.md"
+  echo "init" > "$dir/app/index.js"
+  echo "init" > "$dir/.github/workflows/deploy-web.yml"
+  git -C "$dir" add -A
+  git -C "$dir" commit -qm init
+  echo "$dir"
+}
+
+commit_change() {
+  local dir="$1" file="$2" message="$3"
+  echo "changed $(date +%s%N)" > "$dir/$file"
+  git -C "$dir" add -A
+  git -C "$dir" commit -qm "$message"
+  git -C "$dir" rev-parse HEAD
+}
+
+# --- Scenario 1: A app change; B docs-only after it => A deploys ---
+repo="$(new_repo)"
+A="$(commit_change "$repo" app/index.js "A: app change")"
+B="$(commit_change "$repo" README.md "B: docs-only")"
+result="$(cd "$repo" && bash "$SCRIPT" "$A" "$B")"
+check "A app-only, B docs-only after => A deploys" "stale=false" "$result"
+rm -rf "$repo"
+
+# --- Scenario 2: A app change; B docs-only; C app change => A skips, C deploys ---
+repo="$(new_repo)"
+A="$(commit_change "$repo" app/index.js "A: app change")"
+B="$(commit_change "$repo" README.md "B: docs-only")"
+C="$(commit_change "$repo" app/index.js "C: app change")"
+result_a="$(cd "$repo" && bash "$SCRIPT" "$A" "$C")"
+check "A skips once C (app change) lands" "stale=true" "$result_a"
+result_c="$(cd "$repo" && bash "$SCRIPT" "$C" "$C")"
+check "C deploys (it IS the latest)" "stale=false" "$result_c"
+rm -rf "$repo"
+
+# --- Scenario 3: A app change; B changes deploy-web.yml => A skips, B deploys ---
+repo="$(new_repo)"
+A="$(commit_change "$repo" app/index.js "A: app change")"
+B="$(commit_change "$repo" .github/workflows/deploy-web.yml "B: workflow change")"
+result="$(cd "$repo" && bash "$SCRIPT" "$A" "$B")"
+check "A skips once B changes deploy-web.yml (B's own run deploys)" "stale=true" "$result"
+rm -rf "$repo"
+
+# --- Scenario 4: freshness lookup fails => must fail loudly, not print stale=true and succeed ---
+if bash "$SCRIPT" "only-one-arg" 2>/dev/null; then
+  echo "FAIL - missing second arg should exit non-zero, not succeed"
+  FAIL=1
+else
+  echo "ok   - missing second arg exits non-zero (set -euo pipefail + \${:?})"
+fi
+if bash "$SCRIPT" "0000000000000000000000000000000000000000" "1111111111111111111111111111111111111111" 2>/dev/null; then
+  echo "FAIL - unresolvable SHAs should exit non-zero, not silently print stale=true"
+  FAIL=1
+else
+  echo "ok   - unresolvable SHAs make git diff fail, propagating as a non-zero exit"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "One or more scenarios FAILED"
+  exit 1
+fi
+echo "All scenarios passed"

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -78,20 +78,28 @@ jobs:
       # Second, independent guard against a stale deploy (the concurrency
       # group above should normally prevent this by cancelling an
       # in-progress older run, but this check covers any window where an
-      # older run's Deploy step is reached anyway). No extra token needed:
-      # actions/checkout persists credentials for the job by default, so
-      # `git ls-remote` against `origin` just works.
-      - name: Verify this commit is still the latest cf-sfu push
+      # older run's Deploy step is reached anyway). "Stale" means cf-sfu
+      # now has a commit that itself touches app/ or this workflow file —
+      # see check-deploy-freshness.sh for why raw SHA equality against
+      # cf-sfu's tip is wrong under this workflow's path-filtered push
+      # trigger (a docs-only commit landing afterward must NOT mark an
+      # in-flight app deploy stale). `set -euo pipefail` here means a
+      # fetch/resolution failure fails this step (and the job) visibly —
+      # it must never be silently treated as "stale, skip deploy, job
+      # green". No extra token needed: actions/checkout persists
+      # credentials for the job by default, so `git fetch origin` works.
+      - name: Verify this commit is still the latest deploy-relevant cf-sfu push
         id: freshness
         run: |
-          latest_sha="$(git ls-remote origin refs/heads/cf-sfu | cut -f1)"
+          set -euo pipefail
+          git fetch --depth=1 origin cf-sfu
+          latest_sha="$(git rev-parse --verify FETCH_HEAD)"
           echo "Building commit: $GITHUB_SHA"
           echo "Latest cf-sfu:    $latest_sha"
-          if [ "$latest_sha" != "$GITHUB_SHA" ]; then
-            echo "::notice::Skipping deploy — cf-sfu has moved on to $latest_sha since this run started. A newer run will (or already did) cover this push."
-            echo "stale=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "stale=false" >> "$GITHUB_OUTPUT"
+          result="$(.github/scripts/check-deploy-freshness.sh "$GITHUB_SHA" "$latest_sha")"
+          echo "$result" >> "$GITHUB_OUTPUT"
+          if [ "$result" = "stale=true" ]; then
+            echo "::notice::Skipping deploy — cf-sfu has a newer commit ($latest_sha) that touches app/ or this workflow file. That commit's own run will (or already did) cover this push."
           fi
 
       - name: Deploy

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -75,7 +75,27 @@ jobs:
         env:
           SFU_APP_ID: ${{ secrets.SFU_APP_ID }}
 
+      # Second, independent guard against a stale deploy (the concurrency
+      # group above should normally prevent this by cancelling an
+      # in-progress older run, but this check covers any window where an
+      # older run's Deploy step is reached anyway). No extra token needed:
+      # actions/checkout persists credentials for the job by default, so
+      # `git ls-remote` against `origin` just works.
+      - name: Verify this commit is still the latest cf-sfu push
+        id: freshness
+        run: |
+          latest_sha="$(git ls-remote origin refs/heads/cf-sfu | cut -f1)"
+          echo "Building commit: $GITHUB_SHA"
+          echo "Latest cf-sfu:    $latest_sha"
+          if [ "$latest_sha" != "$GITHUB_SHA" ]; then
+            echo "::notice::Skipping deploy — cf-sfu has moved on to $latest_sha since this run started. A newer run will (or already did) cover this push."
+            echo "stale=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "stale=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Deploy
+        if: steps.freshness.outputs.stale != 'true'
         run: |
           npx wrangler deploy \
             --var "SFU_APP_ID:${SFU_APP_ID}"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,7 +69,7 @@ npx wrangler secret put SFU_APP_SECRET
 npx wrangler secret put TURNSTILE_SECRET_KEY
 ```
 
-Manual deployment:
+Manual deployment (recovery only — see note below):
 
 ```bash
 cd app
@@ -77,6 +77,15 @@ yarn cf-build
 npx wrangler deploy \
   --var "SFU_APP_ID:$SFU_APP_ID"
 ```
+
+**Production deploys should go through CI, not this manual path.** A local
+`wrangler deploy` builds with whatever's in your own environment/`.dev.vars`
+— pairing a local dev value (e.g. `NEXT_PUBLIC_TURNSTILE_SITE_KEY`) with the
+real production `TURNSTILE_SECRET_KEY` (a Cloudflare Worker secret, unaffected
+by any deploy) silently breaks verification. If a deployment needs retrying,
+re-run the `CI / Deploy` workflow run in GitHub Actions instead of deploying
+locally, unless you're deliberately reproducing the full production build-time
+configuration.
 
 ## SFU architecture
 


### PR DESCRIPTION
## Context

Small follow-up to #84. That PR added a `concurrency` group to the `deploy` job so a newer run cancels an in-progress older one — the primary fix for the race observed after #80/#81 (documented in #84 with exact timestamps: the deploy for the newer commit finished at 12:32:34Z, then the deploy for the older commit finished three seconds later at 12:32:48Z and silently overwrote it).

This PR adds the second, independent layer requested on top of that: a freshness check immediately before the actual `wrangler deploy`, for the residual window where an older run's Deploy step gets reached anyway (e.g. before cancellation propagates).

## What changed

**`.github/workflows/deploy-web.yml`** — new step between `Validate deployment variables` and `Deploy`:

```yaml
- name: Verify this commit is still the latest cf-sfu push
  id: freshness
  run: |
    latest_sha="$(git ls-remote origin refs/heads/cf-sfu | cut -f1)"
    if [ "$latest_sha" != "$GITHUB_SHA" ]; then
      echo "::notice::Skipping deploy — cf-sfu has moved on to $latest_sha since this run started..."
      echo "stale=true" >> "$GITHUB_OUTPUT"
    else
      echo "stale=false" >> "$GITHUB_OUTPUT"
    fi

- name: Deploy
  if: steps.freshness.outputs.stale != 'true'
  ...
```

- No extra token: `git ls-remote origin` reuses the credentials `actions/checkout` already persisted for the job.
- If stale, the `Deploy` step shows as **skipped** in the Actions UI (not a misleading green success, not a hard failure) with an explicit `::notice::` explaining why.
- Scoped to right before `Deploy` only — doesn't touch the `lint` job, doesn't add serialization beyond what #84 already does.

**`DEVELOPMENT.md`** — added a short note under "Manual deployment" explaining that path is recovery-only, not the normal retry mechanism, and *why*: during this incident's triage, a manual local `wrangler deploy` picked up `NEXT_PUBLIC_TURNSTILE_SITE_KEY` from `.dev.vars` (local-only) while the production `TURNSTILE_SECRET_KEY` (a separate Cloudflare Worker secret, untouched by any deploy) stayed on the real value — the mismatch broke Turnstile verification for a few minutes until caught. Re-running the CI workflow is the correct way to retry a deploy; no `.dev.vars` values are read or uploaded by CI.

## Preserved behavior

- PR → lint/typecheck only, no deploy (unchanged `if` condition)
- `cf-sfu` push → build + deploy (unchanged)
- `app/**` path filtering (unchanged `on.push.paths`)
- `agent-runtime.yml` untouched — separate workflow, not modified
- `NEXT_PUBLIC_TURNSTILE_SITE_KEY` / `SFU_APP_ID` still sourced only from GitHub Actions secrets at deploy time — this PR doesn't read or reference `.dev.vars` anywhere in CI

## Validation

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-web.yml'))"  # YAML parses
```
No production code touched, no deploy triggered by this PR itself (base branch is `cf-sfu` but this PR only lands once merged, per normal flow).

Not merged — awaiting review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update: fixed a blocking review finding

**Finding:** the freshness check compared `GITHUB_SHA` against cf-sfu's raw HEAD SHA — wrong, because `deploy-web.yml`'s push trigger is path-filtered (`app/**` and the workflow file itself). A docs-only commit landing on `cf-sfu` after an app-changing commit's deploy run started never triggers its own run, so the old check would mark the in-flight app deploy "stale" and skip it — and nothing would ever deploy that app change.

**Fix:** extracted the comparison into [`.github/scripts/check-deploy-freshness.sh`](.github/scripts/check-deploy-freshness.sh). "Stale" now means cf-sfu's current tip *differs from the built commit on deploy-relevant paths specifically* (`git diff --quiet BUILT_SHA LATEST_SHA -- app .github/workflows/deploy-web.yml`), matching the trigger's own path list exactly — not raw SHA equality.

**A real bug the test harness caught while I was building it:** `git diff --quiet`'s exit code is `0` (no diff), `1` (diff found), or higher (e.g. `128` for an unresolvable revision). My first pass used `if git diff --quiet ...; then stale=false; else stale=true; fi` — which only distinguishes zero from non-zero, so a genuine git failure (bad SHA, broken shallow fetch) was silently folded into "diff found" → `stale=true` → deploy skipped → job reports green. Fixed by capturing the exit code explicitly; anything other than `0`/`1` now aborts the script (and the workflow step, and the job) instead of silently skipping a deploy. This is exactly the failure mode the review asked me to guard against, and I'm glad the test caught it before it shipped rather than after.

The workflow step wraps the whole thing in `set -euo pipefail`: a failed `git fetch` (network/auth) or an unresolvable `FETCH_HEAD` now fails the step visibly — never silently downgraded to a "stale, skipped" success.

### Test evidence — all four review scenarios, deterministic, no network

`.github/scripts/check-deploy-freshness.test.sh` (throwaway local git repos per scenario):

```
ok   - A app-only, B docs-only after => A deploys
ok   - A skips once C (app change) lands
ok   - C deploys (it IS the latest)
ok   - A skips once B changes deploy-web.yml (B's own run deploys)
ok   - missing second arg exits non-zero (set -euo pipefail + ${:?})
ok   - unresolvable SHAs make git diff fail, propagating as a non-zero exit
All scenarios passed
```

Mapped to the desired behavior from the review:
| Scenario | Expected | Result |
|---|---|---|
| A (app), B (docs-only) | A deploys | ✅ `stale=false` |
| A (app), B (docs-only), C (app) | A skips, C deploys | ✅ `stale=true` for A, `stale=false` for C |
| A (app), B (changes deploy-web.yml) | A skips, B deploys | ✅ `stale=true` |
| freshness lookup fails | workflow fails visibly | ✅ non-zero exit, not a silent `stale=true` |

### Preserved

- The #84 concurrency group — unchanged.
- The second-freshness-layer rationale — an older run's Deploy step can still be reached even with concurrency protection in place.
- The `DEVELOPMENT.md` manual-deploy guidance from the prior commit on this PR — untouched.

### Validation

```
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-web.yml'))"  # YAML parses
bash .github/scripts/check-deploy-freshness.test.sh                                  # 6/6 assertions pass
```

Not merged. Not deployed.
