### PR TITLE
chore: release free4chat-agent 0.1.1

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -31,7 +31,7 @@ The text-only Agent protocol does not require OAuth, an account, or another secr
 The MCP endpoint is a stateless Room API. It is not a resident lifecycle owner. For a local Agent that should remain present across many Harness turns, the human-facing path is a copied Invite Agent prompt. The Agent fetches `agent.md`, identifies its own Harness, and runs the published package:
 
 ```bash
-npx -y @i365dev/free4chat-agent@0.1.0 join --room <room-id> --agent <harness> --name <name>
+npx -y @i365dev/free4chat-agent@0.1.1 join --room <room-id> --agent <harness> --name <name>
 ```
 
 The package is prepared for npm publication but is not published by CI. For repository development only, run `npm install && npm run build` in `agent-runtime`, then use `node dist/cli.js ...`. The runtime uses a restrictive Unix socket under `~/.free4chat-agent/` and does not open a public inbound port. It keeps the participant handle, token, cursor, and lease in memory; none are passed to the Harness prompt or written to user-visible output. The same generic ACP v1 adapter launches the configured local Harness, negotiates its capabilities, creates one retained ACP session, and wakes it for each addressed room turn. The runtime itself owns `wait_for_events`, reconnect, bounded room context, `read_attachment`, and `send_text`. Use `--agent-command <command> --agent-arg <arg>` for any ACP-compatible process. Do not replace this with cron, shell polling, or an interactive Harness UI session.

--- a/agent-runtime/README.md
+++ b/agent-runtime/README.md
@@ -15,7 +15,7 @@ status response, Harness prompt, room message, analytics, or external logs.
 An Agent can bootstrap the published package without a repository checkout:
 
 ```bash
-npx -y @i365dev/free4chat-agent@0.1.0 join \
+npx -y @i365dev/free4chat-agent@0.1.1 join \
   --room <room-id> \
   --agent <hermes|opencode|codex|claude|pi|deepseek-harness> \
   --name <name>

--- a/agent-runtime/package-lock.json
+++ b/agent-runtime/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@i365dev/free4chat-agent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@i365dev/free4chat-agent",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",

--- a/agent-runtime/package.json
+++ b/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i365dev/free4chat-agent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Zero-setup local lifecycle runtime for resident Free4Chat Agents",
   "author": "i365dev",
   "license": "MIT",

--- a/agent-runtime/src/bootstrap.ts
+++ b/agent-runtime/src/bootstrap.ts
@@ -1,5 +1,5 @@
 export const RUNTIME_PACKAGE_NAME = "@i365dev/free4chat-agent"
-export const RUNTIME_PACKAGE_VERSION = "0.1.0"
+export const RUNTIME_PACKAGE_VERSION = "0.1.1"
 
 export const BUILT_IN_AGENT_IDS = [
   "hermes",

--- a/agent-runtime/test/productization.test.ts
+++ b/agent-runtime/test/productization.test.ts
@@ -41,7 +41,7 @@ test("bootstrap command uses the official pinned package and argv boundaries", (
   assert.equal(invocation.command, "npx")
   assert.deepEqual(invocation.args, [
     "-y",
-    "@i365dev/free4chat-agent@0.1.0",
+    "@i365dev/free4chat-agent@0.1.1",
     "join",
     "--room",
     "room\nwith `quotes`",
@@ -100,7 +100,7 @@ test("agent protocol uses the pinned doctor fallback for npx bootstrap", async (
     new URL("../../app/public/agent.md", import.meta.url),
     "utf8"
   )
-  assert.match(protocol, /npx -y @i365dev\/free4chat-agent@0\.1\.0 doctor/)
+  assert.match(protocol, /npx -y @i365dev\/free4chat-agent@0\.1\.1 doctor/)
   assert.match(protocol, /When the `free4chat-agent` CLI is already installed/)
 })
 

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -76,7 +76,7 @@ from the repository, configure MCP/ACP, or start a daemon manually.
 4. Otherwise, run the bounded official package command:
 
    ```text
-   npx -y @i365dev/free4chat-agent@0.1.0 join --room <room-id> --agent <harness> --name <name>
+   npx -y @i365dev/free4chat-agent@0.1.1 join --room <room-id> --agent <harness> --name <name>
    ```
 
 The package command is the only automatic installation allowed by this
@@ -94,7 +94,7 @@ When the runtime was started through `npx`, use the same pinned package for the
 fallback diagnostic:
 
 ```text
-npx -y @i365dev/free4chat-agent@0.1.0 doctor
+npx -y @i365dev/free4chat-agent@0.1.1 doctor
 ```
 
 Do not create cron jobs, scheduled tasks, persistent shell pollers, or raw HTTP


### PR DESCRIPTION
## Summary\n- bump @i365dev/free4chat-agent to 0.1.1\n- update runtime bootstrap and public agent bootstrap pins\n- update release documentation and productization expectations\n\n## Validation\n- Agent Runtime type-check, lint, 70 tests, build, pack check, format check\n- app frozen install, type-check, lint\n\nNo production media flag or authorization behavior changes.