### PR TITLE
chore: enable Meeting Notes media canary

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -106,7 +106,8 @@ jobs:
         if: steps.freshness.outputs.stale != 'true'
         run: |
           npx wrangler deploy \
-            --var "SFU_APP_ID:${SFU_APP_ID}"
+            --var "SFU_APP_ID:${SFU_APP_ID}" \
+            --var "AGENT_MEDIA_ENABLED:true"
         working-directory: app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/app/.dev.vars.example
+++ b/app/.dev.vars.example
@@ -5,7 +5,8 @@ SFU_APP_SECRET=your_realtime_sfu_app_secret
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=your_turnstile_site_key (build-time env for turnstile)
 TURNSTILE_SECRET_KEY=your_turnstile_secret_key
 
-# Phase-0 (#82) MediaBridge dev/test kill switch — NOT the production
-# authorization model, and NOT set by the CI deploy workflow. Uncomment
-# only to locally test the agent-session / agent-room-media routes.
+# Phase-0 (#82) MediaBridge dev/test switch — NOT the production
+# authorization model. Production CI explicitly enables the coarse switch;
+# the per-room Human Meeting Notes grant remains required. Uncomment locally
+# only to test the agent-session / agent-room-media routes.
 # AGENT_MEDIA_ENABLED=true


### PR DESCRIPTION
## Summary

- Pass `AGENT_MEDIA_ENABLED=true` explicitly in the production deploy command.
- Document that the coarse switch is CI-enabled while the per-room Human Meeting Notes grant remains required.

## Scope

This change does not alter Meeting Notes authorization semantics, SFU secrets, TTS, transcript persistence, or raw-audio persistence.

## Validation

- App type-check
- App lint
- App Prettier check
- App tests: 130 passed