### PR TITLE
fix: align Meeting Notes SFU transport with v1 API

### DIFF
--- a/agent-runtime/src/media/peerConnectionLike.ts
+++ b/agent-runtime/src/media/peerConnectionLike.ts
@@ -28,12 +28,6 @@ export interface MediaTrackLike {
  * of a real WebRTC/ICE/DTLS stack.
  */
 export interface PeerConnectionLike {
-  /** Adds the Runtime's single subscribe-only audio m-line before its first
-   * SDP offer. This is never a publishing track. */
-  prepareReceiveOnlyAudio(): void
-  /** Mirrors the browser's initial SFU transport setup. The Runtime never
-   * consumes or publishes application messages on this channel. */
-  prepareServerEventsDataChannel(): void
   createOffer(): Promise<SessionDescriptionLike>
   setRemoteDescription(description: SessionDescriptionLike): Promise<void>
   createAnswer(): Promise<SessionDescriptionLike>
@@ -49,14 +43,14 @@ export type PeerConnectionFactory = () =>
  * that file has zero direct werift dependency and stays fully unit-testable. */
 export async function createWeriftPeerConnection(): Promise<PeerConnectionLike> {
   const { RTCPeerConnection } = await import("werift")
-  const pc = new RTCPeerConnection({})
+  // Match Cloudflare's official DataChannel example rather than werift's
+  // defaults (Google STUN + max-compat). This connection receives the SFU's
+  // server-offer transport bootstrap before any MediaBridge subscription.
+  const pc = new RTCPeerConnection({
+    iceServers: [{ urls: "stun:stun.cloudflare.com:3478" }],
+    bundlePolicy: "max-bundle",
+  })
   return {
-    prepareReceiveOnlyAudio: () => {
-      pc.addTransceiver("audio", { direction: "recvonly" })
-    },
-    prepareServerEventsDataChannel: () => {
-      pc.createDataChannel("server-events")
-    },
     createOffer: async () =>
       (await pc.createOffer()) as unknown as SessionDescriptionLike,
     setRemoteDescription: async (description) => {

--- a/agent-runtime/src/media/sfuMediaBridge.ts
+++ b/agent-runtime/src/media/sfuMediaBridge.ts
@@ -120,13 +120,11 @@ export class SfuMediaBridge {
       this.mySessionId = await this.restClient.createAgentSession()
       this.pc = await this.createPeerConnection()
       this.pc.onTrack.subscribe((track) => this.handleIncomingTrack(track))
-      this.pc.prepareReceiveOnlyAudio()
-      this.pc.prepareServerEventsDataChannel()
-      const initialOffer = await this.pc.createOffer()
-      await this.pc.setLocalDescription(initialOffer)
+      // Cloudflare's official example supports the server-offer bootstrap:
+      // establish first, then answer its SDP. This avoids relying on a
+      // client-created DataChannel offer before the transport exists.
       const transport = await this.restClient.establishDataChannelTransport(
-        this.mySessionId,
-        initialOffer
+        this.mySessionId
       )
       if (!transport.sessionDescription)
         throw new Error("missing_datachannel_session_description")

--- a/agent-runtime/src/media/sfuRestClient.ts
+++ b/agent-runtime/src/media/sfuRestClient.ts
@@ -27,13 +27,30 @@ export interface DataChannelTransportLike {
   requiresImmediateRenegotiation?: boolean
 }
 
+/**
+ * DOM and werift descriptions are class instances. Cross the REST boundary
+ * with the browser's literal `{ type, sdp }` shape instead of relying on a
+ * library instance's JSON serialization.
+ */
+function sessionDescriptionPayload(description: SessionDescriptionLike): {
+  type: string
+  sdp: string
+} {
+  if (
+    typeof description.type !== "string" ||
+    typeof description.sdp !== "string"
+  )
+    throw new Error("invalid_session_description")
+  return { type: description.type, sdp: description.sdp }
+}
+
 /** The subset of SfuRestClient that SfuMediaBridge depends on — kept as an
  * interface so tests can inject a fake instead of doing real network I/O. */
 export interface SfuRestClientLike {
   createAgentSession(): Promise<string>
   establishDataChannelTransport(
     mySessionId: string,
-    offer: SessionDescriptionLike
+    offer?: SessionDescriptionLike
   ): Promise<DataChannelTransportLike>
   roomMedia(): Promise<RoomMediaParticipant[]>
   subscribeTrack(
@@ -104,13 +121,15 @@ export class SfuRestClient implements SfuRestClientLike {
    * no DataChannel payload is observed or forwarded by this Runtime. */
   async establishDataChannelTransport(
     mySessionId: string,
-    offer: SessionDescriptionLike
+    offer?: SessionDescriptionLike
   ): Promise<DataChannelTransportLike> {
     const data = await this.request("datachannels/establish", "POST", {
       ...this.base(),
       sessionId: mySessionId,
       dataChannel: { location: "remote", dataChannelName: "server-events" },
-      sessionDescription: offer,
+      ...(offer
+        ? { sessionDescription: sessionDescriptionPayload(offer) }
+        : {}),
     })
     const sessionDescription = data.sessionDescription as
       SessionDescriptionLike | undefined
@@ -176,7 +195,7 @@ export class SfuRestClient implements SfuRestClientLike {
     await this.request("renegotiate", "PUT", {
       ...this.base(),
       sessionId: mySessionId,
-      sessionDescription: answer,
+      sessionDescription: sessionDescriptionPayload(answer),
     })
   }
 }

--- a/agent-runtime/test/media.test.ts
+++ b/agent-runtime/test/media.test.ts
@@ -31,7 +31,7 @@ class FakeRestClient implements SfuRestClientLike {
   subscribeErrors = new Map<string, Error>()
   establishTransportCalls: Array<{
     sessionId: string
-    offer: SessionDescriptionLike
+    offer?: SessionDescriptionLike
   }> = []
   renegotiateCalls = 0
   createAgentSessionError: Error | undefined
@@ -46,7 +46,7 @@ class FakeRestClient implements SfuRestClientLike {
   }
   async establishDataChannelTransport(
     mySessionId: string,
-    offer: SessionDescriptionLike
+    offer?: SessionDescriptionLike
   ) {
     this.establishTransportCalls.push({ sessionId: mySessionId, offer })
     if (this.establishTransportError) throw this.establishTransportError
@@ -91,8 +91,6 @@ type RtpCallback = (packet: {
  * `lastRtpCallback` so a test can drive fake packets through it. */
 class FakePeerConnection implements PeerConnectionLike {
   closed = false
-  receiveOnlyAudioPrepared = false
-  serverEventsDataChannelPrepared = false
   localDescriptions: SessionDescriptionLike[] = []
   codec: MediaCodecLike | undefined
   lastRtpCallback: RtpCallback | undefined
@@ -103,12 +101,6 @@ class FakePeerConnection implements PeerConnectionLike {
     },
   }
 
-  prepareReceiveOnlyAudio(): void {
-    this.receiveOnlyAudioPrepared = true
-  }
-  prepareServerEventsDataChannel(): void {
-    this.serverEventsDataChannelPrepared = true
-  }
   async createOffer(): Promise<SessionDescriptionLike> {
     return { type: "offer", sdp: "fake-initial-offer" }
   }
@@ -158,8 +150,6 @@ class DelayedPeerConnection implements PeerConnectionLike {
     },
   }
 
-  prepareReceiveOnlyAudio(): void {}
-  prepareServerEventsDataChannel(): void {}
   async createOffer(): Promise<SessionDescriptionLike> {
     return { type: "offer", sdp: "fake-initial-offer" }
   }
@@ -320,12 +310,9 @@ test("subscribes to a newly discovered Human audio track and reports it started"
     sessionId: "sess-1",
     trackName: "audio-1",
   })
-  assert.equal(pc.receiveOnlyAudioPrepared, true)
-  assert.equal(pc.serverEventsDataChannelPrepared, true)
   assert.deepEqual(restClient.establishTransportCalls, [
     {
       sessionId: "agent-session-1",
-      offer: { type: "offer", sdp: "fake-initial-offer" },
     },
   ])
   assert.equal(restClient.renegotiateCalls, 1)

--- a/agent-runtime/test/meetingNotesController.test.ts
+++ b/agent-runtime/test/meetingNotesController.test.ts
@@ -55,8 +55,6 @@ class FakeRestClient implements SfuRestClientLike {
 class FakePeerConnection implements PeerConnectionLike {
   closed = false
   onTrack = { subscribe: () => undefined }
-  prepareReceiveOnlyAudio(): void {}
-  prepareServerEventsDataChannel(): void {}
   async createOffer(): Promise<SessionDescriptionLike> {
     return { type: "offer", sdp: "fake-initial-offer" }
   }

--- a/agent-runtime/test/sfuRestClient.test.ts
+++ b/agent-runtime/test/sfuRestClient.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { SfuRestClient } from "../src/media/sfuRestClient.js"
+
+test("establishes the server-events transport with the official server-offer request shape", async () => {
+  const originalFetch = globalThis.fetch
+  let receivedBody: Record<string, unknown> | undefined
+  globalThis.fetch = async (_input, init) => {
+    receivedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+    return Response.json({})
+  }
+
+  try {
+    const client = new SfuRestClient("https://example.test", {
+      room: "room",
+      participantId: "participant",
+      participantToken: "token",
+    })
+    await client.establishDataChannelTransport("session")
+
+    assert.deepEqual(receivedBody, {
+      room: "room",
+      participantId: "participant",
+      token: "token",
+      sessionId: "session",
+      dataChannel: {
+        location: "remote",
+        dataChannelName: "server-events",
+      },
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("serializes a class-like renegotiation answer as a plain SDP payload", async () => {
+  const originalFetch = globalThis.fetch
+  let receivedBody: Record<string, unknown> | undefined
+  globalThis.fetch = async (_input, init) => {
+    receivedBody = JSON.parse(String(init?.body)) as Record<string, unknown>
+    return Response.json({})
+  }
+
+  try {
+    const client = new SfuRestClient("https://example.test", {
+      room: "room",
+      participantId: "participant",
+      participantToken: "token",
+    })
+    const answer = Object.create({ inherited: true }) as {
+      type: string
+      sdp: string
+    }
+    answer.type = "answer"
+    answer.sdp = "v=0\r\n"
+
+    await client.renegotiate("session", answer)
+
+    assert.deepEqual(receivedBody?.sessionDescription, {
+      type: "answer",
+      sdp: "v=0\r\n",
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/app/src/do/realtimeMedia.test.ts
+++ b/app/src/do/realtimeMedia.test.ts
@@ -15,11 +15,16 @@ describe("closeRealtimeTracks — fail-closed contract", () => {
   })
 
   it("a 2xx response is confirmed success", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("", { status: 200 }))
-    )
+    let requestedUrl: string | undefined
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      requestedUrl = String(input)
+      return new Response("", { status: 200 })
+    })
+    vi.stubGlobal("fetch", fetchMock)
     await expect(closeRealtimeTracks(env, "sess-1", ["1"])).resolves.toBe(true)
+    expect(requestedUrl).toBe(
+      "https://rtc.live.cloudflare.com/v1/apps/app-id/sessions/sess-1/tracks/close"
+    )
   })
 
   it("a 401 response is not treated as success", async () => {

--- a/app/src/do/realtimeMedia.ts
+++ b/app/src/do/realtimeMedia.ts
@@ -59,7 +59,7 @@ export async function closeRealtimeTracks(
   if (!credentials) return false
   try {
     const response = await fetch(
-      `https://rtc.live.cloudflare.com/apps/${encodeURIComponent(
+      `https://rtc.live.cloudflare.com/v1/apps/${encodeURIComponent(
         credentials.appId
       )}/sessions/${encodeURIComponent(sessionId)}/tracks/close`,
       {

--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -116,9 +116,11 @@ describe("AGENT_MEDIA_ENABLED gate", () => {
   })
 
   it("agent-session proceeds past the gate when explicitly enabled, and still enforces agent auth", async () => {
-    const fetchMock = vi.fn(async () =>
-      Response.json({ sessionId: "cf-session-1" })
-    )
+    let requestedUrl: string | undefined
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      requestedUrl = String(input)
+      return Response.json({ sessionId: "cf-session-1" })
+    })
     vi.stubGlobal("fetch", fetchMock)
     const env = makeEnv({ AGENT_MEDIA_ENABLED: "true" }, okDoResponder)
     const res = await handleSfuRequest(
@@ -127,6 +129,9 @@ describe("AGENT_MEDIA_ENABLED gate", () => {
     )
     expect(res.status).toBe(200)
     expect((await json(res)).sessionId).toBe("cf-session-1")
+    expect(requestedUrl).toBe(
+      "https://rtc.live.cloudflare.com/v1/apps/app-id/sessions/new"
+    )
     vi.unstubAllGlobals()
   })
 

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -164,7 +164,7 @@ async function realtimeRequest(
   headers.set("Authorization", `Bearer ${credentials.appSecret}`)
   headers.set("Content-Type", "application/json")
   return fetch(
-    `https://rtc.live.cloudflare.com/apps/${encodeURIComponent(
+    `https://rtc.live.cloudflare.com/v1/apps/${encodeURIComponent(
       credentials.appId
     )}${path}`,
     { ...init, headers }


### PR DESCRIPTION
## Summary
- use the documented Realtime v1 upstream URL for SFU proxy requests and server-side subscribed-track cleanup
- establish the initial server-events DataChannel using the SFU server-offer flow, then answer and renegotiate as required
- align the Runtime peer connection with the official connection setup and normalize answer SDP before sending it upstream
- add regression coverage for the v1 URLs and server-offer bootstrap payload

## Validation
- app: Prettier check, ESLint, 131 tests, type-check, cf-build
- agent-runtime: tests, lint, build

## E2E status
The deployed old endpoint returned a decoding error during datachannels/establish. This PR moves that call to the documented v1 endpoint and needs the same Stop-to-Start plus multi-speaker test after deployment.