### PR TITLE
[codex] wait for SFU connection before subscriptions

### DIFF
--- a/agent-runtime/src/core/runtime.ts
+++ b/agent-runtime/src/core/runtime.ts
@@ -35,6 +35,9 @@ export interface RuntimeStatus {
   state: "starting" | "waiting" | "turn" | "reconnecting" | "stopped" | "failed"
   participantId?: string
   lastError?: string
+  /** Optional Meeting Notes bridge lifecycle state. This is deliberately
+   * status-only: no media credentials, SDP, audio, or transcript content. */
+  meetingNotesMediaState?: "idle" | "starting" | "running"
 }
 
 export interface ResidentRuntimeOptions {
@@ -146,6 +149,7 @@ export class ResidentRoomRuntime {
       state: this.state,
       participantId: this.participantId,
       lastError: this.lastError,
+      meetingNotesMediaState: this.meetingNotes?.state,
     }
   }
 

--- a/agent-runtime/src/media/meetingNotesController.ts
+++ b/agent-runtime/src/media/meetingNotesController.ts
@@ -83,6 +83,12 @@ export class MeetingNotesController {
     return this.createPeerConnection
   }
 
+  /** A sanitized lifecycle indicator for local runtime diagnostics. It never
+   * includes an SFU session, participant capability, SDP, or audio data. */
+  get state(): BridgeState {
+    return this.bridgeState
+  }
+
   // Mirrors SfuMediaBridge.start()'s own shape: await the initial poll
   // before arming the interval, so a caller that awaits start() sees the
   // first authorization check settle deterministically. Callers on the

--- a/agent-runtime/src/media/peerConnectionLike.ts
+++ b/agent-runtime/src/media/peerConnectionLike.ts
@@ -28,8 +28,18 @@ export interface MediaTrackLike {
  * of a real WebRTC/ICE/DTLS stack.
  */
 export interface PeerConnectionLike {
+  /** Adds the Runtime's single subscribe-only audio m-line before its first
+   * SDP offer. This is never a publishing track. */
+  prepareReceiveOnlyAudio(): void
+  /** Creates the initial in-band server-events channel before the first
+   * browser-compatible SDP offer. The Runtime never reads or publishes
+   * application messages on this transport channel. */
+  prepareServerEventsDataChannel(): void
   createOffer(): Promise<SessionDescriptionLike>
   setRemoteDescription(description: SessionDescriptionLike): Promise<void>
+  /** Wait until ICE/DTLS has made this PeerConnection usable by the SFU for
+   * remote-track operations. */
+  waitForConnection(timeoutMs: number): Promise<void>
   createAnswer(): Promise<SessionDescriptionLike>
   setLocalDescription(description: SessionDescriptionLike): Promise<void>
   onTrack: { subscribe(callback: (track: MediaTrackLike) => void): void }
@@ -51,12 +61,47 @@ export async function createWeriftPeerConnection(): Promise<PeerConnectionLike> 
     bundlePolicy: "max-bundle",
   })
   return {
+    prepareReceiveOnlyAudio: () => {
+      pc.addTransceiver("audio", { direction: "recvonly" })
+    },
+    prepareServerEventsDataChannel: () => {
+      pc.createDataChannel("server-events")
+    },
     createOffer: async () =>
       (await pc.createOffer()) as unknown as SessionDescriptionLike,
     setRemoteDescription: async (description) => {
       await pc.setRemoteDescription(
         description as unknown as Parameters<typeof pc.setRemoteDescription>[0]
       )
+    },
+    waitForConnection: async (timeoutMs) => {
+      if (pc.connectionState === "connected") return
+      if (pc.connectionState === "closed" || pc.connectionState === "failed")
+        throw new Error("peer_connection_not_connected")
+      await new Promise<void>((resolve, reject) => {
+        let settled = false
+        let timeout: ReturnType<typeof setTimeout> | undefined = undefined
+        let subscription: { unSubscribe(): void } | undefined = undefined
+        const finish = (result: "connected" | "failed") => {
+          if (settled) return
+          settled = true
+          if (timeout) clearTimeout(timeout)
+          subscription?.unSubscribe()
+          if (result === "connected") resolve()
+          else reject(new Error("peer_connection_not_connected"))
+        }
+        subscription = pc.connectionStateChange.subscribe((state) => {
+          if (state === "connected") finish("connected")
+          else if (state === "closed" || state === "failed") finish("failed")
+        })
+        timeout = setTimeout(() => {
+          if (settled) return
+          settled = true
+          subscription?.unSubscribe()
+          reject(new Error("peer_connection_connect_timeout"))
+        }, timeoutMs)
+        if (settled) clearTimeout(timeout)
+      })
     },
     createAnswer: async () =>
       (await pc.createAnswer()) as unknown as SessionDescriptionLike,

--- a/agent-runtime/src/media/sfuMediaBridge.ts
+++ b/agent-runtime/src/media/sfuMediaBridge.ts
@@ -17,6 +17,7 @@ import type { MediaTrackLike, RtpPacketLike } from "./peerConnectionLike.js"
 
 const DEFAULT_POLL_INTERVAL_MS = 5000
 const INCOMING_TRACK_TIMEOUT_MS = 10000
+const CONNECTION_TIMEOUT_MS = 10000
 /** Emit a bounded stats event at most this often per track, not per packet. */
 const STATS_FLUSH_INTERVAL_MS = 2000
 
@@ -120,11 +121,18 @@ export class SfuMediaBridge {
       this.mySessionId = await this.restClient.createAgentSession()
       this.pc = await this.createPeerConnection()
       this.pc.onTrack.subscribe((track) => this.handleIncomingTrack(track))
-      // Cloudflare's official example supports the server-offer bootstrap:
-      // establish first, then answer its SDP. This avoids relying on a
-      // client-created DataChannel offer before the transport exists.
+      // The browser's initial transport SDP already has an audio m-line from
+      // its microphone. The subscribe-only Runtime must offer the equivalent
+      // recvonly m-line before it establishes its DataChannel transport.
+      this.pc.prepareReceiveOnlyAudio()
+      // Match the browser's working initial transport setup exactly: create
+      // the in-band server-events channel, then offer it to the SFU.
+      this.pc.prepareServerEventsDataChannel()
+      const initialOffer = await this.pc.createOffer()
+      await this.pc.setLocalDescription(initialOffer)
       const transport = await this.restClient.establishDataChannelTransport(
-        this.mySessionId
+        this.mySessionId,
+        initialOffer
       )
       if (!transport.sessionDescription)
         throw new Error("missing_datachannel_session_description")
@@ -134,6 +142,11 @@ export class SfuMediaBridge {
         await this.pc.setLocalDescription(answer)
         await this.restClient.renegotiate(this.mySessionId, answer)
       }
+      // Cloudflare rejects or blocks remote-track operations until ICE/DTLS
+      // reaches connected. Completing the initial SDP exchange alone is not
+      // sufficient, especially for a Node/werift peer without browser event
+      // loop timing. Wait once, bounded, before asking for room media.
+      await this.pc.waitForConnection(CONNECTION_TIMEOUT_MS)
       await this.poll()
       this.pollTimer = setInterval(() => {
         void this.poll().catch(() => undefined)

--- a/agent-runtime/src/media/sfuRestClient.ts
+++ b/agent-runtime/src/media/sfuRestClient.ts
@@ -91,10 +91,14 @@ export class SfuRestClient implements SfuRestClientLike {
     const raw = await response.text()
     const data = raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
     if (!response.ok) {
+      const errorCode =
+        typeof data.errorCode === "string" ? data.errorCode : undefined
       const error =
         typeof data.error === "string"
           ? data.error
-          : `SFU request failed (${response.status})`
+          : errorCode
+            ? `sfu_${path.replaceAll("/", "_")}_${errorCode}`
+            : `SFU request failed (${response.status})`
       throw new Error(error)
     }
     return data

--- a/agent-runtime/test/media.test.ts
+++ b/agent-runtime/test/media.test.ts
@@ -38,6 +38,7 @@ class FakeRestClient implements SfuRestClientLike {
   establishTransportError: Error | undefined
   roomMediaError: Error | undefined
   createAgentSessionCalls = 0
+  roomMediaCalls = 0
 
   async createAgentSession(): Promise<string> {
     this.createAgentSessionCalls += 1
@@ -48,13 +49,16 @@ class FakeRestClient implements SfuRestClientLike {
     mySessionId: string,
     offer?: SessionDescriptionLike
   ) {
-    this.establishTransportCalls.push({ sessionId: mySessionId, offer })
+    this.establishTransportCalls.push(
+      offer ? { sessionId: mySessionId, offer } : { sessionId: mySessionId }
+    )
     if (this.establishTransportError) throw this.establishTransportError
     return {
       sessionDescription: { type: "answer", sdp: "fake-transport-answer" },
     }
   }
   async roomMedia(): Promise<RoomMediaParticipant[]> {
+    this.roomMediaCalls += 1
     if (this.roomMediaError) throw this.roomMediaError
     return this.participants
   }
@@ -91,6 +95,8 @@ type RtpCallback = (packet: {
  * `lastRtpCallback` so a test can drive fake packets through it. */
 class FakePeerConnection implements PeerConnectionLike {
   closed = false
+  waitForConnectionCalls = 0
+  connectionGate: Promise<void> | undefined
   localDescriptions: SessionDescriptionLike[] = []
   codec: MediaCodecLike | undefined
   lastRtpCallback: RtpCallback | undefined
@@ -101,11 +107,21 @@ class FakePeerConnection implements PeerConnectionLike {
     },
   }
 
+  prepareReceiveOnlyAudio(): void {}
+  prepareServerEventsDataChannel(): void {}
+  async waitForConnection(): Promise<void> {
+    this.waitForConnectionCalls += 1
+    await this.connectionGate
+  }
+
   async createOffer(): Promise<SessionDescriptionLike> {
     return { type: "offer", sdp: "fake-initial-offer" }
   }
 
-  async setRemoteDescription(): Promise<void> {
+  async setRemoteDescription(
+    description: SessionDescriptionLike
+  ): Promise<void> {
+    if (description.sdp !== "fake-sdp") return
     const track: MediaTrackLike = {
       kind: "audio",
       codec: this.codec,
@@ -150,11 +166,18 @@ class DelayedPeerConnection implements PeerConnectionLike {
     },
   }
 
+  prepareReceiveOnlyAudio(): void {}
+  prepareServerEventsDataChannel(): void {}
+  async waitForConnection(): Promise<void> {}
+
   async createOffer(): Promise<SessionDescriptionLike> {
     return { type: "offer", sdp: "fake-initial-offer" }
   }
 
-  async setRemoteDescription(): Promise<void> {
+  async setRemoteDescription(
+    description: SessionDescriptionLike
+  ): Promise<void> {
+    if (description.sdp !== "fake-sdp") return
     const track: MediaTrackLike = {
       kind: "audio",
       codec: this.codec,
@@ -234,6 +257,25 @@ function makeBridge(
   return { bridge, events }
 }
 
+test("waits for the initial PeerConnection connection before listing remote tracks", async () => {
+  const restClient = new FakeRestClient()
+  const pc = new FakePeerConnection()
+  let releaseConnection: (() => void) | undefined
+  pc.connectionGate = new Promise<void>((resolve) => {
+    releaseConnection = resolve
+  })
+  const { bridge } = makeBridge(restClient, pc)
+
+  const starting = bridge.start()
+  await waitFor(() => pc.waitForConnectionCalls === 1)
+  assert.equal(restClient.roomMediaCalls, 0)
+
+  releaseConnection?.()
+  await starting
+  assert.equal(restClient.roomMediaCalls, 1)
+  bridge.stop()
+})
+
 test("raw negotiated Opus reaches only the dedicated audio callback with attribution and copied bytes", async () => {
   const restClient = new FakeRestClient()
   restClient.participants = [humanTrack("human-1", "sess-1")]
@@ -248,6 +290,7 @@ test("raw negotiated Opus reaches only the dedicated audio callback with attribu
   )
 
   await bridge.start()
+  assert.equal(pc.waitForConnectionCalls, 1)
   const rtp = pc.lastRtpCallback
   assert.ok(rtp)
   if (!rtp) return
@@ -313,6 +356,7 @@ test("subscribes to a newly discovered Human audio track and reports it started"
   assert.deepEqual(restClient.establishTransportCalls, [
     {
       sessionId: "agent-session-1",
+      offer: { type: "offer", sdp: "fake-initial-offer" },
     },
   ])
   assert.equal(restClient.renegotiateCalls, 1)

--- a/agent-runtime/test/meetingNotesController.test.ts
+++ b/agent-runtime/test/meetingNotesController.test.ts
@@ -55,6 +55,9 @@ class FakeRestClient implements SfuRestClientLike {
 class FakePeerConnection implements PeerConnectionLike {
   closed = false
   onTrack = { subscribe: () => undefined }
+  prepareReceiveOnlyAudio(): void {}
+  prepareServerEventsDataChannel(): void {}
+  async waitForConnection(): Promise<void> {}
   async createOffer(): Promise<SessionDescriptionLike> {
     return { type: "offer", sdp: "fake-initial-offer" }
   }
@@ -138,7 +141,9 @@ test("an authorized grant starts the MediaBridge", async () => {
   await controller.start()
 
   assert.equal(restClient.createAgentSessionCalls, 1)
+  assert.equal(controller.state, "running")
   await controller.stop()
+  assert.equal(controller.state, "idle")
 })
 
 test("no grant never starts the MediaBridge", async () => {

--- a/agent-runtime/test/sfuRestClient.test.ts
+++ b/agent-runtime/test/sfuRestClient.test.ts
@@ -65,3 +65,30 @@ test("serializes a class-like renegotiation answer as a plain SDP payload", asyn
     globalThis.fetch = originalFetch
   }
 })
+
+test("reports an SFU route and error code without echoing its response body", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () =>
+    Response.json(
+      {
+        errorCode: "decoding_error",
+        errorDescription: "untrusted upstream detail",
+      },
+      { status: 400 }
+    )
+
+  try {
+    const client = new SfuRestClient("https://example.test", {
+      room: "room",
+      participantId: "participant",
+      participantToken: "token",
+    })
+
+    await assert.rejects(
+      client.establishDataChannelTransport("session"),
+      /sfu_datachannels_establish_decoding_error/
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})


### PR DESCRIPTION
## Problem

The resident Meeting Notes Runtime completed its initial DataChannel SDP exchange and immediately listed/subscribed to Human tracks. Cloudflare Realtime requires the WebRTC PeerConnection to reach `connected` before remote-track operations; otherwise those operations can block or time out. In a real room this left Meeting Notes in `starting` even though the UI showed Listening.

## Fix

- Build the same initial, subscribe-only transport shape as the browser: one recvonly audio transceiver plus the `server-events` DataChannel before the first offer.
- Wait for werift ICE/DTLS `connected` after the initial SDP exchange and before `agent-room-media` or `/tracks`; the wait is bounded to 10 seconds and failure remains fail-open for text Agent operation.
- Surface a sanitized `meetingNotesMediaState` (`idle`, `starting`, or `running`) in local Runtime status so field diagnostics do not need tokens, SDP, raw audio, or transcript contents.
- Preserve only the safe SFU route/error-code diagnostic already used by the Runtime; upstream response bodies remain hidden.

## Validation

- `npm run format`
- `npm test` — 85 passing tests
- `npm run lint`
- `npm run type-check`
- `npm run build`
- Direct real-SFU probe with the local credential: agent session and DataChannel establish both returned 200; a second probe confirmed werift accepts the returned SDP answer.
- Local Worker-route integration probe using the actual `handleSfuRequest` path and real SFU also returned 200 for agent session and DataChannel establish.

No Worker/DO authorization, transcript behavior, STT provider behavior, speaker attribution, or media publishing capability changes are included.
