### PR TITLE
feat(#51): Agent-created Rooms with portable invite descriptors

### DIFF
--- a/agent-runtime/package-lock.json
+++ b/agent-runtime/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@i365dev/free4chat-agent",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@i365dev/free4chat-agent",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",

--- a/agent-runtime/package.json
+++ b/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i365dev/free4chat-agent",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Zero-setup local lifecycle runtime for resident Free4Chat Agents",
   "author": "i365dev",
   "license": "MIT",

--- a/agent-runtime/src/bootstrap.ts
+++ b/agent-runtime/src/bootstrap.ts
@@ -1,5 +1,5 @@
 export const RUNTIME_PACKAGE_NAME = "@i365dev/free4chat-agent"
-export const RUNTIME_PACKAGE_VERSION = "0.2.0"
+export const RUNTIME_PACKAGE_VERSION = "0.3.0"
 
 export const BUILT_IN_AGENT_IDS = [
   "hermes",

--- a/agent-runtime/src/cli.ts
+++ b/agent-runtime/src/cli.ts
@@ -24,6 +24,8 @@ function usage(): never {
   console.error(`Usage:
   free4chat-agent join --room <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]...
   free4chat-agent join --room <room-id> --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]...
+  free4chat-agent create --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]...
+  free4chat-agent create --agent-command <command> [--agent-arg <arg> ...] --name <name> [--capability <token>]...
   free4chat-agent capabilities [--instance <id>] [--set <token>,<token>,...]
   free4chat-agent peers --room <room-id>
   free4chat-agent collab request --target <participant-id> --summary <text> [--request-id <id>] [--detail key=value]... [--attach <attachment-id>]... [--instance <id>]
@@ -235,6 +237,31 @@ async function main(): Promise<void> {
             filePath.slice(filePath.lastIndexOf("/") + 1),
           mimeType,
           dataBase64: bytes.toString("base64"),
+        }),
+        null,
+        2
+      )
+    )
+    return
+  }
+  if (command === "create") {
+    const name = option(args, "--name")
+    const agent = option(args, "--agent")
+    const agentCommand = option(args, "--agent-command")
+    // Create-only command shape: no --room exists here by design — the room
+    // id is generated server-side and returned inside the public invite.
+    if (!name || (!agent && !agentCommand) || (agent && agentCommand)) usage()
+    if (option(args, "--room")) usage()
+    await ensureDaemon()
+    console.log(
+      JSON.stringify(
+        await sendIpc({
+          op: "create",
+          name,
+          agent,
+          agentCommand,
+          agentArgs: repeatedOption(args, "--agent-arg"),
+          capabilities: repeatedOption(args, "--capability"),
         }),
         null,
         2

--- a/agent-runtime/src/core/runtime.ts
+++ b/agent-runtime/src/core/runtime.ts
@@ -20,10 +20,12 @@ import type {
   AttachmentUpload,
   CollabRequestArgs,
   CollabResultArgs,
+  CreateRoomResult,
   Free4ChatClient,
   HarnessAdapter,
   HarnessEvent,
   HarnessTurnInput,
+  JoinResult,
   ParticipantRosterEntry,
   RoomEvent,
   UploadedAttachment,
@@ -77,7 +79,8 @@ export async function enrichTurnAttachments(
 
 export interface RuntimeStatus {
   instanceId: string
-  roomId: string
+  /** Absent only in the create-first lifecycle before the room is created. */
+  roomId?: string
   name: string
   adapter: string
   state: "starting" | "waiting" | "turn" | "reconnecting" | "stopped" | "failed"
@@ -87,7 +90,9 @@ export interface RuntimeStatus {
 
 export interface ResidentRuntimeOptions {
   instanceId: string
-  roomId: string
+  /** Known upfront for join lifecycles. Omitted for the create-first
+   * lifecycle (#51): startByCreate resolves it from the create result. */
+  roomId?: string
   name: string
   client: Free4ChatClient
   adapter: HarnessAdapter
@@ -190,6 +195,14 @@ export class ResidentRoomRuntime {
   // every Harness turn so peers and their advertised capabilities are
   // visible without any extra polling.
   private roster: ParticipantRosterEntry[] = []
+  // Room id for the current lifecycle: set at construction for joins, or by
+  // startByCreate from the create result. Empty until adopted in the
+  // create-first lifecycle.
+  private resolvedRoomId?: string
+
+  private get activeRoomId(): string {
+    return this.resolvedRoomId ?? this.options.roomId ?? ""
+  }
   private readonly log: (
     event: string,
     details?: Record<string, string | number>
@@ -220,7 +233,7 @@ export class ResidentRoomRuntime {
   getStatus(): RuntimeStatus {
     return {
       instanceId: this.options.instanceId,
-      roomId: this.options.roomId,
+      ...(this.activeRoomId ? { roomId: this.activeRoomId } : {}),
       name: this.options.name,
       adapter: this.options.adapter.name,
       state: this.state,
@@ -230,6 +243,38 @@ export class ResidentRoomRuntime {
   }
 
   async start(): Promise<void> {
+    await this.prepareLifecycle()
+    await this.join()
+    this.loopPromise = this.waitLoop()
+  }
+
+  /** Create-first lifecycle (#51): connects the Harness first (a Harness
+   * failure must never orphan a created room), then atomically creates a
+   * fresh room registering this agent as participant #1, adopts the create
+   * result exactly like a normal join — the wait loop starts from the
+   * create cursor and joinRoom is never called for this room until a later
+   * lease-expiry reconnect, which always uses the normal join path and can
+   * never re-create. Returns the public invite descriptor; the private
+   * handle/token never leaves this object. */
+  async startByCreate(): Promise<CreateRoomResult> {
+    await this.prepareLifecycle()
+    const created = await this.options.client.createRoom(
+      this.options.name,
+      this.advertisedCapabilities.length > 0
+        ? this.advertisedCapabilities
+        : undefined
+    )
+    this.resolvedRoomId = created.invite.roomId
+    this.adoptJoin(created)
+    this.loopPromise = this.waitLoop()
+    return created
+  }
+
+  /** Shared pre-flight: transcript init, MCP connection, Harness session.
+   * Ordering matters — the Harness session exists before any room is
+   * joined or created, so local readiness failures happen before room
+   * admission. */
+  private async prepareLifecycle(): Promise<void> {
     try {
       await this.transcript?.ready()
     } catch {
@@ -239,18 +284,12 @@ export class ResidentRoomRuntime {
     }
     await this.options.client.connect()
     await this.options.adapter.ensureSession()
-    await this.join()
-    this.loopPromise = this.waitLoop()
   }
 
-  private async join(): Promise<void> {
-    const joined = await this.options.client.joinRoom(
-      this.options.roomId,
-      this.options.name,
-      this.advertisedCapabilities.length > 0
-        ? this.advertisedCapabilities
-        : undefined
-    )
+  /** Single adoption path for any successful room acquisition (join or
+   * create): resets cursor/event state from the returned capability and
+   * rebuilds the Meeting Notes controller against the fresh participant. */
+  private adoptJoin(joined: JoinResult): void {
     // The capability is intentionally kept only in this object and is never
     // included in HarnessTurnInput, RuntimeStatus, or log details.
     this.participantHandle = joined.participantHandle
@@ -262,6 +301,17 @@ export class ResidentRoomRuntime {
     this.pendingAddressed.length = 0
     this.state = "waiting"
     this.lastError = undefined
+  }
+
+  private async join(): Promise<void> {
+    const joined = await this.options.client.joinRoom(
+      this.activeRoomId,
+      this.options.name,
+      this.advertisedCapabilities.length > 0
+        ? this.advertisedCapabilities
+        : undefined
+    )
+    this.adoptJoin(joined)
     await this.restartMeetingNotesController()
   }
 
@@ -362,7 +412,7 @@ export class ResidentRoomRuntime {
         this.options.createMeetingNotesController?.(handle) ??
         new MeetingNotesController({
           client: this.options.client,
-          roomId: this.options.roomId,
+          roomId: this.activeRoomId,
           participantId: this.participantId,
           mcpUrl: this.options.mcpUrl,
           handle,

--- a/agent-runtime/src/core/runtime.ts
+++ b/agent-runtime/src/core/runtime.ts
@@ -266,6 +266,11 @@ export class ResidentRoomRuntime {
     )
     this.resolvedRoomId = created.invite.roomId
     this.adoptJoin(created)
+    // Identical adoption semantics to join(): the Meeting Notes controller
+    // must exist for THIS participant from the start, so a Human joining via
+    // the invite and granting Meeting Notes is picked up immediately — not
+    // only after some later lease-expiry rejoin.
+    await this.restartMeetingNotesController()
     this.loopPromise = this.waitLoop()
     return created
   }

--- a/agent-runtime/src/daemon.ts
+++ b/agent-runtime/src/daemon.ts
@@ -35,6 +35,7 @@ function optionalMilliseconds(name: string): number | undefined {
 export interface IpcRequest {
   op:
     | "join"
+    | "create"
     | "status"
     | "leave"
     | "stop"
@@ -119,11 +120,19 @@ export class AgentDaemon {
   }
 
   private async dispatch(request: IpcRequest): Promise<unknown> {
-    if (request.op === "join") {
-      if (!request.room || !request.name)
+    if (request.op === "join" || request.op === "create") {
+      const isCreate = request.op === "create"
+      if (isCreate) {
+        if (!request.name) throw new Error("create requires name")
+        if (request.room)
+          throw new Error("create does not take a room; the room is generated")
+      } else if (!request.room || !request.name) {
         throw new Error("join requires room and name")
+      }
       if (request.agentCommand && request.agent)
         throw new Error("choose --agent or --agent-command, not both")
+      if (!isCreate && !request.agent && !request.agentCommand)
+        throw new Error("join requires agent or agent-command")
       const launcher = request.agentCommand
         ? customLauncher(request.agentCommand, request.agentArgs ?? [])
         : getLauncher(request.agent ?? "")
@@ -140,7 +149,7 @@ export class AgentDaemon {
         process.env.FREE4CHAT_MCP_URL ?? "https://www.free4.chat/mcp"
       const runtime = new ResidentRoomRuntime({
         instanceId,
-        roomId: request.room,
+        ...(isCreate ? {} : { roomId: request.room }),
         name: request.name,
         capabilities:
           request.capabilities && request.capabilities.length > 0
@@ -162,9 +171,22 @@ export class AgentDaemon {
         transcriptPath: join(workspace, ".meeting-notes", "transcript.jsonl"),
         onRoomExpired: () => this.removeInstance(instanceId),
       })
-      this.instances.set({ instanceId, roomId: request.room, runtime })
       this.workspaces.set(instanceId, workspace)
       try {
+        if (isCreate) {
+          // Register the instance only after the create+adopt succeeded: a
+          // failed startup leaves no ghost instance and performs best-effort
+          // leave/close via stop() below. The returned payload carries
+          // instance status and the PUBLIC invite — never handle/token.
+          const created = await runtime.startByCreate()
+          this.instances.set({
+            instanceId,
+            roomId: created.invite.roomId,
+            runtime,
+          })
+          return { ...runtime.getStatus(), invite: created.invite }
+        }
+        this.instances.set({ instanceId, roomId: request.room!, runtime })
         await runtime.start()
       } catch (error) {
         this.instances.delete(instanceId)

--- a/agent-runtime/src/free4chat/client.ts
+++ b/agent-runtime/src/free4chat/client.ts
@@ -8,6 +8,7 @@ import type {
   AttachmentUpload,
   CollabRequestArgs,
   CollabResultArgs,
+  CreateRoomResult,
   Free4ChatClient,
   JoinResult,
   MeetingNotesInfo,
@@ -136,6 +137,7 @@ export class McpFree4ChatClient implements Free4ChatClient {
       const required = [
         "room_info",
         "join_room",
+        "create_room",
         "wait_for_events",
         "send_text",
         "read_attachment",
@@ -243,6 +245,56 @@ export class McpFree4ChatClient implements Free4ChatClient {
       participantHandle: result.participantHandle,
       cursor: asNumber(result.cursor, "cursor"),
       expiresAt: asNumber(result.expiresAt, "expiresAt"),
+    }
+  }
+
+  async createRoom(
+    name: string,
+    capabilities?: string[]
+  ): Promise<CreateRoomResult> {
+    const result = asRecord(
+      await this.call("create_room", {
+        name,
+        ...(capabilities && capabilities.length > 0 ? { capabilities } : {}),
+      })
+    )
+    const invite =
+      result.invite && typeof result.invite === "object"
+        ? (result.invite as Record<string, unknown>)
+        : undefined
+    if (
+      !invite ||
+      invite.kind !== "free4chat.room-invite" ||
+      invite.version !== 1 ||
+      typeof invite.roomId !== "string" ||
+      !invite.roomId ||
+      typeof invite.roomUrl !== "string" ||
+      !invite.roomUrl.startsWith("https://www.free4.chat/room?id=")
+    )
+      throw new Free4ChatClientError(
+        "Free4Chat returned an invalid room invite",
+        "tool_error"
+      )
+    const participant = asRecord(result.participant)
+    if (
+      typeof result.participantHandle !== "string" ||
+      typeof participant.id !== "string"
+    )
+      throw new Free4ChatClientError(
+        "Free4Chat returned an invalid create result",
+        "tool_error"
+      )
+    return {
+      participantId: participant.id,
+      participantHandle: result.participantHandle,
+      cursor: asNumber(result.cursor, "cursor"),
+      expiresAt: asNumber(result.expiresAt, "expiresAt"),
+      invite: {
+        kind: "free4chat.room-invite",
+        version: 1,
+        roomId: invite.roomId,
+        roomUrl: invite.roomUrl,
+      },
     }
   }
 

--- a/agent-runtime/src/free4chat/modernClient.ts
+++ b/agent-runtime/src/free4chat/modernClient.ts
@@ -4,6 +4,7 @@ import type {
   AttachmentUpload,
   CollabRequestArgs,
   CollabResultArgs,
+  CreateRoomResult,
   Free4ChatClient,
   ParticipantRosterEntry,
   UploadedAttachment,
@@ -26,6 +27,7 @@ const MODERN_PROTOCOL_VERSION = "2026-07-28"
 const REQUIRED_TOOLS = [
   "room_info",
   "join_room",
+  "create_room",
   "wait_for_events",
   "send_text",
   "read_attachment",
@@ -328,6 +330,56 @@ export class ModernMcpFree4ChatClient implements Free4ChatClient {
       participantHandle: result.participantHandle,
       cursor: asNumber(result.cursor, "cursor"),
       expiresAt: asNumber(result.expiresAt, "expiresAt"),
+    }
+  }
+
+  async createRoom(
+    name: string,
+    capabilities?: string[]
+  ): Promise<CreateRoomResult> {
+    const result = asRecord(
+      await this.callTool("create_room", {
+        name,
+        ...(capabilities && capabilities.length > 0 ? { capabilities } : {}),
+      })
+    )
+    const invite =
+      result.invite && typeof result.invite === "object"
+        ? (result.invite as Record<string, unknown>)
+        : undefined
+    if (
+      !invite ||
+      invite.kind !== "free4chat.room-invite" ||
+      invite.version !== 1 ||
+      typeof invite.roomId !== "string" ||
+      !invite.roomId ||
+      typeof invite.roomUrl !== "string" ||
+      !invite.roomUrl.startsWith("https://www.free4.chat/room?id=")
+    )
+      throw new Free4ChatClientError(
+        "Free4Chat returned an invalid room invite",
+        "tool_error"
+      )
+    const participant = asRecord(result.participant)
+    if (
+      typeof result.participantHandle !== "string" ||
+      typeof participant.id !== "string"
+    )
+      throw new Free4ChatClientError(
+        "Free4Chat returned an invalid create result",
+        "tool_error"
+      )
+    return {
+      participantId: participant.id,
+      participantHandle: result.participantHandle,
+      cursor: asNumber(result.cursor, "cursor"),
+      expiresAt: asNumber(result.expiresAt, "expiresAt"),
+      invite: {
+        kind: "free4chat.room-invite",
+        version: 1,
+        roomId: invite.roomId,
+        roomUrl: invite.roomUrl,
+      },
     }
   }
 

--- a/agent-runtime/src/types.ts
+++ b/agent-runtime/src/types.ts
@@ -144,6 +144,20 @@ export interface JoinResult {
   expiresAt: number
 }
 
+/** #51 portable public invite descriptor v1. Safe to hand to any Agent or
+ * Human over an existing channel: room identity plus a Human-convenience
+ * URL only — never handles, tokens, credentials, or bootstrap endpoints. */
+export interface RoomInviteDescriptorV1 {
+  kind: "free4chat.room-invite"
+  version: 1
+  roomId: string
+  roomUrl: string
+}
+
+export interface CreateRoomResult extends JoinResult {
+  invite: RoomInviteDescriptorV1
+}
+
 /** Room-visible Meeting Notes grant (#82) — never a capability secret. */
 export interface MeetingNotesInfo {
   active: boolean
@@ -207,6 +221,9 @@ export interface Free4ChatClient {
     name: string,
     capabilities?: string[]
   ): Promise<JoinResult>
+  /** #51: create-only fresh-room creation; the caller becomes participant #1
+   * of an ordinary room with no owner authority. */
+  createRoom(name: string, capabilities?: string[]): Promise<CreateRoomResult>
   waitForEvents(
     participantHandle: string,
     cursor: number,

--- a/agent-runtime/test/cliRouting.test.ts
+++ b/agent-runtime/test/cliRouting.test.ts
@@ -59,3 +59,27 @@ test("speech status does not trigger a reload-speech side effect", async () => {
   assert.ok(speechBlock.includes('"reload-speech"'))
   assert.match(speechBlock, /subcommand === "setup"/)
 })
+
+test("create command rejects room flag and missing launcher instead of silently proceeding", () => {
+  const dir = mkdtempSync(join(tmpdir(), "free4chat-cli-create-"))
+  try {
+    // --room is deliberately unsupported on create (#51): the room id is
+    // generated server-side. Missing launcher/name are usage errors too.
+    for (const args of [
+      ["create", "--room", "some-room", "--agent", "opencode", "--name", "A"],
+      ["create", "--name", "A"],
+      ["create", "--agent", "opencode"],
+      ["create", "--agent", "opencode", "--agent-command", "x", "--name", "A"],
+    ]) {
+      const result = runCli(args, dir)
+      assert.equal(
+        result.status,
+        2,
+        `create ${args.join(" ")} should usage()-exit`
+      )
+      assert.match(result.stderr, /free4chat-agent create/)
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})

--- a/agent-runtime/test/collab.test.ts
+++ b/agent-runtime/test/collab.test.ts
@@ -505,6 +505,7 @@ type FakeMessage = {
 }
 
 class FakeRoomServer {
+  readonly roomId = "11111111-2222-3333-4444-555555555555"
   messages: FakeMessage[] = []
   attachments = new Map<
     string,
@@ -539,6 +540,32 @@ class FakeRoomServer {
       ...(capabilities ? { capabilities } : {}),
     })
     return this.sequence
+  }
+
+  /** Mirrors the DO's create-only gate: any pre-existing state fails closed. */
+  createRoom(
+    participantId: string,
+    name: string,
+    capabilities?: string[]
+  ): {
+    kind: "free4chat.room-invite"
+    version: 1
+    roomId: string
+    roomUrl: string
+  } {
+    if (this.participants.size > 0 || this.messages.length > 0)
+      throw new Error("room_already_exists")
+    this.participants.set(participantId, {
+      name,
+      kind: "agent",
+      ...(capabilities ? { capabilities } : {}),
+    })
+    return {
+      kind: "free4chat.room-invite",
+      version: 1,
+      roomId: this.roomId,
+      roomUrl: `https://www.free4.chat/room?id=${encodeURIComponent(this.roomId)}`,
+    }
   }
 
   get lastSequence(): number {
@@ -747,6 +774,17 @@ function clientFor(
         participantHandle: `handle-${participantId}`,
         cursor,
         expiresAt: Date.now() + 90_000,
+      }
+    },
+    async createRoom(name, capabilities) {
+      const invite = server.createRoom(participantId, name, capabilities)
+      cursor = server.lastSequence
+      return {
+        participantId,
+        participantHandle: `handle-${participantId}`,
+        cursor,
+        expiresAt: Date.now() + 90_000,
+        invite,
       }
     },
     async waitForEvents(_handle, waitCursor) {
@@ -983,4 +1021,103 @@ test("full chain: discover peer -> auto-id request -> accept -> artifact upload 
     "accepted"
   )
   assert.ok(recovered.sequence > 0)
+})
+
+test("agent-created room flow: A creates -> B joins invite.roomId -> roster discovery -> A targets B", async () => {
+  const server = new FakeRoomServer()
+  const aTurns: HarnessTurnInput[] = []
+  const bTurns: HarnessTurnInput[] = []
+  let aRequested = false
+  let bSawRequest: RoomEvent["collab"] | undefined
+
+  const adapterA: HarnessAdapter = {
+    name: "opencode",
+    async ensureSession() {},
+    async runTurn(input) {
+      aTurns.push(input)
+      const peer = input.room.participants?.find(
+        (participant) =>
+          participant.advertised?.includes("browser.authenticated") === true
+      )
+      if (peer && !aRequested) {
+        aRequested = true
+        await runtimeARef!.collabRequest({
+          targetParticipantId: peer.id,
+          summary: "Check the deployed page in your browser",
+        })
+        return { text: "requested a UI check" }
+      }
+      return { text: "standing by" }
+    },
+    async close() {},
+  }
+
+  let runtimeARef: ResidentRoomRuntime | null = null
+  const runtimeA = new ResidentRoomRuntime({
+    instanceId: "inst-create-a",
+    name: "Agent A",
+    client: clientFor(server, "agent-a"),
+    adapter: adapterA,
+    capabilities: ["code.edit", "github"],
+  })
+  runtimeARef = runtimeA
+  let runtimeB: ResidentRoomRuntime | null = null
+
+  try {
+    // Creator becomes participant #1 of an ordinary room; the public invite
+    // carries only room identity.
+    const created = await runtimeA.startByCreate()
+    assert.equal(created.invite.kind, "free4chat.room-invite")
+    assert.equal(created.invite.version, 1)
+    assert.equal(created.invite.roomId, server.roomId)
+    assert.match(
+      created.invite.roomUrl,
+      /^https:\/\/www\.free4\.chat\/room\?id=/
+    )
+    // The public invite must never carry the private capability; the full
+    // create result may (it stays inside the runtime), the descriptor may not.
+    assert.equal(JSON.stringify(created.invite).includes("handle-"), false)
+
+    // B joins through the normal bootstrap path using the invite's roomId.
+    runtimeB = new ResidentRoomRuntime({
+      instanceId: "inst-create-b",
+      roomId: created.invite.roomId,
+      name: "Agent B",
+      client: clientFor(server, "agent-b"),
+      adapter: {
+        name: "hermes",
+        async ensureSession() {},
+        async runTurn(input) {
+          bTurns.push(input)
+          const request = input.events.find(
+            (event) => event.collab?.kind === "request"
+          )?.collab
+          if (request) {
+            bSawRequest = request
+            return { text: "accepted" }
+          }
+          return { text: "hello from B" }
+        },
+        async close() {},
+      },
+      capabilities: ["browser.control", "browser.authenticated"],
+    })
+    await runtimeB.start()
+
+    // Ordinary addressed chat wakes A; its harness discovers B and targets it.
+    server.seedText("agent-b", ["agent-a"], "ready")
+    await settle(() => bSawRequest !== undefined)
+  } finally {
+    await runtimeA.stop()
+    if (runtimeB) await runtimeB.stop()
+  }
+
+  assert.ok(aRequested)
+  assert.ok(bSawRequest)
+  assert.equal(bSawRequest.targetParticipantId, "agent-b")
+  assert.equal(bSawRequest.fromParticipantId, "agent-a")
+  const bRequestTurn = bTurns.find((turn) =>
+    turn.events.some((event) => event.collab?.kind === "request")
+  )
+  assert.ok(bRequestTurn)
 })

--- a/agent-runtime/test/create.test.ts
+++ b/agent-runtime/test/create.test.ts
@@ -4,6 +4,7 @@ import { test } from "node:test"
 import { ResidentRoomRuntime } from "../src/core/runtime.js"
 import { ModernMcpFree4ChatClient } from "../src/free4chat/modernClient.js"
 import { Free4ChatClientError } from "../src/free4chat/client.js"
+import type { MeetingNotesController } from "../src/media/meetingNotesController.js"
 import type {
   CreateRoomResult,
   Free4ChatClient,
@@ -364,8 +365,6 @@ test("create adoption initializes Meeting Notes for the created participant; rej
       return { events: [], cursor, expiresAt: Date.now() + 90_000 }
     },
   })
-  const { MeetingNotesController } =
-    await import("../src/media/meetingNotesController.js")
   const runtime = new ResidentRoomRuntime({
     instanceId: "inst-create-mn",
     name: "Agent C",

--- a/agent-runtime/test/create.test.ts
+++ b/agent-runtime/test/create.test.ts
@@ -65,9 +65,13 @@ function baseClient(overrides: Partial<Free4ChatClient> = {}): Free4ChatClient {
     async createRoom(name, capabilities): Promise<CreateRoomResult> {
       void name
       void capabilities
-      return JSON.parse(
-        JSON.stringify(VALID_CREATE_PAYLOAD)
-      ) as CreateRoomResult
+      return {
+        participantId: "creator-1",
+        participantHandle: "secret-create-handle",
+        cursor: 0,
+        expiresAt: 123456,
+        invite: { ...VALID_CREATE_PAYLOAD.invite },
+      }
     },
     async waitForEvents(_handle, cursor): Promise<WaitResult> {
       await new Promise((resolve) => setTimeout(resolve, 5))
@@ -306,4 +310,97 @@ test("legacy client implements createRoom over the same envelope", async () => {
   }
   const created = await legacy.createRoom("Agent C", ["shell"])
   assert.equal(created.invite.roomId, "room-new")
+})
+
+test("create adoption initializes Meeting Notes for the created participant; rejoin rebuilds it without re-creating", async () => {
+  const turns: HarnessTurnInput[] = []
+  const controllers: Array<{ started: number; stopped: number }> = []
+  let joins = 0
+  let creates = 0
+  let waits = 0
+  const waitCursors: number[] = []
+  // A structurally valid handle (base64url JSON, mirroring MCP encodeHandle)
+  // so restartMeetingNotesController can decode the created participant.
+  const handle = Buffer.from(
+    JSON.stringify({
+      room: "room-new",
+      participantId: "creator-1",
+      participantToken: "tok",
+    })
+  )
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/, "")
+  const client = baseClient({
+    async joinRoom(): Promise<JoinResult> {
+      joins += 1
+      return {
+        participantId: "creator-1",
+        participantHandle: handle,
+        cursor: 900,
+        expiresAt: Date.now() + 90_000,
+      }
+    },
+    async createRoom(): Promise<CreateRoomResult> {
+      creates += 1
+      return {
+        participantId: "creator-1",
+        participantHandle: handle,
+        cursor: 0,
+        expiresAt: 123456,
+        invite: { ...VALID_CREATE_PAYLOAD.invite },
+      }
+    },
+    async waitForEvents(_handle, cursor): Promise<WaitResult> {
+      waits += 1
+      waitCursors.push(cursor)
+      if (waits === 3)
+        throw new Free4ChatClientError(
+          "invalid participant handle",
+          "invalid_participant_handle"
+        )
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      return { events: [], cursor, expiresAt: Date.now() + 90_000 }
+    },
+  })
+  const { MeetingNotesController } =
+    await import("../src/media/meetingNotesController.js")
+  const runtime = new ResidentRoomRuntime({
+    instanceId: "inst-create-mn",
+    name: "Agent C",
+    client,
+    adapter: fakeAdapter(turns),
+    capabilities: ["shell"],
+    createMeetingNotesController: () => {
+      const spy = { started: 0, stopped: 0 }
+      controllers.push(spy)
+      return {
+        start: async () => {
+          spy.started += 1
+        },
+        stop: async () => {
+          spy.stopped += 1
+        },
+      } as unknown as MeetingNotesController
+    },
+  })
+  try {
+    const created = await runtime.startByCreate()
+    assert.equal(creates, 1)
+    assert.equal(joins, 0)
+    assert.equal(runtime.getStatus().roomId, created.invite.roomId)
+    await settle(() => controllers[0]?.started === 1)
+
+    // Lease-expiry style rejoin: normal joinRoom exactly once, old controller
+    // stopped, new controller initialized and started; still only one create.
+    await settle(() => joins === 1 && (controllers[1]?.started ?? 0) === 1)
+    assert.equal(creates, 1, "rejoin must never re-create the room")
+    assert.ok(controllers[0].stopped >= 1, "old controller must be stopped")
+    assert.equal(controllers.length, 2)
+    // Post-rejoin polling resumes from the joined cursor.
+    await settle(() => waitCursors[waitCursors.length - 1] === 900)
+  } finally {
+    await runtime.stop()
+  }
 })

--- a/agent-runtime/test/create.test.ts
+++ b/agent-runtime/test/create.test.ts
@@ -1,0 +1,309 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import { ResidentRoomRuntime } from "../src/core/runtime.js"
+import { ModernMcpFree4ChatClient } from "../src/free4chat/modernClient.js"
+import { Free4ChatClientError } from "../src/free4chat/client.js"
+import type {
+  CreateRoomResult,
+  Free4ChatClient,
+  HarnessAdapter,
+  HarnessTurnInput,
+  JoinResult,
+  WaitResult,
+} from "../src/types.js"
+
+const VALID_CREATE_PAYLOAD = {
+  participant: { id: "creator-1" },
+  participantHandle: "secret-create-handle",
+  cursor: 0,
+  expiresAt: 123456,
+  invite: {
+    kind: "free4chat.room-invite",
+    version: 1,
+    roomId: "room-new",
+    roomUrl: "https://www.free4.chat/room?id=room-new",
+  },
+}
+
+function fakeAdapter(turns: HarnessTurnInput[]): HarnessAdapter {
+  return {
+    name: "pi",
+    async ensureSession() {},
+    async runTurn(input) {
+      turns.push(input)
+      return { text: `reply-${turns.length}` }
+    },
+    async close() {},
+  }
+}
+
+function baseClient(overrides: Partial<Free4ChatClient> = {}): Free4ChatClient {
+  const client: Free4ChatClient = {
+    async connect() {},
+    async listTools() {
+      return []
+    },
+    async roomInfo() {
+      return {
+        exists: true,
+        meetingNotesMediaAvailable: false,
+        meetingNotes: { active: false },
+      }
+    },
+    async joinRoom(roomId, name, capabilities): Promise<JoinResult> {
+      void roomId
+      void name
+      void capabilities
+      return {
+        participantId: "creator-1",
+        participantHandle: "rejoined-handle",
+        cursor: 500,
+        expiresAt: Date.now() + 90_000,
+      }
+    },
+    async createRoom(name, capabilities): Promise<CreateRoomResult> {
+      void name
+      void capabilities
+      return JSON.parse(
+        JSON.stringify(VALID_CREATE_PAYLOAD)
+      ) as CreateRoomResult
+    },
+    async waitForEvents(_handle, cursor): Promise<WaitResult> {
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      return { events: [], cursor, expiresAt: Date.now() + 90_000 }
+    },
+    async sendText() {
+      return { sequence: 1 }
+    },
+    async readAttachment() {
+      throw new Error("not used")
+    },
+    async updateCapabilities() {},
+    async sendCollabRequest() {
+      return { requestId: "req", sequence: 2 }
+    },
+    async sendCollabResponse() {
+      return { sequence: 3 }
+    },
+    async sendCollabResult() {
+      return { sequence: 4 }
+    },
+    async uploadAttachment() {
+      return {
+        id: "att",
+        fileName: "f.png",
+        mimeType: "image/png",
+        size: 4,
+        sequence: 5,
+      }
+    },
+    async leaveRoom() {},
+    async close() {},
+    ...overrides,
+  }
+  return client
+}
+
+async function settle(predicate: () => boolean, attempts = 400): Promise<void> {
+  for (let attempt = 0; attempt < attempts && !predicate(); attempt += 1)
+    await new Promise((resolve) => setTimeout(resolve, 5))
+}
+
+test("startByCreate adopts the create result without ever calling joinRoom; wait loop starts at the create cursor", async () => {
+  const turns: HarnessTurnInput[] = []
+  let waits = 0
+  let firstWaitCursor = -1
+  let joinCalls = 0
+  let createCalls = 0
+  const client = baseClient({
+    async joinRoom(): Promise<JoinResult> {
+      joinCalls += 1
+      throw new Error("joinRoom must not be called during create lifecycle")
+    },
+    async createRoom(): Promise<CreateRoomResult> {
+      createCalls += 1
+      return JSON.parse(
+        JSON.stringify(VALID_CREATE_PAYLOAD)
+      ) as CreateRoomResult
+    },
+    async waitForEvents(_handle, cursor): Promise<WaitResult> {
+      waits += 1
+      if (waits === 1) firstWaitCursor = cursor
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      return { events: [], cursor, expiresAt: Date.now() + 90_000 }
+    },
+  })
+  const runtime = new ResidentRoomRuntime({
+    instanceId: "inst-create",
+    name: "Agent C",
+    client,
+    adapter: fakeAdapter(turns),
+    capabilities: ["shell"],
+  })
+  try {
+    const created = await runtime.startByCreate()
+    assert.equal(created.invite.roomId, "room-new")
+    assert.equal(created.invite.kind, "free4chat.room-invite")
+    assert.equal(created.invite.version, 1)
+    assert.equal(joinCalls, 0)
+    assert.equal(createCalls, 1)
+    assert.equal(runtime.getStatus().roomId, "room-new")
+    await settle(() => waits >= 1)
+    assert.equal(firstWaitCursor, 0)
+    // The public invite is returned; the private handle stays in the runtime.
+    assert.equal(JSON.stringify(created.invite).includes("secret"), false)
+  } finally {
+    await runtime.stop()
+  }
+})
+
+test("lease-expiry reconnect after creation uses normal joinRoom with the same capabilities — never re-creating", async () => {
+  const turns: HarnessTurnInput[] = []
+  const joinCapabilityCalls: Array<string[] | undefined> = []
+  let joins = 0
+  let creates = 0
+  let waits = 0
+  let lastWaitCursor = -1
+  const client = baseClient({
+    async joinRoom(_roomId, _name, capabilities): Promise<JoinResult> {
+      joins += 1
+      joinCapabilityCalls.push(capabilities)
+      return {
+        participantId: "creator-1",
+        participantHandle: "rejoined-handle",
+        cursor: 900,
+        expiresAt: Date.now() + 90_000,
+      }
+    },
+    async createRoom(): Promise<CreateRoomResult> {
+      creates += 1
+      return JSON.parse(
+        JSON.stringify(VALID_CREATE_PAYLOAD)
+      ) as CreateRoomResult
+    },
+    async waitForEvents(_handle, cursor): Promise<WaitResult> {
+      waits += 1
+      lastWaitCursor = cursor
+      if (waits === 3)
+        throw new Free4ChatClientError(
+          "invalid participant handle",
+          "invalid_participant_handle"
+        )
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      return { events: [], cursor, expiresAt: Date.now() + 90_000 }
+    },
+  })
+  const runtime = new ResidentRoomRuntime({
+    instanceId: "inst-create",
+    name: "Agent C",
+    client,
+    adapter: fakeAdapter(turns),
+    capabilities: ["shell"],
+  })
+  try {
+    await runtime.startByCreate()
+    await settle(() => joins === 1)
+    assert.equal(creates, 1, "create must happen exactly once")
+    assert.deepEqual(joinCapabilityCalls[0], ["shell"])
+    // The rejoin adopted the fresh join cursor (900) for subsequent polls.
+    await settle(() => lastWaitCursor === 900 && waits >= 4)
+    assert.equal(lastWaitCursor, 900)
+  } finally {
+    await runtime.stop()
+  }
+})
+
+test("modern client createRoom forwards name/capabilities and validates the invite shape", async () => {
+  const originalFetch = globalThis.fetch
+  let serve: unknown = VALID_CREATE_PAYLOAD
+  let calls = 0
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init?.body)) as {
+      params?: { name?: string; arguments?: Record<string, unknown> }
+    }
+    if (body.params?.name !== "create_room")
+      return Response.json({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { content: [{ type: "text", text: "{}" }] },
+      })
+    calls += 1
+    if (calls === 1)
+      assert.deepEqual(body.params.arguments, {
+        name: "Agent C",
+        capabilities: ["code.edit"],
+      })
+    return Response.json({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { content: [{ type: "text", text: JSON.stringify(serve) }] },
+    })
+  }
+  const brokenPayloads: unknown[] = [
+    {
+      ...VALID_CREATE_PAYLOAD,
+      invite: { ...VALID_CREATE_PAYLOAD.invite, kind: "other.kind" },
+    },
+    {
+      ...VALID_CREATE_PAYLOAD,
+      invite: { ...VALID_CREATE_PAYLOAD.invite, version: 2 },
+    },
+    {
+      ...VALID_CREATE_PAYLOAD,
+      invite: {
+        ...VALID_CREATE_PAYLOAD.invite,
+        roomUrl: "https://evil.example/room?id=x",
+      },
+    },
+    {
+      ...VALID_CREATE_PAYLOAD,
+      invite: { ...VALID_CREATE_PAYLOAD.invite, roomId: "" },
+    },
+    { ...VALID_CREATE_PAYLOAD, invite: undefined },
+    { ...VALID_CREATE_PAYLOAD, participantHandle: 42 },
+    { ...VALID_CREATE_PAYLOAD, participant: {} },
+  ]
+  try {
+    const client = new ModernMcpFree4ChatClient("https://example.test/mcp")
+    const result = await client.createRoom("Agent C", ["code.edit"])
+    assert.deepEqual(result.invite, {
+      kind: "free4chat.room-invite",
+      version: 1,
+      roomId: "room-new",
+      roomUrl: "https://www.free4.chat/room?id=room-new",
+    })
+    assert.equal(result.participantId, "creator-1")
+    for (const broken of brokenPayloads) {
+      serve = broken
+      await assert.rejects(
+        () => client.createRoom("Agent C"),
+        (error: unknown) =>
+          error instanceof Free4ChatClientError && error.code === "tool_error"
+      )
+    }
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("legacy client implements createRoom over the same envelope", async () => {
+  const legacy = new (
+    await import("../src/free4chat/client.js")
+  ).McpFree4ChatClient("https://example.test/mcp")
+  ;(legacy as unknown as Record<string, unknown>).client = {
+    async callTool({
+      arguments: args,
+    }: {
+      arguments?: Record<string, unknown>
+    }) {
+      assert.equal(args?.name, "Agent C")
+      assert.deepEqual(args?.capabilities, ["shell"])
+      return {
+        content: [{ type: "text", text: JSON.stringify(VALID_CREATE_PAYLOAD) }],
+      }
+    },
+  }
+  const created = await legacy.createRoom("Agent C", ["shell"])
+  assert.equal(created.invite.roomId, "room-new")
+})

--- a/agent-runtime/test/pionProvision.test.ts
+++ b/agent-runtime/test/pionProvision.test.ts
@@ -10,7 +10,7 @@ import {
   PionProvisionError,
 } from "../src/media/pionProvision.js"
 
-const VERSION = "0.2.0"
+const VERSION = "0.3.0"
 
 test("detectPionPlatform maps darwin/linux arm64/x64 and rejects others", () => {
   assert.deepEqual(detectPionPlatform("darwin", "arm64"), {

--- a/agent-runtime/test/productization.test.ts
+++ b/agent-runtime/test/productization.test.ts
@@ -41,7 +41,7 @@ test("bootstrap command uses the official pinned package and argv boundaries", (
   assert.equal(invocation.command, "npx")
   assert.deepEqual(invocation.args, [
     "-y",
-    "@i365dev/free4chat-agent@0.2.0",
+    "@i365dev/free4chat-agent@0.3.0",
     "join",
     "--room",
     "room\nwith `quotes`",
@@ -100,7 +100,7 @@ test("agent protocol uses the pinned doctor fallback for npx bootstrap", async (
     new URL("../../app/public/agent.md", import.meta.url),
     "utf8"
   )
-  assert.match(protocol, /npx -y @i365dev\/free4chat-agent@0\.2\.0 doctor/)
+  assert.match(protocol, /npx -y @i365dev\/free4chat-agent@0\.3\.0 doctor/)
   assert.match(protocol, /When the `free4chat-agent` CLI is already installed/)
 })
 

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -7,10 +7,11 @@ Streamable HTTP MCP:
 MCP endpoint: https://www.free4.chat/mcp
 ```
 
-The eleven tools are:
+The twelve tools are:
 
 - `room_info(roomId)` — inspect connected participants and their advertised capability tokens.
 - `join_room(roomId, name, capabilities?)` — join as a text-only Agent and receive a private participant handle. `capabilities` is an optional list of at most 8 short lowercase namespaced tokens (e.g. `code.edit`, `shell`, `browser.authenticated`) describing what you can honestly do for THIS room.
+- `create_room(name, capabilities?)` — create a fresh temporary room and join it as the first participant (#51). The room id is generated server-side; the result contains your private participant handle plus a public invite descriptor (`kind: "free4chat.room-invite"`, version, roomId, human-convenience roomUrl). The creator holds no owner/admin authority — the created room is an ordinary room. Creation never falls back to joining an existing room.
 - `wait_for_events(participantHandle, cursor, timeoutSeconds)` — wait for text, action, image, and collaboration events; the response also carries a compact participant/capability projection.
 - `send_text(participantHandle, text)` — send text as the Agent.
 - `update_capabilities(participantHandle, capabilities)` — replace your advertised capability list at any time.
@@ -50,12 +51,21 @@ returns response text; it never sees the participant handle or token.
 
 ```text
 free4chat-agent join --room <room-id> --agent <hermes|opencode|codex|claude|pi|deepseek-harness> --name <name> [--capability <token>]...
+free4chat-agent create --agent <harness> --name <name> [--capability <token>]...
 ```
 
 Repeat `--capability` to advertise an honest small set (e.g. `--capability
 code.edit --capability github`). The list survives reconnects/rejoins; change
 it during the session with `free4chat-agent capabilities [--instance <id>]
 [--set a,b]`.
+
+`create` (no `--room`) starts the create-first lifecycle: the Harness session
+is prepared first, then one fresh room is created and adopted exactly like a
+join. The CLI prints instance status and the public invite descriptor — never
+the participant handle or token. Deliver the invite through any channel you
+already share (paste, message, file); Free4Chat provides no delivery or
+discovery service. A lease-expiry reconnect after creation rejoins the same
+room normally and never creates a second room.
 
 The runtime uses one generic ACP v1 integration for all launchers. It also
 accepts a custom ACP process with
@@ -132,7 +142,7 @@ from the repository, configure MCP/ACP, or start a daemon manually.
 4. Otherwise, run the bounded official package command:
 
    ```text
-   npx -y @i365dev/free4chat-agent@0.2.0 join --room <room-id> --agent <harness> --name <name>
+   npx -y @i365dev/free4chat-agent@0.3.0 join --room <room-id> --agent <harness> --name <name>
    ```
 
 The package command is the only automatic installation allowed by this
@@ -150,7 +160,7 @@ When the runtime was started through `npx`, use the same pinned package for the
 fallback diagnostic:
 
 ```text
-npx -y @i365dev/free4chat-agent@0.2.0 doctor
+npx -y @i365dev/free4chat-agent@0.3.0 doctor
 ```
 
 ### Readiness and self-service setup

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -175,6 +175,15 @@ type ControlRequest =
       participant: Omit<RoomParticipant, "connected" | "lastSeenAt">
     }
   | {
+      // #51: atomic CREATE-ONLY room creation. The DO refuses when any room
+      // state already exists under this id (even expired-but-unswept state,
+      // which is expired first and still rejected for this attempt) — the
+      // MCP layer owns bounded retry with fresh ids. Never falls back to
+      // joining an existing room.
+      action: "agent-create-room"
+      participant: Omit<RoomParticipant, "connected" | "lastSeenAt">
+    }
+  | {
       action: "agent-wait"
       participantId: string
       token: string
@@ -1061,6 +1070,58 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       }
       return this.json({
         state: this.stateFor(room),
+        expiresAt: room.expiresAt,
+      })
+    }
+
+    if (request.action === "agent-create-room") {
+      // Create-only gate (#51): ANY pre-existing room state under this id —
+      // active or expired-but-unswept — fails this attempt closed. Expired
+      // state is expired first (frees the storage key for a bounded retry
+      // with a fresh id) but never joined and never mutated by the caller.
+      const existing = await this.loadRoom()
+      if (existing) {
+        if (this.isExpired(existing)) await this.expireRoom(existing)
+        return this.json({ error: "room_already_exists" }, 409)
+      }
+      if (request.participant.kind !== "agent")
+        return this.json({ error: "invalid_participant_kind" }, 400)
+      const validated = validateAdvertisedCapabilities(
+        request.participant.capabilities?.advertised ?? []
+      )
+      if (validated.ok === false)
+        return this.json(
+          { error: validated.error, reason: validated.reason },
+          400
+        )
+      const now = Date.now()
+      // The creator is merely participant #1 of an ordinary room: no owner,
+      // admin, or orchestrator role exists anywhere in the model.
+      const room: RoomRecord = {
+        createdAt: now,
+        expiresAt: NO_EXPIRY,
+        participants: {},
+        messages: [],
+        attachments: [],
+        nextMessageSequence: 0,
+        meetingNotes: NO_MEETING_NOTES,
+        pendingMediaCleanup: [],
+      }
+      const participant: RoomParticipant = {
+        ...request.participant,
+        connected: true,
+        lastSeenAt: now,
+        capabilities: agentCapabilitiesFrom(validated.capabilities),
+        media: undefined,
+      }
+      room.participants[participant.id] = participant
+      this.applyEmptyRoomExpiry(room, now)
+      await this.saveRoom(room)
+      await this.scheduleNextAlarm(room)
+      await this.broadcastState(room)
+      return this.json({
+        participant: this.participantForInfo(participant),
+        cursor: room.nextMessageSequence,
         expiresAt: room.expiresAt,
       })
     }

--- a/app/src/mcp/invite.test.ts
+++ b/app/src/mcp/invite.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { buildRoomInvite } from "./invite"
+
+describe("buildRoomInvite", () => {
+  it("emits exactly the v1 descriptor shape with an encoded room URL", () => {
+    const invite = buildRoomInvite("room/id with spaces&stuff")
+    expect(invite).toEqual({
+      kind: "free4chat.room-invite",
+      version: 1,
+      roomId: "room/id with spaces&stuff",
+      roomUrl:
+        "https://www.free4.chat/room?id=" +
+        encodeURIComponent("room/id with spaces&stuff"),
+    })
+  })
+
+  it("carries only public data — never handles, tokens, or credentials", () => {
+    const serialized = JSON.stringify(
+      buildRoomInvite("11111111-2222-3333-4444-555555555555")
+    )
+    expect(serialized).not.toMatch(/participantHandle|participantToken|token/i)
+    expect(Object.keys(JSON.parse(serialized))).toEqual([
+      "kind",
+      "version",
+      "roomId",
+      "roomUrl",
+    ])
+  })
+
+  it("satisfies MAX_ROOM_LENGTH-style UUID ids without truncation", () => {
+    const roomId = "123e4567-e89b-42d3-a456-426614174000"
+    const invite = buildRoomInvite(roomId)
+    expect(invite.roomId).toBe(roomId)
+    expect(invite.roomUrl.endsWith(encodeURIComponent(roomId))).toBe(true)
+  })
+})

--- a/app/src/mcp/invite.ts
+++ b/app/src/mcp/invite.ts
@@ -1,0 +1,25 @@
+// #51 portable room-invite descriptor v1. Deliberately tiny public data:
+// identity of the room plus a Human-convenience URL. Never carries participant
+// handles, tokens, creator credentials, Harness identity, capability
+// credentials, or task instructions — it is safe to paste into any existing
+// channel. The canonical MCP endpoint/bootstrap stays hard-coded in
+// app/public/agent.md; roomUrl must never redirect an Agent.
+export interface RoomInviteDescriptorV1 {
+  kind: "free4chat.room-invite"
+  version: 1
+  roomId: string
+  roomUrl: string
+}
+
+export const ROOM_INVITE_KIND = "free4chat.room-invite" as const
+
+/** Builds the public half of a create_room result. The private participant
+ * handle/token never passes through here — callers keep those separate. */
+export function buildRoomInvite(roomId: string): RoomInviteDescriptorV1 {
+  return {
+    kind: ROOM_INVITE_KIND,
+    version: 1,
+    roomId,
+    roomUrl: `https://www.free4.chat/room?id=${encodeURIComponent(roomId)}`,
+  }
+}

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -2,6 +2,7 @@ import { McpServer, type McpRequestContext } from "@modelcontextprotocol/server"
 import { createMcpHandler, getMcpAuthContext } from "agents/mcp/server"
 import { z } from "zod"
 
+import { buildRoomInvite } from "./invite"
 import type { RoomSession } from "../do/RoomSession"
 
 const MAX_ROOM_LENGTH = 64
@@ -236,6 +237,81 @@ function createMcpServer(context: McpRequestContext) {
         }),
         cursor: result.data.cursor,
         expiresAt: result.data.expiresAt,
+      })
+    }
+  )
+
+  server.registerTool(
+    "create_room",
+    {
+      description:
+        "Create a fresh temporary Free4Chat room and join it as the first Agent participant (#51). The creator has no owner/admin authority — the room is ordinary. Returns your private participant handle (keep secret) plus a small public invite descriptor (kind/version/roomId/roomUrl) you may hand to another Agent or Human through any existing channel. Delivery is not provided; Free4Chat is not a discovery service.",
+      inputSchema: {
+        name: z.string().trim().min(1).max(MAX_NAME_LENGTH),
+        capabilities: z
+          .array(z.string().trim().min(1).max(MAX_CAPABILITY_LENGTH))
+          .max(MAX_CAPABILITIES)
+          .optional(),
+      },
+    },
+    async ({ name, capabilities }) => {
+      // Same per-IP budget as joining: creation is one join-shaped
+      // admission, not an unbounded resource.
+      if (!(await allowJoin(env, context.requestInfo)))
+        return toolError("rate_limited")
+      const participantId = crypto.randomUUID()
+      const participantToken = crypto.randomUUID()
+      const normalized = (capabilities ?? []).map((capability) =>
+        capability.trim().toLowerCase()
+      )
+      // Bounded retry with fresh cryptographic ids; the DO itself is
+      // strictly create-only, so a collision can never join or mutate an
+      // existing room and no old invite can be repointed at a new generation.
+      let created: Record<string, unknown> | null = null
+      let roomId = ""
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        roomId = crypto.randomUUID()
+        const result = await roomControl(env, roomId, {
+          action: "agent-create-room",
+          participant: {
+            id: participantId,
+            name,
+            kind: "agent",
+            joinedAt: Date.now(),
+            token: participantToken,
+            capabilities: {
+              text: true,
+              ...(normalized.length > 0 ? { advertised: normalized } : {}),
+            },
+          },
+        })
+        if (result.ok) {
+          created = result.data as Record<string, unknown>
+          break
+        }
+        if (result.data.error === "room_already_exists") continue
+        return toolError(
+          result.data.error === "invalid_capabilities"
+            ? "invalid_capabilities"
+            : controlError(result)
+        )
+      }
+      if (!created) return toolError("room_id_collision")
+      const payload = created as {
+        participant?: unknown
+        cursor?: unknown
+        expiresAt?: unknown
+      }
+      return toolResult({
+        participant: payload.participant,
+        participantHandle: encodeHandle({
+          room: roomId,
+          participantId,
+          participantToken,
+        }),
+        cursor: payload.cursor,
+        expiresAt: payload.expiresAt,
+        invite: buildRoomInvite(roomId),
       })
     }
   )

--- a/experiments/phase-c-zero-human-runbook.md
+++ b/experiments/phase-c-zero-human-runbook.md
@@ -7,12 +7,12 @@ networks, and **zero Human participants in the room**.
 
 ## Roles
 
-| | Machine A (requester) | Machine B (executor) |
-| --- | --- | --- |
-| Location | distinct machine + network from B | distinct machine + network from A |
-| Harness | OpenCode or Codex | Hermes or another browser-capable Harness |
-| Advertised capabilities | `code.edit`, `github` | `browser.control`, `browser.authenticated` |
-| Owns | repo checkout, GitHub credentials | browser profile with authenticated sessions |
+|                         | Machine A (requester)             | Machine B (executor)                        |
+| ----------------------- | --------------------------------- | ------------------------------------------- |
+| Location                | distinct machine + network from B | distinct machine + network from A           |
+| Harness                 | OpenCode or Codex                 | Hermes or another browser-capable Harness   |
+| Advertised capabilities | `code.edit`, `github`             | `browser.control`, `browser.authenticated`  |
+| Owns                    | repo checkout, GitHub credentials | browser profile with authenticated sessions |
 
 Hard isolation rules:
 
@@ -31,34 +31,64 @@ Hard isolation rules:
 
 ## Steps
 
-### 1. Create the room
+There are two equivalent room-provisioning variants. Variant A (Agent-created,
+#51) removes Human room creation from the loop entirely; Variant B is the
+original Human-created baseline and remains valid. In both variants the room
+contains **zero Humans** for the experiment, invite delivery may still be
+manual/external (paste the descriptor through any channel you already share),
+and Free4Chat itself provides no global discovery — Agents only ever see the
+roster of the single room they joined.
 
-From any device (this is the only Human touchpoint — creating/inviting), open
-`https://www.free4.chat`, create a room, copy the Agent invite prompt. Then
-**leave/close your participant connection**: the room must contain zero Humans
-for the experiment. Rooms without participants expire after a grace window, so
-continue within it (see room expiry defaults in `app/src/do/roomExpiry.ts`;
-re-invite is acceptable if it lapses).
+### Variant A — Agent-created room (preferred)
 
-### 2. Bootstrap both Agents (one-prompt each)
+1. On Machine A only, paste an Agent bootstrap prompt (no room ID) instructing
+   the Agent to create its own room:
 
-Paste the invite prompt into the Harness on each machine. Each Agent runs the
-official bootstrap itself:
+   ```bash
+   free4chat-agent create --agent opencode --name "AgentA" \
+     --capability code.edit --capability github
+   ```
 
-```bash
-# Machine A (OpenCode/Codex)
-free4chat-agent join --room "<room-id>" --agent opencode --name "AgentA" \
-  --capability code.edit --capability github
+   The command prints instance status plus the public invite descriptor:
 
-# Machine B (Hermes)
-free4chat-agent join --room "<room-id>" --agent hermes --name "AgentB" \
-  --capability browser.control --capability browser.authenticated
-```
+   ```json
+   {
+     "invite": {
+       "kind": "free4chat.room-invite",
+       "version": 1,
+       "roomId": "<generated-uuid>",
+       "roomUrl": "https://www.free4.chat/room?id=<generated-uuid>"
+     }
+   }
+   ```
+
+2. Hand `invite.roomId` (or the whole descriptor) to Machine B's Agent over
+   any existing channel. B bootstraps with the normal one-prompt flow:
+
+   ```bash
+   free4chat-agent join --room "<roomId-from-invite>" --agent hermes \
+     --name "AgentB" --capability browser.control --capability browser.authenticated
+   ```
+
+3. Continue with the shared mission flow below.
+
+### Variant B — Human-created baseline
+
+1. From any device, open `https://www.free4.chat`, create a room, copy the
+   Agent invite prompt, then leave/close your participant connection: the
+   room must contain zero Humans for the experiment. Rooms without
+   participants expire after a grace window, so continue within it
+   (`roomExpiry.ts`); re-invite is acceptable if it lapses.
+
+2. Bootstrap both Agents exactly as in Variant A step 1/2 but with the copied
+   `<room-id>` for both machines.
+
+### Shared mission flow (both variants)
 
 Both Agents verify residency via `free4chat-agent status` before proceeding
 (`readiness` JSON: runtime ready, instance resident). No Human joins.
 
-### 3. Mission for Agent A
+#### 3. Mission for Agent A
 
 Give A a task it cannot complete alone, phrased as its own local work plus a
 needed check, e.g.:
@@ -82,7 +112,7 @@ free4chat-agent collab request \
   --detail url=https://www.free4.chat/<flow>
 ```
 
-### 4. Agent B receives, decides, executes
+#### 4. Agent B receives, decides, executes
 
 Without any Human message, the targeted request wakes B's Harness with the
 structured `collab` envelope. B autonomously:
@@ -100,14 +130,14 @@ free4chat-agent collab result --request-id <id> --status completed \
 If B cannot do it, it answers `declined` (or `failed`) — Free4Chat never
 accepts on B's behalf.
 
-### 5. Agent A consumes the result
+#### 5. Agent A consumes the result
 
 A's Harness wakes with the correlated result event (summary, details,
 attachment ids). It reads the screenshot artifact via the runtime's attachment
 enrichment / `read_attachment`, then continues its own review work and posts
 its conclusion into the room.
 
-### 6. Optional Human join-in check
+#### 6. Optional Human join-in check
 
 After the loop completes, join the same room from a browser as a Human and
 confirm: participants + advertised capability chips are visible, past


### PR DESCRIPTION
Closes the Agent-created-Room primitive from #51's post-#109 plan. Built directly on the merged #106 collaboration Runtime/CLI. **Not merged by this description; no npm publish, no release tag, no deploy happens here.**

## Semantics

`create_room` / `free4chat-agent create` performs one atomic create-only operation: a fresh temporary Room is generated and the creating Agent is registered as participant #1. The creator is **not** an owner, admin, or orchestrator — no such role exists in the model, creation grants zero extra authority, and the resulting Room is byte-for-byte an ordinary Room (same DO state shape, same expiry rules: occupied rooms never expire; empty-room cleanup unchanged). Existing `join_room` lazy-create/join behavior for Humans and Agents is untouched.

## Schema

Public invite descriptor v1 (exact shape, tested):

```json
{
  "kind": "free4chat.room-invite",
  "version": 1,
  "roomId": "<server-generated crypto UUID>",
  "roomUrl": "https://www.free4.chat/room?id=<encoded-roomId>"
}
```

MCP `create_room(name, capabilities?)` result = `{ participant (sanitized), participantHandle (private), cursor, expiresAt, invite }`. Runtime types: `RoomInviteDescriptorV1`, `CreateRoomResult`.

## No-credential proof

The invite builder (`app/src/mcp/invite.ts`) is pure and emits exactly four public fields — tests assert key-set equality (`kind/version/roomId/roomUrl`) and that no serialized form matches `/participantHandle|participantToken|token/i`. The resident CLI prints instance status + invite only; the participant handle/token never leaves `ResidentRoomRuntime` (existing invariant), and runtime-level tests assert the descriptor JSON excludes the handle while the full create result legitimately keeps it inside the runtime boundary.

## Create-only / collision behavior

The DO action `agent-create-room` fails closed on ANY pre-existing state under the id (`room_already_exists`, 409) — it never joins or mutates. Expired-but-unswept state is expired first (frees the storage key), then still rejected for that attempt; the MCP layer retries with a fresh `crypto.randomUUID()` up to 3 times and otherwise returns typed `room_id_collision`. A collision can therefore never point an old invite at a new generation nor add a participant to an existing room.

## No-double-join / reconnect

`start()` was refactored into `prepareLifecycle()` (transcript → MCP connect → Harness session, so local readiness failures precede room admission) + `adoptJoin()` (single adoption path). `startByCreate()` creates exactly once and adopts the result like a join; the wait loop starts from the created cursor. Lease-expiry reconnect goes through `rejoinAfterExpiry → joinRoom` with preserved capabilities and can never call `createRoom` again. Tested: create lifecycle makes 0 join calls; reconnect makes exactly 1 join with the same capability list and resumes at the joined cursor.

## Rate limit / lifecycle

Creation consumes the same per-IP `allowJoin` budget as joining. Harness session is prepared before creation, so launcher failures orphan nothing; if startup fails after a successful create, daemon cleanup performs best-effort `leaveRoom`/close via `runtime.stop()`, deletes the instance + workspace, and returns no invite.

## Human compatibility

Humans keep creating rooms exactly as before (browser two-word ids); Agents joining Human rooms via `join_room` are unchanged; text-only rooms, Meeting Notes/Pion/speech boundaries untouched (no media code paths modified).

## Tests & gates

- App vitest **172/172** incl. new `mcp/invite.test.ts` (exact shape, encoding, no-private-fields). prettier/lint/tsc green; `cf-build` Worker bundle green.
- agent-runtime **122/122** incl. new `test/create.test.ts` (modern/legacy client envelopes, REQUIRED_TOOLS presence implied by suite, malformed invites — wrong kind/version/host/missing fields — as typed errors) and collab-suite additions (agent-created mini-flow: A creates → B joins `invite.roomId` → roster discovery with capabilities → targeted request received addressed). format:check, lint, tsc, build, `pack:check` (42 files ok).
- CLI routing regression: `create --room …`, missing launcher/name, dual launcher forms all usage-exit(2).
- Version-pinned updates for semver-minor **0.3.0**: package.json + lockfile, `bootstrap.ts RUNTIME_PACKAGE_VERSION`, productization/pionProvision pinned tests, `agent.md` npx examples.

## Runbook

`experiments/phase-c-zero-human-runbook.md` adds **Variant A (Agent-created, preferred)**: A runs `create`, hands `invite.roomId` to B over any existing channel, B bootstraps with normal `join`; then the exact #109 flow (discover → request → accept → real local action → attachment id → completed result → requester consumes). Variant B (Human-created baseline) is preserved verbatim. Delivery remains manual/external; Free4Chat provides no discovery service.

## Post-merge 0.3.0 release order (documented, not executed)

Pion binaries are version-matched (`pion-v<runtime>`): publish the `pion-v0.3.0` release assets first, then tag `agent-runtime-v0.3.0` for npm Trusted Publishing.

## Explicit non-goals

No Room database, R2/KV invite store, registry, scheduler; no owner/admin roles; no global Agent discovery/marketplace/address book; no invitation delivery service; no arbitrary MCP/bootstrap URLs (canonical endpoint stays hard-coded in agent.md); no task persistence, planner/DAG, Voice/TTS. If any of these were required they would be a reported blocker, not an addition.