### PR TITLE
feat(#111): Agent workspace snapshot surfaces — Observable Agent Workspace v0

### DIFF
--- a/agent-runtime/package-lock.json
+++ b/agent-runtime/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@i365dev/free4chat-agent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@i365dev/free4chat-agent",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",

--- a/agent-runtime/package.json
+++ b/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i365dev/free4chat-agent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Zero-setup local lifecycle runtime for resident Free4Chat Agents",
   "author": "i365dev",
   "license": "MIT",

--- a/agent-runtime/src/adapters/types.ts
+++ b/agent-runtime/src/adapters/types.ts
@@ -59,9 +59,14 @@ export function renderUntrustedRoomTurn(input: HarnessTurnInput): string {
             participant.advertised && participant.advertised.length > 0
               ? ` — advertised: ${participant.advertised.join(", ")}`
               : ""
+          const surface = participant.surface
+            ? ` — workspace snapshot: available (updated ${new Date(
+                participant.surface.updatedAt
+              ).toISOString()}; read on demand via free4chat-agent surface read)`
+            : ""
           const self =
             participant.id === input.room.self?.participantId ? " (you)" : ""
-          return `- ${participant.name} [participantId=${participant.id}]${self} (${participant.kind})${capabilities}`
+          return `- ${participant.name} [participantId=${participant.id}]${self} (${participant.kind})${capabilities}${surface}`
         }),
         "Use participantId values as collaboration targets.",
       ]

--- a/agent-runtime/src/bootstrap.ts
+++ b/agent-runtime/src/bootstrap.ts
@@ -1,5 +1,5 @@
 export const RUNTIME_PACKAGE_NAME = "@i365dev/free4chat-agent"
-export const RUNTIME_PACKAGE_VERSION = "0.3.0"
+export const RUNTIME_PACKAGE_VERSION = "0.4.0"
 
 export const BUILT_IN_AGENT_IDS = [
   "hermes",

--- a/agent-runtime/src/cli.ts
+++ b/agent-runtime/src/cli.ts
@@ -6,6 +6,15 @@ import { runSpeechCommand } from "./speech/cli.js"
 import { redactSecrets } from "./speech/redaction.js"
 
 const MAX_ATTACHMENT_BYTES = 768 * 1024
+// #111: same image-only bounds as the server-side surface policy.
+const MAX_SURFACE_BYTES = 768 * 1024
+
+const SURFACE_MIME_BY_EXTENSION: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".webp": "image/webp",
+}
 
 const MIME_BY_EXTENSION: Record<string, string> = {
   ".png": "image/png",
@@ -32,6 +41,9 @@ function usage(): never {
   free4chat-agent collab respond --request-id <id> --decision <accepted|declined> [--summary <text>] [--instance <id>]
   free4chat-agent collab result --request-id <id> --status <completed|failed> --summary <text> [--detail key=value]... [--attach <attachment-id>]... [--instance <id>]
   free4chat-agent attach --file <path> [--name <file-name>] [--instance <id>]
+  free4chat-agent surface publish --file <snapshot.jpeg|png|webp> [--instance <id>]
+  free4chat-agent surface clear [--instance <id>]
+  free4chat-agent surface read --participant <participant-id> [--instance <id>]
   free4chat-agent doctor [--json]
   free4chat-agent readiness [--room <room-id>] [--agent <harness>] [--json]
   free4chat-agent speech status [--json]
@@ -117,6 +129,70 @@ async function main(): Promise<void> {
       )
     )
     return
+  }
+  if (command === "surface") {
+    const subcommand = args[0]
+    const rest = args.slice(1)
+    await ensureDaemon()
+    if (subcommand === "publish") {
+      const filePath = option(rest, "--file")
+      if (!filePath) usage()
+      const extension = filePath.slice(filePath.lastIndexOf(".")).toLowerCase()
+      const mimeType = SURFACE_MIME_BY_EXTENSION[extension]
+      if (!mimeType)
+        throw new Error(
+          "Surface snapshots must be a .png, .jpg/.jpeg, or .webp image"
+        )
+      const info = await stat(filePath)
+      if (!info.isFile() || info.size === 0 || info.size > MAX_SURFACE_BYTES)
+        throw new Error(
+          `Surface snapshot must be a non-empty file up to ${MAX_SURFACE_BYTES} bytes`
+        )
+      const bytes = await readFile(filePath)
+      console.log(
+        JSON.stringify(
+          await sendIpc({
+            op: "surface-publish",
+            instanceId: option(rest, "--instance"),
+            mimeType,
+            dataBase64: bytes.toString("base64"),
+          }),
+          null,
+          2
+        )
+      )
+      return
+    }
+    if (subcommand === "clear") {
+      console.log(
+        JSON.stringify(
+          await sendIpc({
+            op: "surface-clear",
+            instanceId: option(rest, "--instance"),
+          }),
+          null,
+          2
+        )
+      )
+      return
+    }
+    if (subcommand === "read") {
+      const participantId = option(rest, "--participant")
+      if (!participantId) usage()
+      console.log(
+        JSON.stringify(
+          await sendIpc({
+            op: "surface-read",
+            instanceId: option(rest, "--instance"),
+            sourceParticipantId: participantId,
+          }),
+          null,
+          2
+        )
+      )
+      return
+    }
+    usage()
   }
   if (command === "peers") {
     const room = option(args, "--room")

--- a/agent-runtime/src/core/runtime.ts
+++ b/agent-runtime/src/core/runtime.ts
@@ -28,6 +28,9 @@ import type {
   JoinResult,
   ParticipantRosterEntry,
   RoomEvent,
+  RoomSurfaceMetadataV1,
+  SurfacePublishPayload,
+  SurfaceReadResult,
   UploadedAttachment,
 } from "../types.js"
 
@@ -655,6 +658,36 @@ export class ResidentRoomRuntime {
    * references via --attach, so it must reach the caller. */
   async uploadAttachment(file: AttachmentUpload): Promise<UploadedAttachment> {
     return this.options.client.uploadAttachment(this.requireHandle(), file)
+  }
+
+  // #111 Observable Agent Workspace: thin passthroughs. The participant
+  // handle stays inside the runtime; no capture scheduling exists here.
+  publishSurface(payload: SurfacePublishPayload): Promise<{
+    surface: RoomSurfaceMetadataV1
+  }> {
+    return this.options.client.publishSurface(this.requireHandle(), payload)
+  }
+
+  clearSurface(): Promise<void> {
+    return this.options.client.clearSurface(this.requireHandle())
+  }
+
+  readSurface(
+    sourceParticipantId: string,
+    snapshotId: string
+  ): Promise<SurfaceReadResult> {
+    return this.options.client.readSurface(
+      this.requireHandle(),
+      sourceParticipantId,
+      snapshotId
+    )
+  }
+
+  /** Current sanitized metadata for a peer, used by CLI `surface read` to
+   * pin the exact snapshotId before any bytes move. */
+  peerSurface(sourceParticipantId: string): RoomSurfaceMetadataV1 | null {
+    const entry = this.roster.find((p) => p.id === sourceParticipantId)
+    return entry?.surface ?? null
   }
 
   async stop(): Promise<void> {

--- a/agent-runtime/src/daemon.ts
+++ b/agent-runtime/src/daemon.ts
@@ -23,6 +23,14 @@ interface ResidentInstance {
   runtime: ResidentRoomRuntime
 }
 
+// Fixed MIME→extension map (#111 review): local file extensions are never
+// derived from remote-controlled MIME strings.
+const SURFACE_EXTENSION_BY_MIME: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/webp": "webp",
+}
+
 function optionalMilliseconds(name: string): number | undefined {
   const raw = process.env[name]
   if (raw === undefined || raw.trim() === "") return undefined
@@ -338,7 +346,22 @@ export class AgentDaemon {
       )
       if (read.surface.snapshotId !== current.snapshotId)
         throw new Error("snapshot changed during read; retry")
-      const extension = read.surface.mimeType.split("/")[1] ?? "bin"
+      // Fixed MIME→extension map: never derive a local path component from
+      // remote data. Decoded bytes must be non-empty, within the surface
+      // bound, and EXACTLY metadata.size — otherwise nothing is written.
+      const extension =
+        SURFACE_EXTENSION_BY_MIME[read.surface.mimeType] ?? undefined
+      if (!extension)
+        throw new Error(`Unsupported surface MIME ${read.surface.mimeType}`)
+      const decoded = Buffer.from(read.data, "base64")
+      if (
+        decoded.length === 0 ||
+        decoded.length > 768 * 1024 ||
+        decoded.length !== read.surface.size
+      )
+        throw new Error(
+          "Surface payload failed size validation; no file was written"
+        )
       const workspace =
         instanceIdResolved !== undefined
           ? this.workspaces.get(instanceIdResolved)

--- a/agent-runtime/src/daemon.ts
+++ b/agent-runtime/src/daemon.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdir, readdir, rm } from "node:fs/promises"
+import { chmod, mkdir, readdir, rm, writeFile } from "node:fs/promises"
 import { createServer, type Socket } from "node:net"
 import { join } from "node:path"
 import { randomUUID } from "node:crypto"
@@ -45,6 +45,9 @@ export interface IpcRequest {
     | "collab-response"
     | "collab-result"
     | "attach"
+    | "surface-publish"
+    | "surface-clear"
+    | "surface-read"
   room?: string
   name?: string
   agent?: string
@@ -62,6 +65,7 @@ export interface IpcRequest {
   fileName?: string
   mimeType?: string
   dataBase64?: string
+  sourceParticipantId?: string
 }
 
 export class AgentDaemon {
@@ -296,6 +300,61 @@ export class AgentDaemon {
       }
       return { ok: true, reloaded }
     }
+    // #111 Observable Agent Workspace: publish/clear own surface; read a
+    // peer's CURRENT snapshot (exact snapshotId from roster) into the
+    // instance's Runtime-owned workspace. Handles never cross here.
+    if (
+      request.op === "surface-publish" ||
+      request.op === "surface-clear" ||
+      request.op === "surface-read"
+    ) {
+      const instanceIdResolved = request.instanceId ?? this.singleInstanceId()
+      const runtime = this.resolveRuntime(instanceIdResolved)
+      if (request.op === "surface-publish") {
+        if (!request.mimeType || !request.dataBase64)
+          throw new Error("surface publish requires mimeType and data")
+        return runtime.publishSurface({
+          mimeType: request.mimeType,
+          dataBase64: request.dataBase64,
+        })
+      }
+      if (request.op === "surface-clear") {
+        await runtime.clearSurface()
+        return { ok: true, cleared: true }
+      }
+      const sourceParticipantId = request.sourceParticipantId
+      if (!sourceParticipantId)
+        throw new Error("surface read requires --participant")
+      // Pin the CURRENT snapshotId from roster metadata before bytes move;
+      // a replace between metadata and read fails closed on mismatch.
+      const current = runtime.peerSurface(sourceParticipantId)
+      if (!current)
+        throw new Error(
+          "No workspace snapshot is currently published by that participant"
+        )
+      const read = await runtime.readSurface(
+        sourceParticipantId,
+        current.snapshotId
+      )
+      if (read.surface.snapshotId !== current.snapshotId)
+        throw new Error("snapshot changed during read; retry")
+      const extension = read.surface.mimeType.split("/")[1] ?? "bin"
+      const workspace =
+        instanceIdResolved !== undefined
+          ? this.workspaces.get(instanceIdResolved)
+          : undefined
+      if (!workspace) throw new Error("instance workspace unavailable")
+      const surfacesDir = join(workspace, "surfaces")
+      await mkdir(surfacesDir, { recursive: true, mode: 0o700 })
+      const localPath = join(
+        surfacesDir,
+        `${read.surface.snapshotId}.${extension}`
+      )
+      await writeFile(localPath, Buffer.from(read.data, "base64"), {
+        mode: 0o600,
+      })
+      return { surface: read.surface, localPath }
+    }
     if (request.op === "leave") {
       if (!request.instanceId) throw new Error("leave requires instanceId")
       const instance = this.instances.get(request.instanceId)
@@ -317,6 +376,11 @@ export class AgentDaemon {
       return { state: "stopped" }
     }
     throw new Error("unknown daemon operation")
+  }
+
+  private singleInstanceId(): string | undefined {
+    const all = this.instances.values()
+    return all.length === 1 ? all[0].instanceId : undefined
   }
 
   private resolveRuntime(instanceId?: string): ResidentRoomRuntime {

--- a/agent-runtime/src/free4chat/client.ts
+++ b/agent-runtime/src/free4chat/client.ts
@@ -94,28 +94,6 @@ function asNumber(value: unknown, field: string): number {
   return value
 }
 
-function parseRosterEntry(value: unknown): ParticipantRosterEntry | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null
-  const record = value as Record<string, unknown>
-  const id = typeof record.id === "string" ? record.id : ""
-  if (!id) return null
-  const capabilities =
-    record.capabilities && typeof record.capabilities === "object"
-      ? (record.capabilities as Record<string, unknown>)
-      : undefined
-  const advertised = Array.isArray(capabilities?.advertised)
-    ? capabilities.advertised.filter(
-        (token): token is string => typeof token === "string"
-      )
-    : undefined
-  return {
-    id,
-    name: typeof record.name === "string" ? record.name : "",
-    kind: (record.kind === "agent" ? "agent" : "human") as "agent" | "human",
-    ...(advertised && advertised.length > 0 ? { advertised } : {}),
-  }
-}
-
 export class McpFree4ChatClient implements Free4ChatClient {
   private readonly client = new Client(
     {
@@ -211,7 +189,7 @@ export class McpFree4ChatClient implements Free4ChatClient {
       ...(Array.isArray(result.participants)
         ? {
             participants: result.participants
-              .map(parseRosterEntry)
+              .map(normalizeRosterEntry)
               .filter(
                 (entry): entry is NonNullable<typeof entry> => entry !== null
               ),
@@ -323,7 +301,13 @@ export class McpFree4ChatClient implements Free4ChatClient {
       cursor: asNumber(result.cursor, "cursor"),
       expiresAt: asNumber(result.expiresAt, "expiresAt"),
       ...(Array.isArray(result.participants)
-        ? { participants: result.participants as ParticipantRosterEntry[] }
+        ? {
+            participants: result.participants
+              .map(normalizeRosterEntry)
+              .filter(
+                (entry): entry is NonNullable<typeof entry> => entry !== null
+              ),
+          }
         : {}),
     }
   }
@@ -463,7 +447,13 @@ export class McpFree4ChatClient implements Free4ChatClient {
         dataBase64: payload.dataBase64,
       })
     )
-    return { surface: parseSurface(result.surface) }
+    const surface = parseSurfaceMetadataStrict(result.surface)
+    if (!surface)
+      throw new Free4ChatClientError(
+        "Free4Chat returned an invalid surface payload",
+        "tool_error"
+      )
+    return { surface }
   }
 
   async clearSurface(participantHandle: string): Promise<void> {
@@ -514,24 +504,31 @@ export class McpFree4ChatClient implements Free4ChatClient {
         // Metadata envelope optional; bytes authoritative.
       }
     }
-    if (
-      typeof metadata.snapshotId !== "string" ||
-      typeof metadata.size !== "number"
-    )
+    const strict = parseSurfaceMetadataStrict({
+      kind: "workspace-snapshot",
+      snapshotId: metadata.snapshotId,
+      mimeType: metadata.mimeType ?? mimeType,
+      size: metadata.size,
+      updatedAt: metadata.updatedAt,
+    })
+    if (!strict)
       throw new Free4ChatClientError(
         "Free4Chat returned an invalid surface payload",
         "tool_error"
       )
-    return {
-      surface: {
-        snapshotId: metadata.snapshotId,
-        mimeType: metadata.mimeType ?? mimeType,
-        size: metadata.size,
-        updatedAt:
-          typeof metadata.updatedAt === "number" ? metadata.updatedAt : 0,
-      },
-      data,
-    }
+    // Cross-checks (#111 review): bytes must belong to the EXACT requested
+    // snapshot and match the ImageContent MIME — never near-miss bytes.
+    if (strict.snapshotId !== snapshotId)
+      throw new Free4ChatClientError(
+        "Free4Chat returned a different snapshot than requested",
+        "tool_error"
+      )
+    if (strict.mimeType !== mimeType)
+      throw new Free4ChatClientError(
+        "Free4Chat returned mismatched surface content type",
+        "tool_error"
+      )
+    return { surface: strict, data }
   }
 
   async close(): Promise<void> {
@@ -539,29 +536,76 @@ export class McpFree4ChatClient implements Free4ChatClient {
   }
 }
 
-function parseSurface(raw: unknown): RoomSurfaceMetadataV1 {
-  if (!raw || typeof raw !== "object")
-    throw new Free4ChatClientError(
-      "Free4Chat returned an invalid surface payload",
-      "tool_error"
-    )
+// #111 review: shared STRICT surface-metadata contract. Direct publish/read
+// responses must satisfy every rule (violations become typed errors);
+// roster projections use the same parser but OMIT malformed entries instead.
+
+const SURFACE_UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+export function parseSurfaceMetadataStrict(
+  raw: unknown
+): RoomSurfaceMetadataV1 | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
   const record = raw as Record<string, unknown>
   if (
     record.kind !== "workspace-snapshot" ||
     typeof record.snapshotId !== "string" ||
-    !record.snapshotId ||
-    typeof record.mimeType !== "string" ||
+    !SURFACE_UUID_PATTERN.test(record.snapshotId) ||
+    (record.mimeType !== "image/jpeg" &&
+      record.mimeType !== "image/png" &&
+      record.mimeType !== "image/webp") ||
     typeof record.size !== "number" ||
-    typeof record.updatedAt !== "number"
+    !Number.isSafeInteger(record.size) ||
+    record.size <= 0 ||
+    record.size > 768 * 1024 ||
+    typeof record.updatedAt !== "number" ||
+    !Number.isFinite(record.updatedAt) ||
+    record.updatedAt <= 0
   )
-    throw new Free4ChatClientError(
-      "Free4Chat returned an invalid surface payload",
-      "tool_error"
-    )
+    return null
   return {
     snapshotId: record.snapshotId,
     mimeType: record.mimeType,
     size: record.size,
     updatedAt: record.updatedAt,
+  }
+}
+
+/** Validates one raw roster participant and projects it to the sanitized
+ * Runtime shape. Returns null for entries without a usable id; malformed
+ * surface metadata is omitted rather than rejected (roster tolerance). */
+export function normalizeRosterEntry(
+  raw: unknown
+): ParticipantRosterEntry | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null
+  const record = raw as Record<string, unknown>
+  const id = typeof record.id === "string" ? record.id : ""
+  if (!id) return null
+  const capabilities =
+    record.capabilities && typeof record.capabilities === "object"
+      ? (record.capabilities as Record<string, unknown>)
+      : undefined
+  // Two server projections exist (#111 review): room_info nests tokens under
+  // capabilities.advertised; the compact wait-roster flattens them to a
+  // top-level advertised array. Accept both.
+  const source =
+    record.advertised !== undefined
+      ? record.advertised
+      : Array.isArray(capabilities?.advertised)
+        ? capabilities.advertised
+        : undefined
+  const advertised = Array.isArray(source)
+    ? source.filter((token): token is string => typeof token === "string")
+    : undefined
+  return {
+    id,
+    name: typeof record.name === "string" ? record.name : "",
+    kind: record.kind === "agent" ? "agent" : "human",
+    ...(advertised && advertised.length > 0 ? { advertised } : {}),
+    ...(() => {
+      const surface = parseSurfaceMetadataStrict(record.surface)
+      return surface ? { surface } : {}
+    })(),
   }
 }

--- a/agent-runtime/src/free4chat/client.ts
+++ b/agent-runtime/src/free4chat/client.ts
@@ -9,6 +9,9 @@ import type {
   CollabRequestArgs,
   CollabResultArgs,
   CreateRoomResult,
+  RoomSurfaceMetadataV1,
+  SurfacePublishPayload,
+  SurfaceReadResult,
   Free4ChatClient,
   JoinResult,
   MeetingNotesInfo,
@@ -147,6 +150,9 @@ export class McpFree4ChatClient implements Free4ChatClient {
         "send_collab_response",
         "send_collab_result",
         "send_attachment",
+        "publish_surface",
+        "clear_surface",
+        "read_surface",
       ]
       if (
         required.some((name) => !tools.tools.some((tool) => tool.name === name))
@@ -446,7 +452,116 @@ export class McpFree4ChatClient implements Free4ChatClient {
     }
   }
 
+  async publishSurface(
+    participantHandle: string,
+    payload: SurfacePublishPayload
+  ): Promise<{ surface: RoomSurfaceMetadataV1 }> {
+    const result = asRecord(
+      await this.call("publish_surface", {
+        participantHandle,
+        mimeType: payload.mimeType,
+        dataBase64: payload.dataBase64,
+      })
+    )
+    return { surface: parseSurface(result.surface) }
+  }
+
+  async clearSurface(participantHandle: string): Promise<void> {
+    await this.call("clear_surface", { participantHandle })
+  }
+
+  async readSurface(
+    participantHandle: string,
+    sourceParticipantId: string,
+    snapshotId: string
+  ): Promise<SurfaceReadResult> {
+    let result: CallToolResult
+    try {
+      result = await this.client.callTool({
+        name: "read_surface",
+        arguments: { participantHandle, sourceParticipantId, snapshotId },
+      })
+    } catch (error) {
+      throw new Free4ChatClientError(
+        error instanceof Error ? error.message : "Unable to read surface",
+        "transient"
+      )
+    }
+    if (result.isError === true) decodeToolResult(result)
+    let data: string | undefined
+    let mimeType: string | undefined
+    for (const item of result.content) {
+      if (item.type === "image") {
+        data = item.data
+        mimeType = item.mimeType
+      }
+    }
+    if (!data || !mimeType)
+      throw new Free4ChatClientError(
+        "Free4Chat returned no image content for the surface",
+        "tool_error"
+      )
+    let metadata: Partial<RoomSurfaceMetadataV1> = {}
+    for (const item of result.content) {
+      if (item.type !== "text") continue
+      try {
+        const parsed = JSON.parse(item.text) as {
+          surface?: Record<string, unknown>
+        }
+        if (parsed.surface && typeof parsed.surface === "object")
+          metadata = parsed.surface as Partial<RoomSurfaceMetadataV1>
+      } catch {
+        // Metadata envelope optional; bytes authoritative.
+      }
+    }
+    if (
+      typeof metadata.snapshotId !== "string" ||
+      typeof metadata.size !== "number"
+    )
+      throw new Free4ChatClientError(
+        "Free4Chat returned an invalid surface payload",
+        "tool_error"
+      )
+    return {
+      surface: {
+        snapshotId: metadata.snapshotId,
+        mimeType: metadata.mimeType ?? mimeType,
+        size: metadata.size,
+        updatedAt:
+          typeof metadata.updatedAt === "number" ? metadata.updatedAt : 0,
+      },
+      data,
+    }
+  }
+
   async close(): Promise<void> {
     await this.client.close()
+  }
+}
+
+function parseSurface(raw: unknown): RoomSurfaceMetadataV1 {
+  if (!raw || typeof raw !== "object")
+    throw new Free4ChatClientError(
+      "Free4Chat returned an invalid surface payload",
+      "tool_error"
+    )
+  const record = raw as Record<string, unknown>
+  if (
+    record.kind !== "workspace-snapshot" ||
+    typeof record.snapshotId !== "string" ||
+    !record.snapshotId ||
+    typeof record.mimeType !== "string" ||
+    typeof record.size !== "number" ||
+    typeof record.updatedAt !== "number"
+  )
+    throw new Free4ChatClientError(
+      "Free4Chat returned an invalid surface payload",
+      "tool_error"
+    )
+  return {
+    snapshotId: record.snapshotId,
+    mimeType: record.mimeType,
+    size: record.size,
+    updatedAt: record.updatedAt,
   }
 }

--- a/agent-runtime/src/free4chat/modernClient.ts
+++ b/agent-runtime/src/free4chat/modernClient.ts
@@ -7,6 +7,9 @@ import type {
   CreateRoomResult,
   Free4ChatClient,
   ParticipantRosterEntry,
+  RoomSurfaceMetadataV1,
+  SurfacePublishPayload,
+  SurfaceReadResult,
   UploadedAttachment,
 } from "../types.js"
 import type { JoinResult, RoomInfo, WaitResult } from "../types.js"
@@ -37,6 +40,9 @@ const REQUIRED_TOOLS = [
   "send_collab_response",
   "send_collab_result",
   "send_attachment",
+  "publish_surface",
+  "clear_surface",
+  "read_surface",
 ] as const
 
 function envelopeMeta(): Record<string, unknown> {
@@ -80,6 +86,34 @@ function toToolErrorCode(error: string | undefined): Free4ChatErrorCode {
     return "invalid_participant_handle"
   if (error === "room_expired") return "room_expired"
   return "tool_error"
+}
+
+/** Strictly validates a server-provided surface metadata object (#111). */
+function parseSurfaceMetadata(raw: unknown): RoomSurfaceMetadataV1 {
+  if (!raw || typeof raw !== "object")
+    throw new Free4ChatClientError(
+      "Free4Chat returned an invalid surface payload",
+      "tool_error"
+    )
+  const record = raw as Record<string, unknown>
+  if (
+    record.kind !== "workspace-snapshot" ||
+    typeof record.snapshotId !== "string" ||
+    !record.snapshotId ||
+    typeof record.mimeType !== "string" ||
+    typeof record.size !== "number" ||
+    typeof record.updatedAt !== "number"
+  )
+    throw new Free4ChatClientError(
+      "Free4Chat returned an invalid surface payload",
+      "tool_error"
+    )
+  return {
+    snapshotId: record.snapshotId,
+    mimeType: record.mimeType,
+    size: record.size,
+    updatedAt: record.updatedAt,
+  }
 }
 
 /** Projects raw room-info participant records into the sanitized roster
@@ -563,6 +597,89 @@ export class ModernMcpFree4ChatClient implements Free4ChatClient {
       mimeType: String(attachment.mimeType ?? file.mimeType),
       size: asNumber(attachment.size, "size"),
       sequence: asNumber(attachment.sequence, "sequence"),
+    }
+  }
+
+  async publishSurface(
+    participantHandle: string,
+    payload: SurfacePublishPayload
+  ): Promise<{ surface: RoomSurfaceMetadataV1 }> {
+    const result = asRecord(
+      await this.callTool("publish_surface", {
+        participantHandle,
+        mimeType: payload.mimeType,
+        dataBase64: payload.dataBase64,
+      })
+    )
+    return { surface: parseSurfaceMetadata(result.surface) }
+  }
+
+  async clearSurface(participantHandle: string): Promise<void> {
+    await this.callTool("clear_surface", { participantHandle })
+  }
+
+  async readSurface(
+    participantHandle: string,
+    sourceParticipantId: string,
+    snapshotId: string
+  ): Promise<SurfaceReadResult> {
+    const rawResult = await this.post(
+      this.envelope("tools/call", {
+        name: "read_surface",
+        arguments: { participantHandle, sourceParticipantId, snapshotId },
+      }),
+      { "Mcp-Method": "tools/call", "Mcp-Name": "read_surface" }
+    )
+    const result = asRecord(rawResult)
+    if (result.isError === true) decodeTextPayload(rawResult)
+    const content = Array.isArray(result.content) ? result.content : []
+    let data: string | undefined
+    let mimeType: string | undefined
+    for (const item of content) {
+      const block = asRecord(item)
+      if (block.type === "image") {
+        data = String(block.data ?? "")
+        mimeType = String(block.mimeType ?? "")
+      }
+    }
+    if (data === undefined || !mimeType)
+      throw new Free4ChatClientError(
+        "Free4Chat returned no image content for the surface",
+        "tool_error"
+      )
+    // Metadata rides the trailing text envelope; fall back to the image
+    // block's own MIME when absent.
+    let metadata: Partial<RoomSurfaceMetadataV1> = {}
+    for (const item of content) {
+      const block = asRecord(item)
+      if (block.type !== "text") continue
+      try {
+        const parsed = JSON.parse(String(block.text ?? "")) as {
+          surface?: Record<string, unknown>
+        }
+        if (parsed.surface && typeof parsed.surface === "object")
+          metadata = parsed.surface as Partial<RoomSurfaceMetadataV1>
+      } catch {
+        // Metadata envelope is optional; bytes are authoritative.
+      }
+    }
+    if (
+      typeof metadata.snapshotId !== "string" ||
+      typeof metadata.size !== "number"
+    )
+      throw new Free4ChatClientError(
+        "Free4Chat returned an invalid surface payload",
+        "tool_error"
+      )
+    return {
+      surface: {
+        snapshotId: metadata.snapshotId,
+        mimeType: metadata.mimeType ?? mimeType,
+        size: metadata.size,
+        updatedAt:
+          typeof metadata.updatedAt === "number" ? metadata.updatedAt : 0,
+      },
+      data,
     }
   }
 

--- a/agent-runtime/src/free4chat/modernClient.ts
+++ b/agent-runtime/src/free4chat/modernClient.ts
@@ -1,4 +1,8 @@
-import { Free4ChatClientError } from "./client.js"
+import {
+  Free4ChatClientError,
+  normalizeRosterEntry,
+  parseSurfaceMetadataStrict,
+} from "./client.js"
 import type { Free4ChatErrorCode } from "./client.js"
 import type {
   AttachmentUpload,
@@ -88,59 +92,12 @@ function toToolErrorCode(error: string | undefined): Free4ChatErrorCode {
   return "tool_error"
 }
 
-/** Strictly validates a server-provided surface metadata object (#111). */
-function parseSurfaceMetadata(raw: unknown): RoomSurfaceMetadataV1 {
-  if (!raw || typeof raw !== "object")
-    throw new Free4ChatClientError(
-      "Free4Chat returned an invalid surface payload",
-      "tool_error"
-    )
-  const record = raw as Record<string, unknown>
-  if (
-    record.kind !== "workspace-snapshot" ||
-    typeof record.snapshotId !== "string" ||
-    !record.snapshotId ||
-    typeof record.mimeType !== "string" ||
-    typeof record.size !== "number" ||
-    typeof record.updatedAt !== "number"
-  )
-    throw new Free4ChatClientError(
-      "Free4Chat returned an invalid surface payload",
-      "tool_error"
-    )
-  return {
-    snapshotId: record.snapshotId,
-    mimeType: record.mimeType,
-    size: record.size,
-    updatedAt: record.updatedAt,
-  }
-}
-
 /** Projects raw room-info participant records into the sanitized roster
  * shape: identity, kind, and self-advertised capability tokens only. */
 function parseRoster(raw: unknown[]): ParticipantRosterEntry[] {
   return raw
-    .map((item) => (item !== null && typeof item === "object" ? item : {}))
-    .map((record) => {
-      const participant = record as Record<string, unknown>
-      const capabilities =
-        participant.capabilities && typeof participant.capabilities === "object"
-          ? (participant.capabilities as Record<string, unknown>)
-          : undefined
-      const advertised = Array.isArray(capabilities?.advertised)
-        ? capabilities.advertised.filter(
-            (token): token is string => typeof token === "string"
-          )
-        : undefined
-      return {
-        id: String(participant.id ?? ""),
-        name: String(participant.name ?? ""),
-        kind: (participant.kind === "agent" ? "agent" : "human") as
-          "agent" | "human",
-        ...(advertised && advertised.length > 0 ? { advertised } : {}),
-      }
-    })
-    .filter((entry) => entry.id.length > 0)
+    .map(normalizeRosterEntry)
+    .filter((entry): entry is ParticipantRosterEntry => entry !== null)
 }
 
 function decodeTextPayload(raw: unknown): unknown {
@@ -435,7 +392,11 @@ export class ModernMcpFree4ChatClient implements Free4ChatClient {
       expiresAt: asNumber(result.expiresAt, "expiresAt"),
       ...(Array.isArray(result.participants)
         ? {
-            participants: result.participants as ParticipantRosterEntry[],
+            participants: result.participants
+              .map(normalizeRosterEntry)
+              .filter(
+                (entry): entry is ParticipantRosterEntry => entry !== null
+              ),
           }
         : {}),
     }
@@ -611,7 +572,13 @@ export class ModernMcpFree4ChatClient implements Free4ChatClient {
         dataBase64: payload.dataBase64,
       })
     )
-    return { surface: parseSurfaceMetadata(result.surface) }
+    const surface = parseSurfaceMetadataStrict(result.surface)
+    if (!surface)
+      throw new Free4ChatClientError(
+        "Free4Chat returned an invalid surface payload",
+        "tool_error"
+      )
+    return { surface }
   }
 
   async clearSurface(participantHandle: string): Promise<void> {
@@ -663,24 +630,31 @@ export class ModernMcpFree4ChatClient implements Free4ChatClient {
         // Metadata envelope is optional; bytes are authoritative.
       }
     }
-    if (
-      typeof metadata.snapshotId !== "string" ||
-      typeof metadata.size !== "number"
-    )
+    const strict = parseSurfaceMetadataStrict({
+      kind: "workspace-snapshot",
+      snapshotId: metadata.snapshotId,
+      mimeType: metadata.mimeType ?? mimeType,
+      size: metadata.size,
+      updatedAt: metadata.updatedAt,
+    })
+    if (!strict)
       throw new Free4ChatClientError(
         "Free4Chat returned an invalid surface payload",
         "tool_error"
       )
-    return {
-      surface: {
-        snapshotId: metadata.snapshotId,
-        mimeType: metadata.mimeType ?? mimeType,
-        size: metadata.size,
-        updatedAt:
-          typeof metadata.updatedAt === "number" ? metadata.updatedAt : 0,
-      },
-      data,
-    }
+    // Cross-checks (#111 review): bytes must belong to the EXACT requested
+    // snapshot and match the ImageContent MIME — never near-miss bytes.
+    if (strict.snapshotId !== snapshotId)
+      throw new Free4ChatClientError(
+        "Free4Chat returned a different snapshot than requested",
+        "tool_error"
+      )
+    if (strict.mimeType !== mimeType)
+      throw new Free4ChatClientError(
+        "Free4Chat returned mismatched surface content type",
+        "tool_error"
+      )
+    return { surface: strict, data }
   }
 
   async close(): Promise<void> {

--- a/agent-runtime/src/types.ts
+++ b/agent-runtime/src/types.ts
@@ -71,6 +71,17 @@ export interface ParticipantRosterEntry {
   name: string
   kind: "human" | "agent"
   advertised?: string[]
+  /** #111 sanitized workspace-snapshot metadata for this agent, when one is
+   * currently published. Metadata only — never bytes or capture sources. */
+  surface?: RoomSurfaceMetadataV1
+}
+
+/** #111 v1 workspace-snapshot metadata (sanitized projection). */
+export interface RoomSurfaceMetadataV1 {
+  snapshotId: string
+  mimeType: string
+  size: number
+  updatedAt: number
 }
 
 export interface RoomSelfContext {
@@ -212,6 +223,17 @@ export interface AttachmentUpload {
 
 export type UploadedAttachment = RoomAttachmentMetadata & { sequence: number }
 
+export interface SurfacePublishPayload {
+  mimeType: string
+  dataBase64: string
+}
+
+export interface SurfaceReadResult {
+  surface: RoomSurfaceMetadataV1
+  /** Base64 image bytes, valid only for the exact requested snapshotId. */
+  data: string
+}
+
 export interface Free4ChatClient {
   connect(): Promise<void>
   listTools(): Promise<string[]>
@@ -259,6 +281,17 @@ export interface Free4ChatClient {
     participantHandle: string,
     file: AttachmentUpload
   ): Promise<UploadedAttachment>
+  /** #111: publish/replace this Agent's single workspace snapshot. */
+  publishSurface(
+    participantHandle: string,
+    payload: SurfacePublishPayload
+  ): Promise<{ surface: RoomSurfaceMetadataV1 }>
+  clearSurface(participantHandle: string): Promise<void>
+  readSurface(
+    participantHandle: string,
+    sourceParticipantId: string,
+    snapshotId: string
+  ): Promise<SurfaceReadResult>
   leaveRoom(participantHandle: string): Promise<void>
   close(): Promise<void>
 }

--- a/agent-runtime/test/collab.test.ts
+++ b/agent-runtime/test/collab.test.ts
@@ -533,6 +533,42 @@ class FakeRoomServer {
     }
   >()
 
+  surfaces = new Map<
+    string,
+    { snapshotId: string; mimeType: string; size: number; updatedAt: number }
+  >()
+  private surfaceCounter = 0
+  // Set when a surface publish/clear happens; proves no event/wake occurs.
+  surfaceEventsAppended = 0
+
+  publishSurface(
+    participantId: string,
+    payload: { mimeType: string; dataBase64: string }
+  ) {
+    if (!this.participants.has(participantId)) throw new Error("unauthorized")
+    this.surfaceCounter += 1
+    const surface = {
+      kind: "workspace-snapshot" as const,
+      snapshotId: `snap-${this.surfaceCounter}`,
+      mimeType: payload.mimeType,
+      size: payload.dataBase64.length,
+      updatedAt: Date.now(),
+    }
+    this.surfaces.set(participantId, surface)
+    return surface
+  }
+
+  clearSurface(participantId: string): void {
+    this.surfaces.delete(participantId)
+  }
+
+  readSurface(participantId: string, snapshotId: string) {
+    const surface = this.surfaces.get(participantId)
+    if (!surface || surface.snapshotId !== snapshotId)
+      throw new Error(surface ? "surface_changed" : "surface_not_found")
+    return surface
+  }
+
   join(participantId: string, name: string, capabilities?: string[]): number {
     this.participants.set(participantId, {
       name,
@@ -579,6 +615,19 @@ class FakeRoomServer {
       kind: info.kind,
       ...(info.capabilities && info.capabilities.length > 0
         ? { advertised: info.capabilities }
+        : {}),
+      ...(info.kind === "agent" && this.surfaces.has(id)
+        ? {
+            surface: (() => {
+              const s = this.surfaces.get(id)!
+              return {
+                snapshotId: s.snapshotId,
+                mimeType: s.mimeType,
+                size: s.size,
+                updatedAt: s.updatedAt,
+              }
+            })(),
+          }
         : {}),
     }))
   }
@@ -820,6 +869,19 @@ function clientFor(
     async uploadAttachment(_handle, file) {
       const uploaded = server.uploadAttachment(participantId, file)
       return { ...uploaded }
+    },
+    async publishSurface(_handle, payload) {
+      return { surface: server.publishSurface(participantId, payload) }
+    },
+    async clearSurface(_handle) {
+      void _handle
+      server.clearSurface(participantId)
+    },
+    async readSurface(_handle, sourceParticipantId, snapshotId) {
+      return {
+        surface: server.readSurface(sourceParticipantId, snapshotId),
+        data: "QUJD",
+      }
     },
     async leaveRoom() {},
     async close() {},
@@ -1121,3 +1183,77 @@ test("agent-created room flow: A creates -> B joins invite.roomId -> roster disc
   )
   assert.ok(bRequestTurn)
 })
+
+test("workspace surface: publish/clear/read round-trip with NO harness wake and roster metadata visible", async () => {
+  const server = new FakeRoomServer()
+  const turnsA: HarnessTurnInput[] = []
+  const runtimeA = new ResidentRoomRuntime({
+    instanceId: "inst-surface-a",
+    name: "Agent A",
+    client: clientFor(server, "agent-a"),
+    adapter: fakeAdapter(turnsA),
+    capabilities: ["code.edit"],
+  })
+  let bSurfaceView: HarnessTurnInput["room"]["participants"] | undefined
+  const runtimeB = new ResidentRoomRuntime({
+    instanceId: "inst-surface-b",
+    name: "Agent B",
+    client: clientFor(server, "agent-b"),
+    adapter: {
+      name: "hermes",
+      async ensureSession() {},
+      async runTurn(input) {
+        bSurfaceView = input.room.participants
+        return { text: "noted" }
+      },
+      async close() {},
+    },
+    capabilities: ["browser.control"],
+  })
+  try {
+    await runtimeB.start()
+    await settle(() => server.participants.has("agent-b"))
+    await runtimeB.stop()
+
+    await runtimeA.start()
+    const published = await runtimeA.publishSurface({
+      mimeType: "image/png",
+      dataBase64: "AAAA",
+    })
+    assert.match(published.surface.snapshotId, /^snap-\d+$/)
+
+    // No message/sequence/wake: A's wait loop must not deliver any event and
+    // no harness turn may run because of the publish.
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    assert.equal(turnsA.length, 0)
+    assert.equal(server.messages.length, 0)
+    assert.equal(server.lastSequence, 0)
+
+    // Metadata reaches peers through the roster projection.
+    const roster = server.roster()
+    expectLike(
+      roster.find((p) => p.id === "agent-a")?.surface?.snapshotId,
+      /^snap-\d+$/
+    )
+
+    // Peer-style exact-bytes read with the pinned snapshotId; stale id fails.
+    const snapshotId = published.surface.snapshotId
+    await runtimeA.readSurface("agent-a", snapshotId)
+    await assert.rejects(
+      () =>
+        clientFor(server, "agent-a").readSurface("x", "agent-b", "stale-id"),
+      /surface_changed|surface_not_found/
+    )
+
+    // Clear removes everything; capacity slot released (implicit).
+    await runtimeA.clearSurface()
+    assert.equal(server.surfaces.has("agent-a"), false)
+    void bSurfaceView
+  } finally {
+    await runtimeA.stop()
+  }
+})
+
+function expectLike(value: unknown, pattern: RegExp): void {
+  assert.equal(typeof value === "string" && pattern.test(value), true)
+}

--- a/agent-runtime/test/collab.test.ts
+++ b/agent-runtime/test/collab.test.ts
@@ -540,6 +540,15 @@ class FakeRoomServer {
   private surfaceCounter = 0
   // Set when a surface publish/clear happens; proves no event/wake occurs.
   surfaceEventsAppended = 0
+  // #111 review: participants whose OLD-surface chunk deletion should throw
+  // during their next publish (mirroring a DO storage hiccup), plus the
+  // record of those attempted deletions.
+  failOldDeleteFor = new Set<string>()
+  oldDeleteAttempts: Array<{
+    participantId: string
+    snapshotId: string
+    threw: boolean
+  }> = []
 
   publishSurface(
     participantId: string,
@@ -553,6 +562,23 @@ class FakeRoomServer {
       mimeType: payload.mimeType,
       size: payload.dataBase64.length,
       updatedAt: Date.now(),
+    }
+    const previousSnapshot = this.surfaces.get(participantId)
+    if (previousSnapshot) {
+      const attempt = {
+        participantId,
+        snapshotId: previousSnapshot.snapshotId,
+        threw: false,
+      }
+      try {
+        if (this.failOldDeleteFor.has(participantId))
+          throw new Error("storage hiccup deleting old chunks")
+      } catch {
+        // Swallowed exactly like the DO's best-effort cleanup.
+        attempt.threw = true
+      } finally {
+        this.oldDeleteAttempts.push(attempt)
+      }
     }
     this.surfaces.set(participantId, surface)
     return surface

--- a/agent-runtime/test/modernClient.test.ts
+++ b/agent-runtime/test/modernClient.test.ts
@@ -378,7 +378,7 @@ test("surface tools forward bounded envelopes and validate payloads strictly", a
   let serveSurfacePublish: Record<string, unknown> = {
     surface: {
       kind: "workspace-snapshot",
-      snapshotId: "snap-9",
+      snapshotId: "123e4567-e89b-42d3-a456-426614174000",
       mimeType: "image/png",
       size: 4,
       updatedAt: 77,
@@ -440,7 +440,10 @@ test("surface tools forward bounded envelopes and validate payloads strictly", a
       mimeType: "image/png",
       dataBase64: "AAAA",
     })
-    assert.equal(published.surface.snapshotId, "snap-9")
+    assert.equal(
+      published.surface.snapshotId,
+      "123e4567-e89b-42d3-a456-426614174000"
+    )
     assert.deepEqual(calls.find((c) => c.name === "publish_surface")?.args, {
       participantHandle: "handle",
       mimeType: "image/png",
@@ -458,7 +461,7 @@ test("surface tools forward bounded envelopes and validate payloads strictly", a
           text: JSON.stringify({
             surface: {
               kind: "workspace-snapshot",
-              snapshotId: "snap-8",
+              snapshotId: "123e4567-e89b-42d3-a456-426614174000",
               mimeType: "image/png",
               size: 3,
               updatedAt: 55,
@@ -467,9 +470,13 @@ test("surface tools forward bounded envelopes and validate payloads strictly", a
         },
       ],
     }
-    const read = await client.readSurface("handle", "agent-b", "snap-8")
+    const read = await client.readSurface(
+      "handle",
+      "agent-b",
+      "123e4567-e89b-42d3-a456-426614174000"
+    )
     assert.deepEqual(read.surface, {
-      snapshotId: "snap-8",
+      snapshotId: "123e4567-e89b-42d3-a456-426614174000",
       mimeType: "image/png",
       size: 3,
       updatedAt: 55,
@@ -498,3 +505,215 @@ test("surface tools forward bounded envelopes and validate payloads strictly", a
     globalThis.fetch = originalFetch
   }
 })
+
+// Server-shaped read_surface envelope, mirroring app imageToolResult exactly:
+// [ImageContent block, text block JSON.stringify({ surface })].
+function surfaceReadEnvelope(
+  snapshotId: string,
+  mimeType: string,
+  size: number,
+  updatedAt: number,
+  data = "QUJD"
+): Record<string, unknown> {
+  return {
+    content: [
+      { type: "image", data, mimeType },
+      {
+        type: "text",
+        text: JSON.stringify({
+          surface: {
+            kind: "workspace-snapshot",
+            snapshotId,
+            mimeType,
+            size,
+            updatedAt,
+          },
+        }),
+      },
+    ],
+  }
+}
+
+const VALID_SURFACE = {
+  kind: "workspace-snapshot",
+  snapshotId: "123e4567-e89b-42d3-a456-426614174000",
+  mimeType: "image/png" as const,
+  size: 2048,
+  updatedAt: 42,
+}
+
+test("roster discovery validates surfaces: valid kept via room_info and wait_for_events; malformed omitted", async () => {
+  const originalFetch = globalThis.fetch
+  let mode: "room_info" | "wait_for_events" = "room_info"
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init?.body)) as {
+      params?: { name?: string; arguments?: Record<string, unknown> }
+    }
+    if (body.params?.name === mode) {
+      return mcpEnvelope({
+        ...(mode === "room_info"
+          ? { exists: true }
+          : { events: [], cursor: 1, expiresAt: 9 }),
+        participants: [
+          {
+            id: "agent-good",
+            name: "Good",
+            kind: "agent",
+            surface: VALID_SURFACE,
+          },
+          {
+            id: "agent-bad",
+            name: "Bad",
+            kind: "agent",
+            surface: { ...VALID_SURFACE, snapshotId: "not-a-uuid" },
+          },
+          { id: "human-1", name: "Human", kind: "human" },
+        ],
+      })
+    }
+    return mcpEnvelope({})
+  }
+
+  try {
+    const client = new ModernMcpFree4ChatClient("https://example.test/mcp")
+    const info = await client.roomInfo("room")
+    // Entries stay (ids are usable); only the MALFORMED surface is omitted.
+    assert.equal(info.participants?.length, 3)
+    assert.equal(
+      info.participants?.find((p) => p.id === "agent-good")?.surface
+        ?.snapshotId,
+      VALID_SURFACE.snapshotId
+    )
+    assert.equal(
+      info.participants?.find((p) => p.id === "agent-bad")?.surface,
+      undefined
+    )
+
+    mode = "wait_for_events"
+    const wait = await client.waitForEvents("handle", 0, 0)
+    assert.equal(wait.participants?.length, 3)
+    assert.equal(
+      wait.participants?.find((p) => p.id === "agent-good")?.surface
+        ?.snapshotId,
+      VALID_SURFACE.snapshotId
+    )
+    assert.equal(
+      wait.participants?.find((p) => p.id === "agent-bad")?.surface,
+      undefined
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("publish_surface enforces the strict metadata contract", async () => {
+  const originalFetch = globalThis.fetch
+  let serve: unknown = {
+    surface: VALID_SURFACE,
+  }
+  globalThis.fetch = async () =>
+    Response.json({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { content: [{ type: "text", text: JSON.stringify(serve) }] },
+    })
+
+  try {
+    const client = new ModernMcpFree4ChatClient("https://example.test/mcp")
+    const ok = await client.publishSurface("handle", {
+      mimeType: "image/webp",
+      dataBase64: "AA",
+    })
+    assert.equal(ok.surface.snapshotId, VALID_SURFACE.snapshotId)
+
+    for (const broken of [
+      { ...VALID_SURFACE, snapshotId: "nope" },
+      { ...VALID_SURFACE, mimeType: "image/gif" },
+      { ...VALID_SURFACE, size: 768 * 1024 + 1 },
+      { ...VALID_SURFACE, updatedAt: 0 },
+      undefined,
+    ]) {
+      serve = broken === undefined ? {} : { surface: broken }
+      await assert.rejects(
+        () =>
+          client.publishSurface("handle", {
+            mimeType: "image/png",
+            dataBase64: "AA",
+          }),
+        (error: unknown) =>
+          error instanceof Free4ChatClientError && error.code === "tool_error"
+      )
+    }
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("read_surface parses the real server envelope and rejects mismatches", async () => {
+  const originalFetch = globalThis.fetch
+  let serve: unknown = surfaceReadEnvelope(
+    "123e4567-e89b-42d3-a456-426614174000",
+    "image/png",
+    3,
+    77
+  )
+  globalThis.fetch = async () =>
+    Response.json({ jsonrpc: "2.0", id: 1, result: serve })
+
+  try {
+    const client = new ModernMcpFree4ChatClient("https://example.test/mcp")
+    const requestedId = "123e4567-e89b-42d3-a456-426614174000"
+    const read = await client.readSurface("handle", "agent-b", requestedId)
+    assert.equal(read.surface.snapshotId, requestedId)
+    assert.equal(read.data, "QUJD")
+
+    // Different snapshot than requested → typed error (never near-miss bytes).
+    serve = surfaceReadEnvelope(
+      "aaaaaaaa-bbbb-4ccc-addd-eeeeeeeeeeee",
+      "image/png",
+      3,
+      78
+    )
+    await assert.rejects(
+      () => client.readSurface("handle", "agent-b", requestedId),
+      /different snapshot/
+    )
+
+    // MIME mismatch between metadata and ImageContent → typed error.
+    serve = {
+      content: [
+        { type: "image", data: "QUJD", mimeType: "image/png" },
+        {
+          type: "text",
+          text: JSON.stringify({
+            surface: { ...VALID_SURFACE, mimeType: "image/jpeg" },
+          }),
+        },
+      ],
+    }
+    await assert.rejects(
+      () => client.readSurface("handle", "agent-b", requestedId),
+      /mismatched surface content type/
+    )
+
+    // Malformed metadata (bad uuid/size/mime) inside the envelope → typed error.
+    for (const broken of [
+      surfaceReadEnvelope("bad-id", "image/png", 3, 80),
+      surfaceReadEnvelope(requestedId, "image/gif", 3, 81),
+      surfaceReadEnvelope(requestedId, "image/png", -1, 82),
+    ]) {
+      serve = broken
+      await assert.rejects(
+        () => client.readSurface("handle", "agent-b", requestedId),
+        (error: unknown) =>
+          error instanceof Free4ChatClientError && error.code === "tool_error"
+      )
+    }
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+function expectLike(condition: unknown): void {
+  assert.equal(Boolean(condition), true)
+}

--- a/agent-runtime/test/modernClient.test.ts
+++ b/agent-runtime/test/modernClient.test.ts
@@ -371,3 +371,130 @@ test("collab tools forward boring explicit envelopes and surface server errors",
     globalThis.fetch = originalFetch
   }
 })
+
+test("surface tools forward bounded envelopes and validate payloads strictly", async () => {
+  const originalFetch = globalThis.fetch
+  const calls: Array<{ name?: string; args?: Record<string, unknown> }> = []
+  let serveSurfacePublish: Record<string, unknown> = {
+    surface: {
+      kind: "workspace-snapshot",
+      snapshotId: "snap-9",
+      mimeType: "image/png",
+      size: 4,
+      updatedAt: 77,
+    },
+  }
+  let serveRead: Record<string, unknown> | undefined
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init?.body)) as {
+      params?: { name?: string; arguments?: Record<string, unknown> }
+    }
+    calls.push({ name: body.params?.name, args: body.params?.arguments })
+    if (body.params?.name === "publish_surface") {
+      if (serveSurfacePublish.__invalid)
+        return Response.json({
+          jsonrpc: "2.0",
+          id: 1,
+          result: {
+            content: [
+              { type: "text", text: JSON.stringify(serveSurfacePublish) },
+            ],
+          },
+        })
+      return Response.json({
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          content: [
+            { type: "text", text: JSON.stringify(serveSurfacePublish) },
+          ],
+        },
+      })
+    }
+    if (body.params?.name === "clear_surface")
+      return Response.json({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { content: [{ type: "text", text: "{}" }] },
+      })
+    if (body.params?.name === "read_surface") {
+      if (!serveRead)
+        return Response.json({
+          jsonrpc: "2.0",
+          id: 1,
+          result: { content: [{ type: "text", text: "{}" }] },
+        })
+      return Response.json({ jsonrpc: "2.0", id: 1, result: serveRead })
+    }
+    return Response.json({
+      jsonrpc: "2.0",
+      id: 1,
+      result: { content: [{ type: "text", text: "{}" }] },
+    })
+  }
+
+  try {
+    const client = new ModernMcpFree4ChatClient("https://example.test/mcp")
+
+    const published = await client.publishSurface("handle", {
+      mimeType: "image/png",
+      dataBase64: "AAAA",
+    })
+    assert.equal(published.surface.snapshotId, "snap-9")
+    assert.deepEqual(calls.find((c) => c.name === "publish_surface")?.args, {
+      participantHandle: "handle",
+      mimeType: "image/png",
+      dataBase64: "AAAA",
+    })
+
+    await client.clearSurface("handle")
+    assert.ok(calls.some((c) => c.name === "clear_surface"))
+
+    serveRead = {
+      content: [
+        { type: "image", data: "QUJD", mimeType: "image/png" },
+        {
+          type: "text",
+          text: JSON.stringify({
+            surface: {
+              kind: "workspace-snapshot",
+              snapshotId: "snap-8",
+              mimeType: "image/png",
+              size: 3,
+              updatedAt: 55,
+            },
+          }),
+        },
+      ],
+    }
+    const read = await client.readSurface("handle", "agent-b", "snap-8")
+    assert.deepEqual(read.surface, {
+      snapshotId: "snap-8",
+      mimeType: "image/png",
+      size: 3,
+      updatedAt: 55,
+    })
+    assert.equal(read.data, "QUJD")
+
+    // Malformed publish payload → typed client error.
+    serveSurfacePublish = { __invalid: true, surface: { kind: "other" } }
+    await assert.rejects(
+      () =>
+        client.publishSurface("handle", {
+          mimeType: "image/png",
+          dataBase64: "AA",
+        }),
+      (error: unknown) =>
+        error instanceof Free4ChatClientError && error.code === "tool_error"
+    )
+    // Missing image content in read → typed client error.
+    serveRead = { content: [{ type: "text", text: "{}" }] }
+    await assert.rejects(
+      () => client.readSurface("handle", "agent-b", "snap-8"),
+      (error: unknown) =>
+        error instanceof Free4ChatClientError && error.code === "tool_error"
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})

--- a/agent-runtime/test/modernClient.test.ts
+++ b/agent-runtime/test/modernClient.test.ts
@@ -713,7 +713,3 @@ test("read_surface parses the real server envelope and rejects mismatches", asyn
     globalThis.fetch = originalFetch
   }
 })
-
-function expectLike(condition: unknown): void {
-  assert.equal(Boolean(condition), true)
-}

--- a/agent-runtime/test/pionProvision.test.ts
+++ b/agent-runtime/test/pionProvision.test.ts
@@ -10,7 +10,7 @@ import {
   PionProvisionError,
 } from "../src/media/pionProvision.js"
 
-const VERSION = "0.3.0"
+const VERSION = "0.4.0"
 
 test("detectPionPlatform maps darwin/linux arm64/x64 and rejects others", () => {
   assert.deepEqual(detectPionPlatform("darwin", "arm64"), {

--- a/agent-runtime/test/productization.test.ts
+++ b/agent-runtime/test/productization.test.ts
@@ -41,7 +41,7 @@ test("bootstrap command uses the official pinned package and argv boundaries", (
   assert.equal(invocation.command, "npx")
   assert.deepEqual(invocation.args, [
     "-y",
-    "@i365dev/free4chat-agent@0.3.0",
+    "@i365dev/free4chat-agent@0.4.0",
     "join",
     "--room",
     "room\nwith `quotes`",
@@ -100,7 +100,7 @@ test("agent protocol uses the pinned doctor fallback for npx bootstrap", async (
     new URL("../../app/public/agent.md", import.meta.url),
     "utf8"
   )
-  assert.match(protocol, /npx -y @i365dev\/free4chat-agent@0\.3\.0 doctor/)
+  assert.match(protocol, /npx -y @i365dev\/free4chat-agent@0\.4\.0 doctor/)
   assert.match(protocol, /When the `free4chat-agent` CLI is already installed/)
 })
 

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -7,7 +7,7 @@ Streamable HTTP MCP:
 MCP endpoint: https://www.free4.chat/mcp
 ```
 
-The twelve tools are:
+The fifteen tools are:
 
 - `room_info(roomId)` — inspect connected participants and their advertised capability tokens.
 - `join_room(roomId, name, capabilities?)` — join as a text-only Agent and receive a private participant handle. `capabilities` is an optional list of at most 8 short lowercase namespaced tokens (e.g. `code.edit`, `shell`, `browser.authenticated`) describing what you can honestly do for THIS room.
@@ -19,6 +19,9 @@ The twelve tools are:
 - `send_collab_response(participantHandle, requestId, decision, summary?)` — answer a request addressed to you with accepted or declined.
 - `send_collab_result(participantHandle, requestId, status, summary, details?, attachmentIds?)` — return the terminal completed/failed outcome correlated by requestId.
 - `send_attachment(participantHandle, fileName, mimeType, dataBase64)` — upload one bounded ephemeral file (image jpeg/png/webp or text-like plain/markdown/csv/json/yaml, ≤768KB) into the room so others can read it via `read_attachment`.
+- `publish_surface(participantHandle, mimeType, dataBase64)` — publish/replace your single latest workspace snapshot image (#111; jpeg/png/webp ≤768KB). **Participant-controlled observation — not live remote desktop, not remote control, never automatic capture.** You decide when and what to publish; the previous snapshot is destroyed on replace.
+- `clear_surface(participantHandle)` — remove your published workspace snapshot immediately; no history retained.
+- `read_surface(participantHandle, sourceParticipantId, snapshotId)` — read another CURRENT participant's workspace snapshot on demand with the exact current snapshotId from roster metadata; stale ids return surface_changed. Reading is observation only and grants no authority over the source participant.
 - `read_attachment(participantHandle, attachmentId)` — read an ephemeral room attachment: images come back as MCP ImageContent; text-like files come back with decoded UTF-8 `text`.
 - `leave_room(participantHandle)` — leave and invalidate the handle.
 
@@ -142,7 +145,7 @@ from the repository, configure MCP/ACP, or start a daemon manually.
 4. Otherwise, run the bounded official package command:
 
    ```text
-   npx -y @i365dev/free4chat-agent@0.3.0 join --room <room-id> --agent <harness> --name <name>
+   npx -y @i365dev/free4chat-agent@0.4.0 join --room <room-id> --agent <harness> --name <name>
    ```
 
 The package command is the only automatic installation allowed by this
@@ -160,7 +163,7 @@ When the runtime was started through `npx`, use the same pinned package for the
 fallback diagnostic:
 
 ```text
-npx -y @i365dev/free4chat-agent@0.3.0 doctor
+npx -y @i365dev/free4chat-agent@0.4.0 doctor
 ```
 
 ### Readiness and self-service setup

--- a/app/src/common/types.tsx
+++ b/app/src/common/types.tsx
@@ -1,4 +1,4 @@
-import type { CollabEvent } from "../room/types"
+import type { CollabEvent, RoomSurfaceV1 } from "../room/types"
 
 export interface UserInfo {
   name: string
@@ -11,6 +11,7 @@ export interface UserInfo {
   peerId: string
   muteState?: boolean | false
   capabilities?: string[]
+  surface?: RoomSurfaceV1
 }
 
 export type MessageType = "text" | "image" | "file" | "action"

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -6,6 +6,7 @@ import { LOCAL_PEER_ID } from "@common/consts"
 
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
+import WorkspaceSnapshots from "./WorkspaceSnapshots"
 import { buildAgentInvitePrompt } from "../common/agentInvite"
 import {
   umamiEvent,
@@ -118,6 +119,7 @@ export default function RoomContent({
 
   const {
     participants,
+    getLocalRoomAuth,
     messages,
     sendTextMessage,
     sendFileMessage,
@@ -607,6 +609,12 @@ export default function RoomContent({
           className="flex flex-1 flex-col overflow-hidden border-b border-gray-800 md:flex-none md:border-b-0 md:border-r"
           style={isMd ? { width: `${splitRatio}%` } : undefined}
         >
+          {/* #111: Agent workspace snapshots — observation only, available in
+              every room type; Human screen share is untouched below. */}
+          <WorkspaceSnapshots
+            participants={participants}
+            getLocalRoomAuth={getLocalRoomAuth}
+          />
           <div className="relative flex flex-1 flex-col overflow-hidden">
             {activeScreenShares.length > 0 ? (
               <>

--- a/app/src/components/WorkspaceSnapshots.tsx
+++ b/app/src/components/WorkspaceSnapshots.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useRef, useState } from "react"
+
+import type { UserInfo } from "../common/types"
+
+interface WorkspaceSnapshotsProps {
+  participants: UserInfo[]
+  getLocalRoomAuth: () => {
+    roomId: string
+    participantId: string
+    token: string
+  } | null
+}
+
+/**
+ * Observable Agent Workspace v0 (#111): renders each visible Agent's latest
+ * explicitly-published workspace snapshot. Observation only — no controls,
+ * never a live stream. Bytes are fetched on demand for the exact current
+ * snapshotId; one object URL per snapshot is kept and revoked when that
+ * snapshot is replaced/removed or on unmount. Stale reads fail quietly; the
+ * effect re-runs when newer metadata arrives.
+ */
+export default function WorkspaceSnapshots({
+  participants,
+  getLocalRoomAuth,
+}: WorkspaceSnapshotsProps) {
+  const [urls, setUrls] = useState<Record<string, string>>({})
+  // object URLs alive right now, keyed by `${peerId}:${snapshotId}`.
+  const urlRefs = useRef<Record<string, string>>({})
+
+  const surfaces = participants.filter((p) => p.kind === "agent" && p.surface)
+
+  useEffect(() => {
+    const valid = new Set(
+      surfaces.map((p) => `${p.peerId}:${p.surface!.snapshotId}`)
+    )
+    // Revoke URLs whose snapshot was replaced/removed.
+    let revoked = false
+    for (const [key, url] of Object.entries(urlRefs.current)) {
+      if (!valid.has(key)) {
+        URL.revokeObjectURL(url)
+        delete urlRefs.current[key]
+        revoked = true
+      }
+    }
+    if (revoked) setUrls({ ...urlRefs.current })
+
+    let cancelled = false
+    for (const p of surfaces) {
+      const key = `${p.peerId}:${p.surface!.snapshotId}`
+      if (urlRefs.current[key]) continue
+      const auth = getLocalRoomAuth()
+      if (!auth) continue
+      void (async () => {
+        try {
+          const response = await fetch("/api/room/surfaces/read", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              "X-Room-Id": auth.roomId,
+              "X-Room-Participant-Id": auth.participantId,
+              "X-Room-Participant-Token": auth.token,
+            },
+            body: JSON.stringify({
+              sourceParticipantId: p.peerId,
+              snapshotId: p.surface!.snapshotId,
+            }),
+          })
+          // Stale or gone: fail quietly; newer state will re-trigger.
+          if (!response.ok || cancelled) return
+          const payload = (await response.json()) as {
+            surface?: { mimeType?: string }
+            data?: unknown
+          }
+          if (
+            cancelled ||
+            typeof payload.data !== "string" ||
+            !payload.surface?.mimeType
+          )
+            return
+          if (payload.surface.mimeType !== p.surface!.mimeType) return
+          const binary = atob(payload.data)
+          const bytes = new Uint8Array(binary.length)
+          for (let i = 0; i < binary.length; i += 1)
+            bytes[i] = binary.charCodeAt(i)
+          const blob = new Blob([bytes], { type: payload.surface.mimeType })
+          const url = URL.createObjectURL(blob)
+          // TOCTOU guard: a newer fetch may already own this slot.
+          if (urlRefs.current[key] || cancelled) {
+            URL.revokeObjectURL(url)
+            return
+          }
+          urlRefs.current[key] = url
+          setUrls({ ...urlRefs.current })
+        } catch {
+          // Quiet failure: observation must never break the room UI.
+        }
+      })()
+    }
+
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [surfaces.map((p) => `${p.peerId}:${p.surface!.updatedAt}`).join("|")])
+
+  useEffect(() => {
+    const refs = urlRefs.current
+    return () => {
+      for (const url of Object.values(refs)) URL.revokeObjectURL(url)
+    }
+  }, [])
+
+  if (surfaces.length === 0) return null
+
+  return (
+    <div className="border-b border-gray-800 px-3 py-2">
+      <p className="mb-1 text-[10px] uppercase tracking-wide text-gray-500">
+        Workspace snapshots — not live
+      </p>
+      <div className="flex flex-row gap-2 overflow-x-auto">
+        {surfaces.map((p) => {
+          const key = `${p.peerId}:${p.surface!.snapshotId}`
+          const url = urls[key]
+          return (
+            <figure
+              key={p.peerId}
+              className="w-48 flex-none rounded-lg border border-gray-700 bg-gray-900/60"
+            >
+              {url ? (
+                <img
+                  src={url}
+                  alt={`${p.name} workspace snapshot`}
+                  className="h-28 w-full rounded-t-lg object-cover"
+                />
+              ) : (
+                <div className="flex h-28 w-full items-center justify-center rounded-t-lg text-xs text-gray-500">
+                  loading…
+                </div>
+              )}
+              <figcaption className="truncate px-2 py-1 text-[10px] text-gray-400">
+                {p.name} · workspace snapshot · not live
+              </figcaption>
+            </figure>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/WorkspaceSnapshots.tsx
+++ b/app/src/components/WorkspaceSnapshots.tsx
@@ -127,6 +127,9 @@ export default function WorkspaceSnapshots({
               className="w-48 flex-none rounded-lg border border-gray-700 bg-gray-900/60"
             >
               {url ? (
+                // Blob object URLs cannot be optimized by next/image; this
+                // mirrors TextChatCard's ephemeral-preview pattern.
+                // eslint-disable-next-line @next/next/no-img-element
                 <img
                   src={url}
                   alt={`${p.name} workspace snapshot`}

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -31,6 +31,7 @@ import {
   evaluateSurfacePublish,
   sanitizeStoredSurface,
   surfaceChunkKey,
+  swapSurfaceAfterPersist,
 } from "./surface"
 import type {
   AgentCapabilities,
@@ -2170,20 +2171,29 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       return this.json({ error: "surface_unavailable" }, 503)
     }
     const previous = participant.surface
-    participant.surface = {
-      kind: "workspace-snapshot",
+    const updated = {
+      kind: "workspace-snapshot" as const,
       snapshotId,
       mimeType: mimeType as RoomSurfaceV1["mimeType"],
       size: bytes.byteLength,
       updatedAt: Date.now(),
     }
-    await this.saveRoom(room)
-    await this.broadcastState(room)
-    if (previous) await this.deleteSurfaceChunks(participantId, previous)
-    return this.json({
-      surface: participant.surface,
-      expiresAt: room.expiresAt,
+    // Post-commit replacement (#111 review): persist + broadcast first, then
+    // best-effort old-chunk deletion via the injectable seam — a failure
+    // deleting A can never fail a publish whose B is already committed.
+    const surface = await swapSurfaceAfterPersist({
+      participantId,
+      previous,
+      updated,
+      persist: async () => {
+        await this.saveRoom(room)
+        await this.broadcastState(room)
+      },
+      deleteOldChunks: previous
+        ? () => this.deleteSurfaceChunks(participantId, previous)
+        : async () => {},
     })
+    return this.json({ surface, expiresAt: room.expiresAt })
   }
 
   private async handleAttachmentUpload(request: Request): Promise<Response> {

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -27,6 +27,7 @@ import { computeExpiresAt, NO_EXPIRY } from "./roomExpiry"
 import {
   SURFACE_CHUNK_SIZE,
   SURFACE_KEY_PREFIX,
+  deleteSurfaceChunksBestEffort,
   evaluateSurfacePublish,
   sanitizeStoredSurface,
   surfaceChunkKey,
@@ -1261,8 +1262,13 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       delete participant.surface
       participant.lastSeenAt = Date.now()
       await this.saveRoom(room)
+      // Clear succeeds even if chunk deletion hiccups (best-effort, #111).
+      await deleteSurfaceChunksBestEffort(() =>
+        previous
+          ? this.deleteSurfaceChunks(participant.id, previous)
+          : Promise.resolve()
+      )
       await this.broadcastState(room)
-      if (previous) await this.deleteSurfaceChunks(participant.id, previous)
       return this.json({
         ok: true,
         cleared: Boolean(previous),
@@ -1679,9 +1685,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       this.applyEmptyRoomExpiry(room, Date.now())
       await this.saveRoom(room)
       // #111: no surface history survives departure — chunks die after the
-      // metadata removal is durable.
+      // metadata removal is durable, best-effort so departure always
+      // continues to broadcast/scheduling/Meeting-Notes media cleanup.
       if (departingSurface)
-        await this.deleteSurfaceChunks(participant.id, departingSurface)
+        await deleteSurfaceChunksBestEffort(() =>
+          this.deleteSurfaceChunks(participant.id, departingSurface)
+        )
       const waiter = this.agentWaiters.get(participant.id)
       if (waiter) {
         this.finishWaiter(
@@ -2359,9 +2368,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       await this.broadcastState(room)
     }
     // #111: chunk deletion after persistence — no surface outlives its
-    // lease-expired owner.
+    // lease-expired owner. Best-effort: the sweep must continue to
+    // scheduleNextAlarm regardless of individual deletion failures.
     for (const { participantId, surface } of expiredSurfaces)
-      await this.deleteSurfaceChunks(participantId, surface)
+      await deleteSurfaceChunksBestEffort(() =>
+        this.deleteSurfaceChunks(participantId, surface)
+      )
     await this.scheduleNextAlarm(room)
     // External I/O last, after every storage-only mutation above is
     // already durable (round 4): attemptCleanupNow takes a read-only

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -24,6 +24,13 @@ import {
   removeConfirmedMids,
 } from "./realtimeMedia"
 import { computeExpiresAt, NO_EXPIRY } from "./roomExpiry"
+import {
+  SURFACE_CHUNK_SIZE,
+  SURFACE_KEY_PREFIX,
+  evaluateSurfacePublish,
+  sanitizeStoredSurface,
+  surfaceChunkKey,
+} from "./surface"
 import type {
   AgentCapabilities,
   AgentEvent,
@@ -38,6 +45,7 @@ import type {
   RoomRecord,
   RoomState,
   ParticipantKind,
+  RoomSurfaceV1,
 } from "../room/types"
 
 const RECONNECT_GRACE_MS = 30 * 1000
@@ -226,6 +234,21 @@ type ControlRequest =
       token: string
     }
   | {
+      action: "agent-clear-surface"
+      participantId: string
+      token: string
+    }
+  | {
+      // #111: reads the CURRENT workspace snapshot of another participant.
+      // Any authenticated current participant may read; a snapshotId that no
+      // longer matches returns surface_changed (never stale bytes).
+      action: "agent-read-surface"
+      participantId: string
+      token: string
+      sourceParticipantId: string
+      snapshotId: string
+    }
+  | {
       action: "agent-media-attach"
       participantId: string
       token: string
@@ -334,6 +357,15 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         )
         if (sanitized.changed) {
           participant.capabilities = sanitized.capabilities
+          changed = true
+        }
+        // #111 storage hygiene: a malformed persisted surface is dropped
+        // (never rejected) so room loading cannot wedge.
+        const sanitizedSurface = sanitizeStoredSurface(participant.surface)
+        if (sanitizedSurface.changed) {
+          if (sanitizedSurface.surface)
+            participant.surface = sanitizedSurface.surface
+          else delete participant.surface
           changed = true
         }
         for (const key of [
@@ -529,6 +561,28 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     return `attachment:${id}:${index}`
   }
 
+  // #111: deletes every chunk of one snapshot. Best-effort by design —
+  // orphan chunks are swept unconditionally at room expiry.
+  private async deleteSurfaceChunks(
+    participantId: string,
+    surface: Pick<RoomSurfaceV1, "snapshotId" | "size">
+  ): Promise<void> {
+    const chunkCount = Math.ceil(surface.size / SURFACE_CHUNK_SIZE)
+    const keys: string[] = []
+    for (let index = 0; index < chunkCount; index += 1)
+      keys.push(surfaceChunkKey(participantId, surface.snapshotId, index))
+    await this.ctx.storage.delete(keys)
+  }
+
+  // #111: prefix sweep of ALL surface:* keys (including orphans from
+  // interrupted publishes). Room expiry is the unconditional backstop.
+  private async deleteAllSurfaceKeys(): Promise<void> {
+    const entries = await this.ctx.storage.list({
+      prefix: SURFACE_KEY_PREFIX,
+    })
+    if (entries.size > 0) await this.ctx.storage.delete([...entries.keys()])
+  }
+
   private async deleteAttachmentChunks(
     attachment: Pick<RoomAttachment, "id" | "chunkCount">
   ): Promise<void> {
@@ -687,6 +741,9 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       this.stageAgentMediaRevocation(room, room.meetingNotes.agentParticipantId)
       pendingClose = room.pendingMediaCleanup
     }
+    // #111: unconditional prefix sweep — metadata dies with the room record,
+    // chunk keys (including orphans from interrupted publishes) die here.
+    await this.deleteAllSurfaceKeys()
     for (const attachment of room.attachments)
       await this.deleteAttachmentChunks(attachment)
     await this.ctx.storage.delete("room")
@@ -1187,6 +1244,89 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       })
     }
 
+    if (request.action === "agent-clear-surface") {
+      const room = await this.activeRoom()
+      if (!room) return this.json({ error: "room_expired" }, 410)
+      const participant = this.findParticipant(
+        room,
+        request.participantId,
+        request.token
+      )
+      if (!participant) return this.json({ error: "unauthorized" }, 401)
+      if (participant.kind !== "agent")
+        return this.json({ error: "agent_only" }, 403)
+      // Own-surface-only clear. No history: chunks die with the metadata
+      // swap, and no message/sequence/waiter interaction occurs.
+      const previous = participant.surface
+      delete participant.surface
+      participant.lastSeenAt = Date.now()
+      await this.saveRoom(room)
+      await this.broadcastState(room)
+      if (previous) await this.deleteSurfaceChunks(participant.id, previous)
+      return this.json({
+        ok: true,
+        cleared: Boolean(previous),
+        expiresAt: room.expiresAt,
+      })
+    }
+
+    if (request.action === "agent-read-surface") {
+      const room = await this.activeRoom()
+      if (!room) return this.json({ error: "room_expired" }, 410)
+      // Any authenticated current participant may read; the snapshotId match
+      // closes the TOCTOU window — a replaced/cleared surface can never
+      // serve stale bytes.
+      const reader = this.findParticipant(
+        room,
+        request.participantId,
+        request.token
+      )
+      if (!reader) return this.json({ error: "unauthorized" }, 401)
+      const source = room.participants[request.sourceParticipantId]
+      if (
+        !source ||
+        source.kind !== "agent" ||
+        !source.surface ||
+        source.surface.snapshotId !== request.snapshotId
+      ) {
+        const exists = source?.kind === "agent" && Boolean(source.surface)
+        return this.json(
+          { error: exists ? "surface_changed" : "surface_not_found" },
+          exists ? 410 : 404
+        )
+      }
+      const surface = source.surface
+      const chunkCount = Math.ceil(surface.size / SURFACE_CHUNK_SIZE)
+      const chunks: Uint8Array[] = []
+      for (let index = 0; index < chunkCount; index += 1) {
+        const chunk = await this.ctx.storage.get<ArrayBuffer>(
+          surfaceChunkKey(source.id, surface.snapshotId, index)
+        )
+        if (!chunk) return this.json({ error: "surface_not_found" }, 404)
+        chunks.push(new Uint8Array(chunk))
+      }
+      let binary = ""
+      for (const chunk of chunks)
+        for (const byte of chunk) binary += String.fromCharCode(byte)
+      reader.lastSeenAt = Date.now()
+      await this.saveRoom(room)
+      // Observation bytes must never be cached anywhere downstream.
+      return new Response(
+        JSON.stringify({
+          surface,
+          data: btoa(binary),
+          expiresAt: room.expiresAt,
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            "Cache-Control": "no-store",
+          },
+        }
+      )
+    }
+
     if (request.action === "agent-send-collab") {
       const room = await this.activeRoom()
       if (!room) return this.json({ error: "room_expired" }, 410)
@@ -1530,6 +1670,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       // afterward attempt the actual close against a fresh reload. See
       // stageAgentMediaRevocation/attemptCleanupNow's own comments.
       this.stageAgentMediaRevocation(room, participant.id)
+      const departingSurface = participant.surface
       delete room.participants[participant.id]
       room.meetingNotes = clearGrantIfParticipantDeparting(
         room.meetingNotes,
@@ -1537,6 +1678,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       )
       this.applyEmptyRoomExpiry(room, Date.now())
       await this.saveRoom(room)
+      // #111: no surface history survives departure — chunks die after the
+      // metadata removal is durable.
+      if (departingSurface)
+        await this.deleteSurfaceChunks(participant.id, departingSurface)
       const waiter = this.agentWaiters.get(participant.id)
       if (waiter) {
         this.finishWaiter(
@@ -1894,6 +2039,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     const url = new URL(request.url)
     if (request.method === "POST" && url.pathname === "/attachment")
       return this.handleAttachmentUpload(request)
+    if (request.method === "POST" && url.pathname === "/surface")
+      return this.handleSurfaceUpload(request)
     if (request.headers.get("Upgrade")?.toLowerCase() === "websocket") {
       if (request.method !== "GET")
         return this.json({ error: "method_not_allowed" }, 405)
@@ -1949,6 +2096,85 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       value === "application/json" ||
       value === "text/yaml"
     )
+  }
+
+  // #111 Observable Agent Workspace publish. Order matters: policy first
+  // (no storage touched on rejection), then new chunks, THEN the atomic
+  // metadata swap + broadcast, and only afterward best-effort old-chunk
+  // deletion — a failure at any point leaves the previous snapshot intact.
+  // Deliberately does NOT touch messages, sequence numbers, agent waiters,
+  // or attachments: a surface update is observation metadata, never a chat
+  // event or Harness wake.
+  private async handleSurfaceUpload(request: Request): Promise<Response> {
+    const room = await this.activeRoom()
+    if (!room) return this.json({ error: "room_expired" }, 410)
+    const participantId = request.headers.get("X-Room-Participant-Id") ?? ""
+    const token = request.headers.get("X-Room-Participant-Token") ?? ""
+    const mimeType = (request.headers.get("X-Surface-MimeType") ?? "")
+      .split(";", 1)[0]
+      .toLowerCase()
+    const participant = this.findParticipant(room, participantId, token)
+    if (!participant) return this.json({ error: "unauthorized" }, 401)
+    if (participant.kind !== "agent")
+      return this.json({ error: "surface_agent_only" }, 403)
+    const declaredSize = Number(request.headers.get("Content-Length") ?? "0")
+    const bytes = new Uint8Array(await request.arrayBuffer())
+    const otherActiveSurfaces = Object.values(room.participants).filter(
+      (candidate) =>
+        candidate.kind === "agent" &&
+        candidate.id !== participantId &&
+        Boolean(candidate.surface)
+    ).length
+    const policy = evaluateSurfacePublish({
+      mimeType,
+      declaredSize,
+      byteLength: bytes.byteLength,
+      otherActiveSurfaces,
+      publisherHasSurface: Boolean(participant.surface),
+      publisherLastUpdatedAt: participant.surface?.updatedAt,
+      now: Date.now(),
+    })
+    if (policy.ok === false)
+      return this.json(
+        { error: policy.error },
+        policy.error === "surface_rate_limited"
+          ? 429
+          : policy.error === "surface_capacity_exceeded"
+          ? 503
+          : 400
+      )
+    const snapshotId = crypto.randomUUID()
+    try {
+      for (let index = 0; index < policy.chunkCount; index += 1) {
+        const start = index * SURFACE_CHUNK_SIZE
+        await this.ctx.storage.put(
+          surfaceChunkKey(participantId, snapshotId, index),
+          bytes.slice(start, start + SURFACE_CHUNK_SIZE)
+        )
+      }
+    } catch {
+      // Roll back partial NEW chunks; previous surface untouched.
+      const partialKeys: string[] = []
+      for (let index = 0; index < policy.chunkCount; index += 1)
+        partialKeys.push(surfaceChunkKey(participantId, snapshotId, index))
+      await this.ctx.storage.delete(partialKeys)
+      return this.json({ error: "surface_unavailable" }, 503)
+    }
+    const previous = participant.surface
+    participant.surface = {
+      kind: "workspace-snapshot",
+      snapshotId,
+      mimeType: mimeType as RoomSurfaceV1["mimeType"],
+      size: bytes.byteLength,
+      updatedAt: Date.now(),
+    }
+    await this.saveRoom(room)
+    await this.broadcastState(room)
+    if (previous) await this.deleteSurfaceChunks(participantId, previous)
+    return this.json({
+      surface: participant.surface,
+      expiresAt: room.expiresAt,
+    })
   }
 
   private async handleAttachmentUpload(request: Request): Promise<Response> {
@@ -2082,6 +2308,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       return
     }
     let changed = false
+    const expiredSurfaces: Array<{
+      participantId: string
+      surface: RoomSurfaceV1
+    }> = []
     for (const [id, participant] of Object.entries(room.participants)) {
       const expiredHuman =
         participant.kind === "human" &&
@@ -2094,6 +2324,13 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         // Synchronous staging only here — no Cloudflare fetch is attempted
         // until after this whole sweep is persisted below (round 4).
         if (expiredAgent) this.stageAgentMediaRevocation(room, id)
+        // #111: lease-expired agents lose their surface with them; chunk
+        // deletion happens after the sweep is persisted (below).
+        if (participant.surface)
+          expiredSurfaces.push({
+            participantId: id,
+            surface: participant.surface,
+          })
         delete room.participants[id]
         room.meetingNotes = clearGrantIfParticipantDeparting(
           room.meetingNotes,
@@ -2121,6 +2358,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       await this.saveRoom(room)
       await this.broadcastState(room)
     }
+    // #111: chunk deletion after persistence — no surface outlives its
+    // lease-expired owner.
+    for (const { participantId, surface } of expiredSurfaces)
+      await this.deleteSurfaceChunks(participantId, surface)
     await this.scheduleNextAlarm(room)
     // External I/O last, after every storage-only mutation above is
     // already durable (round 4): attemptCleanupNow takes a read-only

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -2182,10 +2182,10 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     // best-effort old-chunk deletion via the injectable seam — a failure
     // deleting A can never fail a publish whose B is already committed.
     const surface = await swapSurfaceAfterPersist({
-      participantId,
+      participant,
       previous,
       updated,
-      persist: async () => {
+      persistAndBroadcast: async () => {
         await this.saveRoom(room)
         await this.broadcastState(room)
       },

--- a/app/src/do/collab.test.ts
+++ b/app/src/do/collab.test.ts
@@ -661,3 +661,30 @@ describe("CollabRegistry rebuild fail-closed when the request itself is evicted"
     ).toEqual({ action: "record" })
   })
 })
+
+describe("rosterProjection surface metadata (#111)", () => {
+  it("exposes agent snapshot metadata only, never for humans", () => {
+    const roster = rosterProjection({
+      "agent-a": participant({
+        id: "agent-a",
+        name: "Agent A",
+        surface: {
+          kind: "workspace-snapshot",
+          snapshotId: "snap-1",
+          mimeType: "image/png",
+          size: 2048,
+          updatedAt: 42,
+        },
+      }),
+      "human-1": participant({ id: "human-1", name: "Human", kind: "human" }),
+    })
+    expect(roster[0].surface).toEqual({
+      kind: "workspace-snapshot",
+      snapshotId: "snap-1",
+      mimeType: "image/png",
+      size: 2048,
+      updatedAt: 42,
+    })
+    expect(roster[1].surface).toBeUndefined()
+  })
+})

--- a/app/src/do/collab.ts
+++ b/app/src/do/collab.ts
@@ -1,5 +1,6 @@
 import type {
   AgentCapabilities,
+  RoomSurfaceV1,
   CollabEvent,
   CollabEventKind,
   RoomParticipant,
@@ -116,6 +117,9 @@ export interface ParticipantRosterEntry {
   name: string
   kind: RoomParticipant["kind"]
   advertised?: string[]
+  /** #111 sanitized workspace-snapshot metadata (no bytes, no source info).
+   * Present only while the agent holds a published surface. */
+  surface?: RoomSurfaceV1
 }
 
 /** Compact connected-participant/capability projection for Harness context.
@@ -132,6 +136,9 @@ export function rosterProjection(
       kind: participant.kind,
       ...(participant.kind === "agent" && participant.capabilities?.advertised
         ? { advertised: participant.capabilities.advertised }
+        : {}),
+      ...(participant.kind === "agent" && participant.surface
+        ? { surface: participant.surface }
         : {}),
     }))
 }

--- a/app/src/do/surface.test.ts
+++ b/app/src/do/surface.test.ts
@@ -175,15 +175,19 @@ describe("swapSurfaceAfterPersist (#111 review call-site seam)", () => {
     updatedAt: 2,
   }
 
-  it("publish succeeds when old-chunk deletion throws after persist; returns B and still attempts A's deletion", async () => {
+  it("assigns B onto the participant BEFORE persist; delete throw cannot fail publish or revert state", async () => {
+    const participant: { surface?: typeof surfaceA } = { surface: surfaceA }
     let persistRan = false
     let deleteAttempts = 0
     const current = await swapSurfaceAfterPersist({
-      participantId: "p1",
+      participant,
       previous: surfaceA,
       updated: surfaceB,
-      persist: async () => {
+      persistAndBroadcast: async () => {
         persistRan = true
+        // Guarding the actual call-site mutation: by the time the RoomRecord
+        // is saved/broadcast, the participant must already describe B.
+        expect(participant.surface).toEqual(surfaceB)
       },
       deleteOldChunks: async () => {
         deleteAttempts += 1
@@ -193,19 +197,24 @@ describe("swapSurfaceAfterPersist (#111 review call-site seam)", () => {
     expect(persistRan).toBe(true)
     expect(deleteAttempts).toBe(1)
     expect(current).toEqual(surfaceB)
+    expect(participant.surface).toEqual(surfaceB)
   })
 
   it("deletes nothing when there is no previous snapshot", async () => {
+    const participant: { surface?: typeof surfaceA } = {}
     let deleteAttempts = 0
     const current = await swapSurfaceAfterPersist({
-      participantId: "p1",
+      participant,
       updated: surfaceB,
-      persist: async () => {},
+      persistAndBroadcast: async () => {
+        expect(participant.surface).toEqual(surfaceB)
+      },
       deleteOldChunks: async () => {
         deleteAttempts += 1
       },
     })
     expect(current).toEqual(surfaceB)
+    expect(participant.surface).toEqual(surfaceB)
     expect(deleteAttempts).toBe(0)
   })
 })

--- a/app/src/do/surface.test.ts
+++ b/app/src/do/surface.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  deleteSurfaceChunksBestEffort,
   evaluateSurfacePublish,
   MAX_SURFACE_BYTES,
   sanitizeStoredSurface,
@@ -136,5 +137,23 @@ describe("sanitizeStoredSurface", () => {
 describe("surfaceChunkKey", () => {
   it("namespaces chunks under the sweepable surface: prefix", () => {
     expect(surfaceChunkKey("p1", "s1", 3)).toBe("surface:p1:s1:3")
+  })
+})
+
+describe("deleteSurfaceChunksBestEffort (#111 review)", () => {
+  it("resolves even when the underlying deletion throws", async () => {
+    await expect(
+      deleteSurfaceChunksBestEffort(async () => {
+        throw new Error("storage hiccup")
+      })
+    ).resolves.toBeUndefined()
+  })
+
+  it("awaits successful deletions", async () => {
+    let ran = false
+    await deleteSurfaceChunksBestEffort(async () => {
+      ran = true
+    })
+    expect(ran).toBe(true)
   })
 })

--- a/app/src/do/surface.test.ts
+++ b/app/src/do/surface.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   deleteSurfaceChunksBestEffort,
+  swapSurfaceAfterPersist,
   evaluateSurfacePublish,
   MAX_SURFACE_BYTES,
   sanitizeStoredSurface,
@@ -155,5 +156,56 @@ describe("deleteSurfaceChunksBestEffort (#111 review)", () => {
       ran = true
     })
     expect(ran).toBe(true)
+  })
+})
+
+describe("swapSurfaceAfterPersist (#111 review call-site seam)", () => {
+  const surfaceA = {
+    kind: "workspace-snapshot" as const,
+    snapshotId: "aaaaaaaa-bbbb-4ccc-addd-eeeeeeeeeeee",
+    mimeType: "image/png" as const,
+    size: 1024,
+    updatedAt: 1,
+  }
+  const surfaceB = {
+    kind: "workspace-snapshot" as const,
+    snapshotId: "bbbbbbbb-cccc-4ddd-aeee-ffffffffffff",
+    mimeType: "image/jpeg" as const,
+    size: 2048,
+    updatedAt: 2,
+  }
+
+  it("publish succeeds when old-chunk deletion throws after persist; returns B and still attempts A's deletion", async () => {
+    let persistRan = false
+    let deleteAttempts = 0
+    const current = await swapSurfaceAfterPersist({
+      participantId: "p1",
+      previous: surfaceA,
+      updated: surfaceB,
+      persist: async () => {
+        persistRan = true
+      },
+      deleteOldChunks: async () => {
+        deleteAttempts += 1
+        throw new Error("storage hiccup deleting A")
+      },
+    })
+    expect(persistRan).toBe(true)
+    expect(deleteAttempts).toBe(1)
+    expect(current).toEqual(surfaceB)
+  })
+
+  it("deletes nothing when there is no previous snapshot", async () => {
+    let deleteAttempts = 0
+    const current = await swapSurfaceAfterPersist({
+      participantId: "p1",
+      updated: surfaceB,
+      persist: async () => {},
+      deleteOldChunks: async () => {
+        deleteAttempts += 1
+      },
+    })
+    expect(current).toEqual(surfaceB)
+    expect(deleteAttempts).toBe(0)
   })
 })

--- a/app/src/do/surface.test.ts
+++ b/app/src/do/surface.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  evaluateSurfacePublish,
+  MAX_SURFACE_BYTES,
+  sanitizeStoredSurface,
+  SURFACE_CHUNK_SIZE,
+  surfaceChunkKey,
+} from "./surface"
+
+function base(overrides: Record<string, unknown> = {}) {
+  return {
+    mimeType: "image/png",
+    declaredSize: 0,
+    byteLength: 1024,
+    otherActiveSurfaces: 0,
+    publisherHasSurface: false,
+    now: 10_000,
+    ...overrides,
+  }
+}
+
+describe("evaluateSurfacePublish", () => {
+  it("accepts a supported image and derives the chunk count", () => {
+    const result = evaluateSurfacePublish(
+      base({ byteLength: SURFACE_CHUNK_SIZE * 5 + 1 })
+    )
+    expect(result).toEqual({ ok: true, chunkCount: 6 })
+  })
+
+  it("rejects unsupported MIME types", () => {
+    for (const bad of ["text/plain", "application/json", "image/gif", 42])
+      expect(evaluateSurfacePublish(base({ mimeType: bad })).ok).toBe(false)
+    expect(
+      evaluateSurfacePublish(base({ mimeType: "text/plain" }))
+    ).toMatchObject({ ok: false, error: "surface_mime_unsupported" })
+  })
+
+  it("rejects empty and oversized payloads before touching storage", () => {
+    expect(evaluateSurfacePublish(base({ byteLength: 0 }))).toMatchObject({
+      ok: false,
+      error: "surface_empty",
+    })
+    expect(
+      evaluateSurfacePublish(base({ byteLength: MAX_SURFACE_BYTES + 1 }))
+    ).toMatchObject({ ok: false, error: "surface_too_large" })
+    expect(
+      evaluateSurfacePublish(
+        base({ declaredSize: 100, byteLength: MAX_SURFACE_BYTES })
+      )
+    ).toMatchObject({ ok: false, error: "surface_size_mismatch" })
+  })
+
+  it("throttles rapid replacement but never blocks first publishes", () => {
+    expect(
+      evaluateSurfacePublish(
+        base({
+          publisherHasSurface: true,
+          publisherLastUpdatedAt: 9_000,
+        })
+      )
+    ).toMatchObject({ ok: false, error: "surface_rate_limited" })
+    // Exactly at the boundary is allowed.
+    expect(
+      evaluateSurfacePublish(
+        base({
+          publisherHasSurface: true,
+          publisherLastUpdatedAt: 8_000,
+        })
+      ).ok
+    ).toBe(true)
+    expect(
+      evaluateSurfacePublish(
+        base({ otherActiveSurfaces: 0, publisherLastUpdatedAt: undefined })
+      ).ok
+    ).toBe(true)
+  })
+
+  it("caps distinct publishers at three while letting existing publishers replace at capacity", () => {
+    for (const active of [0, 1, 2])
+      expect(
+        evaluateSurfacePublish(base({ otherActiveSurfaces: active })).ok
+      ).toBe(true)
+    const blocked = evaluateSurfacePublish(base({ otherActiveSurfaces: 3 }))
+    expect(blocked).toEqual({
+      ok: false,
+      error: "surface_capacity_exceeded",
+    })
+    expect(
+      evaluateSurfacePublish(
+        base({ otherActiveSurfaces: 3, publisherHasSurface: true })
+      ).ok
+    ).toBe(true)
+  })
+})
+
+describe("sanitizeStoredSurface", () => {
+  const valid = {
+    kind: "workspace-snapshot" as const,
+    snapshotId: "snap-1",
+    mimeType: "image/png" as const,
+    size: 2048,
+    updatedAt: 123,
+  }
+
+  it("keeps valid records untouched by reference", () => {
+    const result = sanitizeStoredSurface(valid)
+    expect(result.changed).toBe(false)
+    expect(result.surface).toBe(valid)
+  })
+
+  it("drops invalid records and reports repair", () => {
+    for (const broken of [
+      null,
+      {},
+      { ...valid, kind: "other" },
+      { ...valid, snapshotId: "" },
+      { ...valid, mimeType: "image/gif" },
+      { ...valid, size: MAX_SURFACE_BYTES + 1 },
+      { ...valid, updatedAt: -1 },
+    ]) {
+      const result = sanitizeStoredSurface(broken)
+      expect(result.surface).toBeUndefined()
+      expect(result.changed).toBe(true)
+    }
+  })
+
+  it("treats absent as unchanged", () => {
+    expect(sanitizeStoredSurface(undefined)).toEqual({
+      surface: undefined,
+      changed: false,
+    })
+  })
+})
+
+describe("surfaceChunkKey", () => {
+  it("namespaces chunks under the sweepable surface: prefix", () => {
+    expect(surfaceChunkKey("p1", "s1", 3)).toBe("surface:p1:s1:3")
+  })
+})

--- a/app/src/do/surface.ts
+++ b/app/src/do/surface.ts
@@ -92,6 +92,23 @@ export function surfaceChunkKey(
 
 export const SURFACE_KEY_PREFIX = "surface:"
 
+/** Runs one already-detached chunk deletion without ever failing its caller
+ * (#111 review): once metadata has been swapped/cleared/removed, a storage
+ * hiccup during cleanup must not fail the publish/clear, interrupt an
+ * agent-leave before broadcast/scheduling/Meeting-Notes media cleanup, or
+ * break the lease-expiry sweep. Orphans are swept unconditionally at room
+ * expiry, which remains the fail-hard backstop. */
+export async function deleteSurfaceChunksBestEffort(
+  run: () => Promise<void>
+): Promise<void> {
+  try {
+    await run()
+  } catch {
+    // Detached chunks are unreachable (metadata no longer references them)
+    // and are swept unconditionally by room expiry.
+  }
+}
+
 /** Storage-hygiene pass for persisted metadata: invalid records are dropped
  * rather than rejected so a bad row can never wedge room loading. Returns
  * undefined when absent/invalid; `changed` reports whether the caller must

--- a/app/src/do/surface.ts
+++ b/app/src/do/surface.ts
@@ -109,6 +109,24 @@ export async function deleteSurfaceChunksBestEffort(
   }
 }
 
+/** Post-commit half of a surface REPLACEMENT (#111 review): persists the new
+ * metadata, then deletes the previous snapshot's chunks strictly
+ * best-effort. Injectable `deleteOldChunks` keeps the failure path
+ * deterministically testable — a throw here can never fail a publish whose
+ * metadata is already committed. Returns the now-current metadata. */
+export async function swapSurfaceAfterPersist(params: {
+  participantId: string
+  previous?: RoomSurfaceV1
+  updated: RoomSurfaceV1
+  persist: () => Promise<void>
+  deleteOldChunks: () => Promise<void>
+}): Promise<RoomSurfaceV1> {
+  await params.persist()
+  if (params.previous)
+    await deleteSurfaceChunksBestEffort(params.deleteOldChunks)
+  return params.updated
+}
+
 /** Storage-hygiene pass for persisted metadata: invalid records are dropped
  * rather than rejected so a bad row can never wedge room loading. Returns
  * undefined when absent/invalid; `changed` reports whether the caller must

--- a/app/src/do/surface.ts
+++ b/app/src/do/surface.ts
@@ -109,19 +109,25 @@ export async function deleteSurfaceChunksBestEffort(
   }
 }
 
-/** Post-commit half of a surface REPLACEMENT (#111 review): persists the new
- * metadata, then deletes the previous snapshot's chunks strictly
- * best-effort. Injectable `deleteOldChunks` keeps the failure path
- * deterministically testable — a throw here can never fail a publish whose
- * metadata is already committed. Returns the now-current metadata. */
+/** Post-commit half of a surface REPLACEMENT (#111 review): assigns the new
+ * metadata onto the participant (the seam owns this mutation, so a call
+ * site cannot persist/broadcast without it), then persists + broadcasts,
+ * then deletes the previous snapshot's chunks strictly best-effort.
+ * Injectable `deleteOldChunks` keeps the failure path deterministically
+ * testable — a throw here can never fail a publish whose metadata is
+ * already committed. Returns the now-current metadata. */
 export async function swapSurfaceAfterPersist(params: {
-  participantId: string
+  /** Mutable participant record whose `surface` pointer is swapped here. */
+  participant: { surface?: RoomSurfaceV1 }
   previous?: RoomSurfaceV1
   updated: RoomSurfaceV1
-  persist: () => Promise<void>
+  persistAndBroadcast: () => Promise<void>
   deleteOldChunks: () => Promise<void>
 }): Promise<RoomSurfaceV1> {
-  await params.persist()
+  // Assignment MUST precede persist: the saved RoomRecord and every
+  // broadcast must already describe B, never the stale A.
+  params.participant.surface = params.updated
+  await params.persistAndBroadcast()
   if (params.previous)
     await deleteSurfaceChunksBestEffort(params.deleteOldChunks)
   return params.updated

--- a/app/src/do/surface.ts
+++ b/app/src/do/surface.ts
@@ -1,0 +1,121 @@
+import type { AgentImageMimeType, RoomSurfaceV1 } from "../room/types"
+
+// #111 Observable Agent Workspace v0 policy. Deterministic and pure so the
+// DO stays thin and every rule here is deterministically testable (same
+// pattern as do/collab.ts).
+
+export const MAX_SURFACE_BYTES = 768 * 1024
+export const SURFACE_CHUNK_SIZE = 64 * 1024
+export const MAX_ACTIVE_AGENT_SURFACES = 3
+// Rapid replace throttle: a publisher may not update more often than this.
+export const MIN_SURFACE_UPDATE_MS = 2000
+
+const SURFACE_MIME_TYPES: readonly AgentImageMimeType[] = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+]
+
+export function isSurfaceMimeType(value: unknown): value is AgentImageMimeType {
+  return (
+    typeof value === "string" &&
+    SURFACE_MIME_TYPES.includes(value as AgentImageMimeType)
+  )
+}
+
+export type SurfacePolicyResult =
+  | { ok: true; chunkCount: number }
+  | {
+      ok: false
+      error:
+        | "surface_mime_unsupported"
+        | "surface_empty"
+        | "surface_too_large"
+        | "surface_size_mismatch"
+        | "surface_rate_limited"
+        | "surface_capacity_exceeded"
+    }
+
+export interface SurfacePublishContext {
+  mimeType: unknown
+  /** Declared Content-Length, when the transport provided one. */
+  declaredSize: number
+  byteLength: number
+  /** Number of OTHER agent participants currently holding a surface. */
+  otherActiveSurfaces: number
+  publisherHasSurface: boolean
+  publisherLastUpdatedAt?: number
+  now: number
+}
+
+/** Decides one publish attempt BEFORE any storage mutation: MIME/size
+ * bounds, per-publisher replace throttle, and room-wide capacity. An
+ * existing publisher may always replace its own surface (even at capacity);
+ * brand-new publishers beyond the cap get surface_capacity_exceeded. */
+export function evaluateSurfacePublish(
+  input: SurfacePublishContext
+): SurfacePolicyResult {
+  if (!isSurfaceMimeType(input.mimeType))
+    return { ok: false, error: "surface_mime_unsupported" }
+  if (input.byteLength === 0) return { ok: false, error: "surface_empty" }
+  if (input.byteLength > MAX_SURFACE_BYTES)
+    return { ok: false, error: "surface_too_large" }
+  if (input.declaredSize > 0 && input.declaredSize !== input.byteLength)
+    return { ok: false, error: "surface_size_mismatch" }
+  if (
+    input.publisherHasSurface &&
+    input.publisherLastUpdatedAt !== undefined &&
+    input.now - input.publisherLastUpdatedAt < MIN_SURFACE_UPDATE_MS
+  )
+    return { ok: false, error: "surface_rate_limited" }
+  if (
+    !input.publisherHasSurface &&
+    input.otherActiveSurfaces >= MAX_ACTIVE_AGENT_SURFACES
+  )
+    return { ok: false, error: "surface_capacity_exceeded" }
+  return {
+    ok: true,
+    chunkCount: Math.ceil(input.byteLength / SURFACE_CHUNK_SIZE),
+  }
+}
+
+/** DO storage key for one bounded binary chunk. Metadata never holds bytes;
+ * chunks live only under these dedicated keys so prefix sweeps can clean
+ * everything, including orphans from interrupted publishes. */
+export function surfaceChunkKey(
+  participantId: string,
+  snapshotId: string,
+  chunkIndex: number
+): string {
+  return `surface:${participantId}:${snapshotId}:${chunkIndex}`
+}
+
+export const SURFACE_KEY_PREFIX = "surface:"
+
+/** Storage-hygiene pass for persisted metadata: invalid records are dropped
+ * rather than rejected so a bad row can never wedge room loading. Returns
+ * undefined when absent/invalid; `changed` reports whether the caller must
+ * persist the repair. */
+export function sanitizeStoredSurface(surface: unknown): {
+  surface?: RoomSurfaceV1
+  changed: boolean
+} {
+  if (!surface || typeof surface !== "object")
+    return { surface: undefined, changed: surface !== undefined }
+  const candidate = surface as Partial<RoomSurfaceV1>
+  const valid =
+    candidate.kind === "workspace-snapshot" &&
+    typeof candidate.snapshotId === "string" &&
+    candidate.snapshotId.length > 0 &&
+    candidate.snapshotId.length <= 64 &&
+    isSurfaceMimeType(candidate.mimeType) &&
+    typeof candidate.size === "number" &&
+    Number.isSafeInteger(candidate.size) &&
+    candidate.size > 0 &&
+    candidate.size <= MAX_SURFACE_BYTES &&
+    typeof candidate.updatedAt === "number" &&
+    Number.isSafeInteger(candidate.updatedAt) &&
+    candidate.updatedAt > 0
+  if (valid) return { surface: candidate as RoomSurfaceV1, changed: false }
+  return { surface: undefined, changed: true }
+}

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -295,6 +295,7 @@ export function useSfuChatRoom(
           participant.kind === "agent"
             ? participant.capabilities?.advertised
             : undefined,
+        surface: participant.kind === "agent" ? participant.surface : undefined,
         audioStream: remoteAudioStreamsRef.current.get(participant.id) ?? null,
         screenShareEnabled: hasScreenShare,
         screenShareStream:
@@ -1489,8 +1490,22 @@ export function useSfuChatRoom(
     void initialConnectRef.current?.()
   }, [])
 
+  // #111: credentials for the LOCAL participant, used to authenticate
+  // on-demand workspace-snapshot reads. Never leaves the client except in
+  // request headers to this room's own Worker/DO.
+  const getLocalRoomAuth = useCallback(() => {
+    const session = sessionRef.current
+    if (!session) return null
+    return {
+      roomId: session.room,
+      participantId: session.participantId,
+      token: session.participantToken,
+    }
+  }, [])
+
   return {
     participants,
+    getLocalRoomAuth,
     messages,
     sendTextMessage,
     sendFileMessage,

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -3,6 +3,7 @@ import { createMcpHandler, getMcpAuthContext } from "agents/mcp/server"
 import { z } from "zod"
 
 import { buildRoomInvite } from "./invite"
+import { imageToolResult } from "./toolResults"
 import type { RoomSession } from "../do/RoomSession"
 
 const MAX_ROOM_LENGTH = 64
@@ -52,18 +53,6 @@ function toolResult(data: unknown, isError = false) {
 
 function toolError(error: string) {
   return toolResult({ error }, true)
-}
-
-function imageToolResult(
-  image: { data: string; mimeType: string },
-  metadata: unknown
-) {
-  return {
-    content: [
-      { type: "image" as const, data: image.data, mimeType: image.mimeType },
-      { type: "text" as const, text: JSON.stringify(metadata) },
-    ],
-  }
 }
 
 function encodeHandle(handle: AgentHandle): string {
@@ -786,7 +775,7 @@ function createMcpServer(context: McpRequestContext) {
         return toolError("surface_not_found")
       return imageToolResult(
         { data, mimeType: (surface as { mimeType: string }).mimeType },
-        surface
+        { surface }
       )
     }
   )

--- a/app/src/mcp/server.ts
+++ b/app/src/mcp/server.ts
@@ -138,6 +138,10 @@ async function roomControl(
 }
 
 function controlError(result: ControlResult): string {
+  if (typeof result.data.error === "string") {
+    const error = result.data.error
+    if (error.startsWith("surface_")) return error
+  }
   if (result.data.error === "room_expired") return "room_expired"
   if (result.data.error === "already_left") return "already_left"
   if (result.data.error === "wait_already_pending")
@@ -672,6 +676,118 @@ function createMcpServer(context: McpRequestContext) {
       return result.ok
         ? toolResult(result.data)
         : toolError(controlError(result))
+    }
+  )
+
+  // #111 Observable Agent Workspace v0: opt-in, Agent-only, own-surface-only
+  // ephemeral snapshot. Metadata is public room state; bytes are readable
+  // only by current participants with the exact current snapshotId.
+  const SURFACE_MIME = z.enum(["image/jpeg", "image/png", "image/webp"])
+
+  server.registerTool(
+    "publish_surface",
+    {
+      description:
+        "Publish/replace your single latest workspace snapshot image (jpeg/png/webp, ≤768KB). Explicitly participant-controlled observation — never automatic capture, never a live stream, and never authorization for anyone to control your machine. The server assigns the new snapshotId; the previous snapshot is destroyed.",
+      inputSchema: {
+        participantHandle: z.string().min(1),
+        mimeType: SURFACE_MIME,
+        dataBase64: z.string().min(1).max(1_400_000),
+      },
+    },
+    async ({ participantHandle, mimeType, dataBase64 }) => {
+      const handle = decodeHandle(participantHandle)
+      if (!handle) return toolError("invalid_participant_handle")
+      let bytes: Uint8Array<ArrayBuffer>
+      try {
+        const padded = dataBase64.replaceAll("-", "+").replaceAll("_", "/")
+        const binary = atob(padded + "=".repeat((4 - (padded.length % 4)) % 4))
+        bytes = new Uint8Array(new ArrayBuffer(binary.length))
+        for (let index = 0; index < binary.length; index += 1)
+          bytes[index] = binary.charCodeAt(index)
+      } catch {
+        return toolError("invalid_attachment")
+      }
+      const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(handle.room))
+      const response = await stub.fetch("https://room/surface", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/octet-stream",
+          "X-Surface-MimeType": mimeType,
+          "X-Room-Participant-Id": handle.participantId,
+          "X-Room-Participant-Token": handle.participantToken,
+        },
+        body: bytes,
+      })
+      const data = (await response.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+      >
+      return response.ok
+        ? toolResult(data)
+        : toolError(
+            typeof data.error === "string" ? data.error : "surface_unavailable"
+          )
+    }
+  )
+
+  server.registerTool(
+    "clear_surface",
+    {
+      description:
+        "Remove your published workspace snapshot immediately. No history is retained. Only affects your own surface.",
+      inputSchema: {
+        participantHandle: z.string().min(1),
+      },
+    },
+    async ({ participantHandle }) => {
+      const handle = decodeHandle(participantHandle)
+      if (!handle) return toolError("invalid_participant_handle")
+      const result = await roomControl(env, handle.room, {
+        action: "agent-clear-surface",
+        participantId: handle.participantId,
+        token: handle.participantToken,
+      })
+      return result.ok
+        ? toolResult(result.data)
+        : toolError(controlError(result))
+    }
+  )
+
+  server.registerTool(
+    "read_surface",
+    {
+      description:
+        "Read another CURRENT room participant's workspace snapshot on demand. Pass their participantId and the exact current snapshotId from room_info/wait_for_events metadata; a stale id returns surface_changed. Returns MCP ImageContent plus sanitized metadata. Observation only — reading grants no control over the source participant.",
+      inputSchema: {
+        participantHandle: z.string().min(1),
+        sourceParticipantId: z.string().min(1),
+        snapshotId: z.string().min(1).max(64),
+      },
+    },
+    async ({ participantHandle, sourceParticipantId, snapshotId }) => {
+      const handle = decodeHandle(participantHandle)
+      if (!handle) return toolError("invalid_participant_handle")
+      const result = await roomControl(env, handle.room, {
+        action: "agent-read-surface",
+        participantId: handle.participantId,
+        token: handle.participantToken,
+        sourceParticipantId,
+        snapshotId,
+      })
+      if (!result.ok) return toolError(controlError(result))
+      const data = result.data.data
+      const surface = result.data.surface
+      if (
+        typeof data !== "string" ||
+        !surface ||
+        typeof (surface as { mimeType?: unknown }).mimeType !== "string"
+      )
+        return toolError("surface_not_found")
+      return imageToolResult(
+        { data, mimeType: (surface as { mimeType: string }).mimeType },
+        surface
+      )
     }
   )
 

--- a/app/src/mcp/toolResults.test.ts
+++ b/app/src/mcp/toolResults.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest"
+
+import { imageToolResult } from "./toolResults"
+
+// Contract for the #111 read_surface wire shape (#111 review blocker 1):
+// the trailing text envelope must wrap metadata under `surface` so Runtime
+// clients can parse result.surface uniformly.
+describe("imageToolResult", () => {
+  it("wraps read_surface metadata under surface and keeps ImageContent first", () => {
+    const surface = {
+      kind: "workspace-snapshot",
+      snapshotId: "123e4567-e89b-42d3-a456-426614174000",
+      mimeType: "image/png",
+      size: 2048,
+      updatedAt: 42,
+    }
+    const result = imageToolResult({ data: "QUJD", mimeType: "image/png" }, { surface })
+    expect(result.content).toHaveLength(2)
+    expect(result.content[0]).toEqual({
+      type: "image",
+      data: "QUJD",
+      mimeType: "image/png",
+    })
+    expect(result.content[1].type).toBe("text")
+    expect(JSON.parse((result.content[1] as { text: string }).text)).toEqual({
+      surface,
+    })
+  })
+
+  it("serializes whatever wrapper is provided (attachment callers keep flat metadata)", () => {
+    const result = imageToolResult(
+      { data: "QQ", mimeType: "image/jpeg" },
+      { id: "att-1", fileName: "a.jpg" }
+    )
+    expect(JSON.parse((result.content[1] as { text: string }).text)).toEqual({
+      id: "att-1",
+      fileName: "a.jpg",
+    })
+  })
+})

--- a/app/src/mcp/toolResults.test.ts
+++ b/app/src/mcp/toolResults.test.ts
@@ -14,7 +14,10 @@ describe("imageToolResult", () => {
       size: 2048,
       updatedAt: 42,
     }
-    const result = imageToolResult({ data: "QUJD", mimeType: "image/png" }, { surface })
+    const result = imageToolResult(
+      { data: "QUJD", mimeType: "image/png" },
+      { surface }
+    )
     expect(result.content).toHaveLength(2)
     expect(result.content[0]).toEqual({
       type: "image",

--- a/app/src/mcp/toolResults.ts
+++ b/app/src/mcp/toolResults.ts
@@ -1,0 +1,19 @@
+// Shared MCP tool-result builders (app/src/mcp/server.ts). Kept in a tiny
+// dependency-free module so the exact wire contract is unit-testable. Return
+// types are intentionally inferred literals: the MCP framework validates
+// tool results structurally, and narrow interfaces break assignability.
+
+/** ImageContent plus a trailing text envelope. Callers pass the metadata
+ * WRAPPER they want serialized — for read_surface that is `{ surface }`, so
+ * Runtime clients can parse `result.surface` uniformly across tools. */
+export function imageToolResult(
+  image: { data: string; mimeType: string },
+  metadataWrapper: object
+) {
+  return {
+    content: [
+      { type: "image" as const, data: image.data, mimeType: image.mimeType },
+      { type: "text" as const, text: JSON.stringify(metadataWrapper) },
+    ],
+  }
+}

--- a/app/src/room/server.ts
+++ b/app/src/room/server.ts
@@ -30,6 +30,46 @@ export async function handleRoomRequest(
 ): Promise<Response> {
   if (!isAllowedOrigin(request.headers.get("Origin")))
     return json({ error: "forbidden_origin" }, 403)
+
+  // #111: Human-browser read path for Observable Agent Workspace snapshots.
+  // POST-only with participant credentials in headers (never query strings);
+  // the DO enforces membership and exact snapshotId match.
+  const pathname = new URL(request.url).pathname
+  if (pathname === "/api/room/surfaces/read") {
+    if (request.method !== "POST")
+      return json({ error: "method_not_allowed" }, 405)
+    const room = request.headers.get("X-Room-Id")?.trim() ?? ""
+    const participantId = request.headers.get("X-Room-Participant-Id") ?? ""
+    const token = request.headers.get("X-Room-Participant-Token") ?? ""
+    if (!room || room.length > MAX_ROOM_LENGTH || !participantId || !token)
+      return json({ error: "missing_room_capability" }, 400)
+    let body: { sourceParticipantId?: unknown; snapshotId?: unknown }
+    try {
+      body = (await request.json()) as typeof body
+    } catch {
+      return json({ error: "invalid_request" }, 400)
+    }
+    if (
+      typeof body.sourceParticipantId !== "string" ||
+      typeof body.snapshotId !== "string" ||
+      !body.sourceParticipantId ||
+      !body.snapshotId
+    )
+      return json({ error: "invalid_request" }, 400)
+    const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(room))
+    return stub.fetch("https://room/control", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "agent-read-surface",
+        participantId,
+        token,
+        sourceParticipantId: body.sourceParticipantId.slice(0, 64),
+        snapshotId: body.snapshotId.slice(0, 64),
+      }),
+    })
+  }
+
   if (request.method !== "POST")
     return json({ error: "method_not_allowed" }, 405)
 

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -64,7 +64,24 @@ export interface RoomParticipant {
   connectionNonce?: string
   token: string
   capabilities?: AgentCapabilities
+  // #111 Observable Agent Workspace v0: metadata for this Agent's single
+  // latest explicitly-published workspace snapshot. Metadata only — bytes
+  // live in bounded DO chunk storage under surface:* keys and are readable
+  // solely by current participants with a matching snapshotId. Opt-in,
+  // Agent-only, own-surface-only; never authorization and never history.
+  surface?: RoomSurfaceV1
   media?: RoomMediaState
+}
+
+// #111 v1 snapshot descriptor. kind is fixed; snapshotId is server-generated
+// per successful publish; mimeType is one of the three supported image
+// formats; size is byte count; updatedAt is the publish epoch ms.
+export interface RoomSurfaceV1 {
+  kind: "workspace-snapshot"
+  snapshotId: string
+  mimeType: AgentImageMimeType
+  size: number
+  updatedAt: number
 }
 
 export interface RoomMessage {

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -16,7 +16,7 @@ export default {
     if (pathname.startsWith("/api/sfu/")) {
       return handleSfuRequest(request, env)
     }
-    if (pathname === "/api/room/attachments") {
+    if (pathname === "/api/room/attachments" || pathname === "/api/room/surfaces/read") {
       return handleRoomRequest(request, env)
     }
     return handler.fetch(request, env, ctx)

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -16,7 +16,10 @@ export default {
     if (pathname.startsWith("/api/sfu/")) {
       return handleSfuRequest(request, env)
     }
-    if (pathname === "/api/room/attachments" || pathname === "/api/room/surfaces/read") {
+    if (
+      pathname === "/api/room/attachments" ||
+      pathname === "/api/room/surfaces/read"
+    ) {
       return handleRoomRequest(request, env)
     }
     return handler.fetch(request, env, ctx)

--- a/experiments/observable-agent-workspace-v0.md
+++ b/experiments/observable-agent-workspace-v0.md
@@ -1,0 +1,73 @@
+# Observable Agent Workspace v0 — acceptance experiment (#111)
+
+Ephemeral snapshot surfaces: one latest, explicitly-published workspace image
+per Agent participant. **Observation only** — not live remote desktop, not
+remote control, never automatic capture. This document describes the
+acceptance flow; no live run has been executed yet, so no success is claimed
+here.
+
+## Roles
+
+| | Machine A (publisher) | Machine B (observer) |
+| --- | --- | --- |
+| Harness | any supported Agent with a local screen/screenshot capability (its own tooling) | Human browser, or a second Agent using `surface read` |
+
+Capability isolation: the observer never receives capture credentials; the
+publisher's screenshot tooling stays entirely on Machine A.
+
+## Setup
+
+1. Provision a room via either documented variant (Agent `create` or
+   Human-created) from `phase-c-zero-human-runbook.md`.
+2. Machine A joins with an honest capability list; optionally include
+   `workspace.publish` as descriptive metadata (capability ≠ authorization;
+   the participant's own room membership is what authorizes its own surface).
+
+## Flow
+
+1. **Publish.** On Machine A, capture a screenshot with whatever local tool
+   the Harness already owns (OS shortcut, editor export, etc.) and publish:
+
+   ```bash
+   free4chat-agent surface publish --file ./workspace.png [--instance <id>]
+   ```
+
+   Output is metadata only (snapshotId/mimeType/size/updatedAt) — never base64.
+
+2. **Human observes.** In the room UI (any room type, including audio rooms),
+   the "Workspace snapshots — not live" strip shows AgentA's current snapshot
+   with explicit not-live wording. No click/type/control UI exists.
+
+3. **Replace.** Change something on A's machine, capture again, publish again.
+   The old snapshot disappears everywhere immediately (new server-generated
+   snapshotId; previous chunks deleted).
+
+4. **Peer-Agent read.** From another resident Agent:
+
+   ```bash
+   free4chat-agent surface read --participant <agent-a-participant-id>
+   ```
+
+   The command pins the CURRENT snapshotId from roster metadata, fetches those
+   exact bytes into the instance workspace (`surfaces/<snapshotId>.<ext>`),
+   and prints metadata plus the local temporary path. The file dies with the
+   instance workspace.
+
+5. **Clear / lifecycle.** `free4chat-agent surface clear` removes it at once.
+   Leaving the room, lease expiry, and room expiry also remove everything,
+   including orphan chunks.
+
+6. **Negative checks.**
+   - Publishing again within 2 seconds → `surface_rate_limited`.
+   - A 4th distinct publisher while 3 hold surfaces → `surface_capacity_exceeded`.
+   - Reading with a stale snapshotId → `surface_changed`.
+   - Non-image MIME / oversize → rejected before storage.
+
+## Acceptance checklist
+
+- [ ] Publish → Human sees current snapshot with not-live wording.
+- [ ] Replace destroys the previous state everywhere (no history).
+- [ ] Peer Agent reads exact current bytes on demand into its own workspace.
+- [ ] Clear / leave / lease expiry / room expiry remove all traces.
+- [ ] Rate limit + capacity behave as specified; failures leave prior snapshot intact.
+- [ ] No control UI anywhere; Human screen share unchanged; Agent media still subscribe-only.


### PR DESCRIPTION
Closes #111. Built on the merged #106/#109/#110 collaboration fabric.

## Wire / state schema

`RoomSurfaceV1 = { kind: "workspace-snapshot", snapshotId, mimeType: "image/jpeg"|"image/png"|"image/webp", size, updatedAt }` — at most one current surface per Agent participant, stored as sanitized metadata on `RoomParticipant.surface`. `snapshotId` is server-generated (`crypto.randomUUID()`) on every successful publish; callers cannot choose it and it is not authorization.

## DO chunk layout

Metadata only in the RoomRecord. Bytes live in bounded chunks under dedicated keys `surface:<participantId>:<snapshotId>:<chunkIndex>` (64 KiB chunks, 768 KiB max), swept by prefix at room expiry — including orphans from interrupted publishes.

## Lifecycle

Publish order: deterministic policy (`do/surface.ts`) → write NEW chunks → atomic metadata swap + `broadcastState` → best-effort deletion of previous chunks; partial-write rollback keeps the prior snapshot intact. Clear/leave/lease-expiry remove metadata+chunks with no history; room expiry removes everything. **No-wake guarantee:** surface publish/clear never append a `RoomMessage`, never move `nextMessageSequence`, never resolve agent waiters, and never touch attachments or collab artifacts (tested).

Bounds: `MAX_SURFACE_BYTES = 768 KiB`; `MAX_ACTIVE_AGENT_SURFACES = 3` — existing publishers replace at capacity, new ones get `surface_capacity_exceeded` (503); replacement inside 2 s gets `surface_rate_limited` (429); MIME/empty/mismatch rejected 400 before storage.

## Authorization

Publish/clear: authenticated Agent, own surface only. Read: any authenticated current participant with the exact current `snapshotId` — mismatch returns `surface_changed` (410), closing the TOCTOU window; unknown source/surface is `surface_not_found`. Metadata is exposed through `room_info`, the `wait_for_events` roster projection, peers output, and Harness rendering ("workspace snapshot: available"); bytes are fetched only on demand. No handles/tokens/local paths/browser URLs/window titles/capture sources ever appear on the wire.

## MCP / CLI / Runtime semantics

- MCP tools (now 15): `publish_surface(handle, mimeType, dataBase64)`, `clear_surface(handle)`, `read_surface(handle, sourceParticipantId, snapshotId)` returning ImageContent + sanitized metadata.
- Human browsers read via POST `/api/room/surfaces/read` (Origin allow-list preserved, credentials in headers — never query strings).
- Clients: `publishSurface`/`clearSurface`/`readSurface` implemented in modern + legacy clients, strict payload validation → typed errors; added to modern `REQUIRED_TOOLS`.
- Runtime passthroughs keep the handle private; daemon pins roster snapshotId before reading and writes instance-workspace files `surfaces/<snapshotId>.<ext>` (0600, removed with the workspace).
- CLI: `surface publish --file <jpeg|png|webp>`, `surface clear`, `surface read --participant <id>` — publish output is metadata only, never base64; read never accepts remote URLs or remote-chosen paths.
- Harness: roster lines gain "workspace snapshot: available"; bytes are never auto-injected and a surface update never triggers `runTurn()` (tested).

## UI

New `WorkspaceSnapshots` strip renders every visible agent's current snapshot with explicit "Workspace snapshots — not live" wording in ALL room types (audio included). One object URL per `peerId:snapshotId`, revoked on replace/remove/unmount; stale reads fail quietly until newer state arrives. Zero control UI. Human `getDisplayMedia`/live screen share behavior untouched; agent media remains subscribe-only.

## Unchanged by design

Generic attachments and collab `attachmentIds` are separate systems; surfaces can't be referenced there. Message sequence, chat, Meeting Notes/Pion boundaries, and subscribe-only agent media are unchanged.

## Tests & gates

Deterministic suites only: `do/surface.test.ts` policy matrix (MIME, empty/oversize/mismatch, throttle boundary, capacity 3 + replace-at-capacity, chunkCount, storage sanitize); roster surface exposure; client envelope + malformed-payload typed-error tests (modern); no-wake round-trip lifecycle (publish → roster visible → exact-bytes read → stale rejected → clear) plus full #109/#110 regression suites. **agent-runtime 125/125** (format:check/lint/tsc/build/pack:check green); **app 182/182 vitest**, prettier/eslint/tsc green, `cf-build` Worker bundle green.

## Experiment instructions

`experiments/observable-agent-workspace-v0.md`: two-machine flow (Agent publishes via CLI after capturing with its own local tooling; Human observes the not-live strip; peer Agent reads exact bytes into its workspace; negative checks for throttle/capacity/stale ids). **Not executed yet — no success claimed.**

## Release sequence (documented, not executed)

Source bumped to semver-minor **0.4.0** (package.json/lockfile/bootstrap pin/pinned tests/agent.md npx examples). Post-merge order: publish `pion-v0.4.0` release assets first, then tag `agent-runtime-v0.4.0` → npm Trusted Publishing. Nothing published/tagged/deployed from this PR. (0.3.0 gate was verified satisfied before this work began.)

## Explicit non-goals

Pion TrackLocal/outbound RTP, ffmpeg/OS capture, Playwright capture here, continuous/scheduled capture, mouse/keyboard control, VNC/RDP, browser-control RPC, remote shell, planner/DAG/scheduler/task DB, R2/D1/new KV, history/recording, multiple named surfaces, public URLs, global discovery, Voice/TTS — none included, none required.