### PR TITLE
feat(#113): Human-originated Agent work requests

### DIFF
--- a/agent-runtime/test/collab.test.ts
+++ b/agent-runtime/test/collab.test.ts
@@ -753,6 +753,9 @@ class FakeRoomServer {
   ): { requestId: string; sequence: number; duplicate?: boolean } {
     if (!this.participants.has(args.targetParticipantId))
       throw new Error("target_not_in_room")
+    // DO parity (#113 review): referenced attachments must exist at send time.
+    for (const id of args.attachmentIds ?? [])
+      if (!this.attachments.has(id)) throw new Error("unknown_attachment")
     const requestId = args.requestId ?? randomUUID()
     const existing = this.requests.get(requestId)
     if (existing)
@@ -1479,4 +1482,99 @@ test("#113 non-target agent receives no addressed work turn from a Human request
     bCollab.every((event) => event.addressed === true),
     true
   )
+})
+
+test("#113 Agent->Agent request preserves details and attachmentIds through the canonical message and addressed event; duplicate appends nothing; Human wire path has no such fields", async () => {
+  const server = new FakeRoomServer()
+  const bTurns: HarnessTurnInput[] = []
+  let seenByB: RoomEvent["collab"] | undefined
+
+  // Requester A must be a current participant before referencing artifacts.
+  server.join("agent-a", "Agent A", ["code.edit", "github"])
+
+  const runtimeB = new ResidentRoomRuntime({
+    instanceId: "inst-preserve-b",
+    roomId: server.roomId,
+    name: "Agent B",
+    client: clientFor(server, "agent-b"),
+    adapter: {
+      name: "hermes",
+      async ensureSession() {},
+      async runTurn(input) {
+        bTurns.push(input)
+        const request = input.events.find(
+          (event) => event.collab?.kind === "request"
+        )?.collab
+        if (request) {
+          seenByB = request
+          return { text: "on it" }
+        }
+        return { text: "idle" }
+      },
+      async close() {},
+    },
+  })
+  try {
+    await runtimeB.start()
+
+    // A uploads an artifact FIRST so the reference is valid at send time.
+    await clientFor(server, "agent-a").uploadAttachment("handle-a", {
+      fileName: "context.json",
+      mimeType: "application/json",
+      dataBase64: "e30=",
+    })
+
+    const sent = await clientFor(server, "agent-a").sendCollabRequest("h", {
+      targetParticipantId: "agent-b",
+      summary: "Check the production flow",
+      details: { environment: "production" },
+      attachmentIds: ["att-1"],
+    })
+    assert.ok(sent.requestId)
+
+    await settle(() => Boolean(seenByB))
+
+    // Canonical RoomMessage keeps BOTH optional fields verbatim.
+    const canonical = server.messages.find((m) => m.collab?.kind === "request")!
+    assert.equal(canonical.collab.details?.environment, "production")
+    assert.deepEqual(canonical.collab.attachmentIds, ["att-1"])
+
+    // B's ADDRESSED RoomEvent preserves BOTH (the #109 production regression).
+    assert.equal(seenByB!.details?.environment, "production")
+    assert.deepEqual(seenByB!.attachmentIds, ["att-1"])
+    assert.equal(seenByB!.fromParticipantId, "agent-a")
+
+    // Duplicate retry with identical payload appends zero additional messages.
+    const before = server.messages.length
+    await clientFor(server, "agent-a").sendCollabRequest("h", {
+      targetParticipantId: "agent-b",
+      summary: "Check the production flow",
+      requestId: sent.requestId,
+      details: { environment: "production" },
+      attachmentIds: ["att-1"],
+    })
+    assert.equal(server.messages.length, before)
+
+    // Human WS v0 path carries ONLY requestId/target/summary by construction —
+    // humanRequest() has no details/attachmentIds parameters, and the resulting
+    // collab envelope must not grow them.
+    server.join("human-a", "Alice", undefined, "human")
+    const humanSent = server.humanRequest(
+      "human-a",
+      "agent-b",
+      "please verify",
+      "req-human-flat"
+    )
+    assert.equal(humanSent.ok, true)
+    const humanEnvelope = JSON.parse(
+      JSON.stringify(
+        server.messages.find((m) => m.collab?.requestId === "req-human-flat")!
+          .collab
+      )
+    )
+    assert.equal("details" in humanEnvelope, false)
+    assert.equal("attachmentIds" in humanEnvelope, false)
+  } finally {
+    await runtimeB.stop()
+  }
 })

--- a/agent-runtime/test/collab.test.ts
+++ b/agent-runtime/test/collab.test.ts
@@ -595,13 +595,59 @@ class FakeRoomServer {
     return surface
   }
 
-  join(participantId: string, name: string, capabilities?: string[]): number {
+  join(
+    participantId: string,
+    name: string,
+    capabilities?: string[],
+    kind: "human" | "agent" = "agent"
+  ): number {
     this.participants.set(participantId, {
       name,
-      kind: "agent",
-      ...(capabilities ? { capabilities } : {}),
+      kind,
+      ...(kind === "agent" && capabilities ? { capabilities } : {}),
     })
     return this.sequence
+  }
+
+  /** #113: mirrors the DO's Human-originated request ingestion. */
+  humanRequest(
+    fromHumanId: string,
+    targetParticipantId: string,
+    summary: string,
+    requestId?: string
+  ): { ok: boolean; error?: string; requestId?: string; sequence?: number } {
+    const sender = this.participants.get(fromHumanId)
+    if (!sender || sender.kind !== "human")
+      return { ok: false, error: "collab_sender_not_human" }
+    const target = this.participants.get(targetParticipantId)
+    if (!target || target.kind !== "agent")
+      return { ok: false, error: "collab_target_not_agent" }
+    const trimmed = summary.trim()
+    if (!trimmed) return { ok: false, error: "summary_required" }
+    const id = requestId ?? `human-req-${++this.surfaceCounter}`
+    const existing = this.requests.get(id)
+    if (existing) return { ok: true, requestId: id }
+    const sequence = this.append({
+      peerId: fromHumanId,
+      kind: "human",
+      name: sender.name,
+      type: "action",
+      actionType: "collab",
+      collab: {
+        requestId: id,
+        kind: "request",
+        fromParticipantId: fromHumanId,
+        targetParticipantId,
+        summary: trimmed,
+      },
+      targets: [targetParticipantId],
+    })
+    this.requests.set(id, {
+      from: fromHumanId,
+      target: targetParticipantId,
+      seen: new Map([["request", sequence]]),
+    })
+    return { ok: true, requestId: id, sequence }
   }
 
   /** Mirrors the DO's create-only gate: any pre-existing state fails closed. */
@@ -1283,3 +1329,154 @@ test("workspace surface: publish/clear/read round-trip with NO harness wake and 
 function expectLike(value: unknown, pattern: RegExp): void {
   assert.equal(typeof value === "string" && pattern.test(value), true)
 }
+
+test("#113 Human -> Agent structured request: addressed wake, accept/completed correlation, dedup, wrong-agent rejection, rebuild", async () => {
+  const server = new FakeRoomServer()
+  const bTurns: HarnessTurnInput[] = []
+  let humanRequestSeen: RoomEvent["collab"] | undefined
+
+  // Agent B resident; Human Alice and a bystander Agent C in the same room.
+  const runtimeB = new ResidentRoomRuntime({
+    instanceId: "inst-h113-b",
+    roomId: server.roomId,
+    name: "Agent B",
+    client: clientFor(server, "agent-b"),
+    adapter: {
+      name: "hermes",
+      async ensureSession() {},
+      async runTurn(input) {
+        bTurns.push(input)
+        const request = input.events.find(
+          (event) => event.collab?.kind === "request"
+        )?.collab
+        if (request) {
+          humanRequestSeen = request
+          await runtimeBRef!.collabResponse(request.requestId, "accepted")
+          const uploaded = await runtimeBRef!.uploadAttachment({
+            fileName: "dashboard.png",
+            mimeType: "image/png",
+            dataBase64: "QUJD",
+          })
+          await runtimeBRef!.collabResult({
+            requestId: request.requestId,
+            status: "completed",
+            summary: "Dashboard loads; console clean.",
+            attachmentIds: [uploaded.id],
+          })
+          return { text: "done" }
+        }
+        return { text: "idle" }
+      },
+      async close() {},
+    },
+    capabilities: ["browser.control", "browser.authenticated"],
+  })
+  let runtimeBRef: ResidentRoomRuntime | null = null
+  runtimeBRef = runtimeB
+
+  server.join("human-a", "Alice", undefined, "human")
+  server.join("agent-c", "Agent C", ["shell"])
+  await runtimeB.start()
+
+  // Human-originated structured request (sender = authenticated human).
+  const sent = server.humanRequest(
+    "human-a",
+    "agent-b",
+    "Open production and verify the signed-in dashboard loads without console errors.",
+    "req-human-1"
+  )
+  assert.equal(sent.ok, true)
+
+  await settle(() => humanRequestSeen !== undefined)
+  // The accepted/completed lifecycle routes back toward the HUMAN requester;
+  // observe it from the canonical message log.
+  await settle(() =>
+    server.messages.some(
+      (m) =>
+        m.collab?.requestId === "req-human-1" && m.collab.kind === "completed"
+    )
+  )
+  await runtimeB.stop()
+
+  // Addressed work turn identifies the HUMAN sender.
+  assert.ok(humanRequestSeen)
+  assert.equal(humanRequestSeen.fromParticipantId, "human-a")
+
+  const completedMessage = server.messages.find(
+    (m) =>
+      m.collab?.kind === "completed" && m.collab.requestId === "req-human-1"
+  )!
+  assert.equal(completedMessage.collab.targetParticipantId, "human-a")
+  assert.deepEqual(completedMessage.collab.attachmentIds, ["att-1"])
+  assert.equal(completedMessage.targets[0], "human-a")
+
+  // Exactly ONE message appended for the request; sequence advanced once by it.
+  const requestMessages = server.messages.filter(
+    (message) =>
+      message.type === "action" &&
+      message.collab?.requestId === "req-human-1" &&
+      message.collab.kind === "request"
+  )
+  assert.equal(requestMessages.length, 1)
+  assert.equal(requestMessages[0].peerId, "human-a")
+  assert.equal(requestMessages[0].kind, "human")
+  assert.deepEqual(requestMessages[0].targets, ["agent-b"])
+
+  // Duplicate requestId creates no second message.
+  const before = server.messages.length
+  const retry = server.humanRequest(
+    "human-a",
+    "agent-b",
+    "Open production and verify the signed-in dashboard loads without console errors.",
+    "req-human-1"
+  )
+  assert.equal(retry.ok, true)
+  assert.equal(server.messages.length, before)
+
+  // Wrong agent cannot respond to the Human's request.
+  const impostor = clientFor(server, "agent-c").sendCollabResponse as never
+  void impostor
+  const respond = () => server.respond("agent-c", "req-human-1", "declined", {})
+  assert.throws(respond, /not_request_target/)
+
+  // Rebuild from bounded room.messages restores Human -> Agent routing.
+  server.restart()
+  assert.throws(
+    () => server.respond("agent-b", "req-human-1", "failed", {}),
+    /unknown_request/
+  )
+  server.recoverCorrelationFromMessages()
+  const late = server.respond("agent-b", "req-human-1", "failed", {})
+  assert.ok(late.sequence > before)
+})
+
+test("#113 non-target agent receives no addressed work turn from a Human request", async () => {
+  const server = new FakeRoomServer()
+  server.join("human-a", "Alice", undefined, "human")
+  server.join("agent-b", "Agent B")
+  server.join("agent-c", "Agent C")
+
+  const sent = server.humanRequest(
+    "human-a",
+    "agent-b",
+    "please check the page",
+    "req-solo-1"
+  )
+  assert.equal(sent.ok, true)
+
+  const cView = server.deliver("agent-c", 0)
+  const cCollab = cView.events.filter((event) => event.collab)
+  assert.equal(cCollab.length > 0, true)
+  assert.equal(
+    cCollab.every((event) => event.addressed === false),
+    true
+  )
+
+  const bView = server.deliver("agent-b", 0)
+  const bCollab = bView.events.filter((event) => event.collab)
+  assert.equal(bCollab.length > 0, true)
+  assert.equal(
+    bCollab.every((event) => event.addressed === true),
+    true
+  )
+})

--- a/app/src/components/AgentWorkRequestComposer.test.tsx
+++ b/app/src/components/AgentWorkRequestComposer.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import AgentWorkRequestComposer from "./AgentWorkRequestComposer"
+
+const base = {
+  agentName: "Agent B",
+  capabilities: ["browser.control", "browser.authenticated"],
+  maxLength: 1200,
+}
+
+describe("AgentWorkRequestComposer (#113)", () => {
+  it("shows agent name, capability chips as metadata, and the explanatory copy", () => {
+    render(
+      <AgentWorkRequestComposer
+        {...base}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Request work from Agent B/)).toBeTruthy()
+    expect(screen.getByText("browser.control")).toBeTruthy()
+    expect(
+      screen.getByText(
+        /The Agent may accept or decline\. This request does not grant new permissions\./
+      )
+    ).toBeTruthy()
+  })
+
+  it("disables Send for empty/whitespace summaries and enables with content", () => {
+    const onSubmit = vi.fn()
+    render(
+      <AgentWorkRequestComposer
+        {...base}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+    const send = screen.getByText("Send request") as HTMLButtonElement
+    expect(send.disabled).toBe(true)
+    fireEvent.change(
+      screen.getByPlaceholderText("What would you like this Agent to do?"),
+      {
+        target: { value: "   " },
+      }
+    )
+    expect(
+      (screen.getByText("Send request") as HTMLButtonElement).disabled
+    ).toBe(true)
+    fireEvent.change(
+      screen.getByPlaceholderText("What would you like this Agent to do?"),
+      {
+        target: { value: "Verify the dashboard" },
+      }
+    )
+    const enabled = screen.getByText("Send request") as HTMLButtonElement
+    expect(enabled.disabled).toBe(false)
+    fireEvent.click(enabled)
+    expect(onSubmit).toHaveBeenCalledWith("Verify the dashboard")
+  })
+
+  it("bounds input to maxLength and reports length", () => {
+    render(
+      <AgentWorkRequestComposer
+        {...base}
+        maxLength={10}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+    const field = screen.getByPlaceholderText(
+      "What would you like this Agent to do?"
+    ) as HTMLTextAreaElement
+    fireEvent.change(field, { target: { value: "a".repeat(50) } })
+    expect(field.value.length).toBe(10)
+    expect(screen.getByText("10/10")).toBeTruthy()
+  })
+
+  it("Cancel invokes onCancel without submitting", () => {
+    const onCancel = vi.fn()
+    const onSubmit = vi.fn()
+    render(
+      <AgentWorkRequestComposer
+        {...base}
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+      />
+    )
+    fireEvent.click(screen.getByText("Cancel"))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/components/AgentWorkRequestComposer.tsx
+++ b/app/src/components/AgentWorkRequestComposer.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react"
+
+interface AgentWorkRequestComposerProps {
+  agentName: string
+  capabilities?: string[]
+  maxLength: number
+  onCancel: () => void
+  onSubmit: (summary: string) => void
+}
+
+/**
+ * #113: Human → Agent structured work request composer. Deliberately tiny:
+ * one bounded summary field. The Agent may accept or decline; submitting
+ * grants no new permissions and never invokes the Agent's tools directly.
+ */
+export default function AgentWorkRequestComposer({
+  agentName,
+  capabilities = [],
+  maxLength,
+  onCancel,
+  onSubmit,
+}: AgentWorkRequestComposerProps) {
+  const [summary, setSummary] = useState("")
+  const trimmed = summary.trim()
+  const canSend = trimmed.length > 0
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="w-full max-w-md rounded-xl border border-gray-700 bg-gray-900 p-4">
+        <h3 className="text-sm font-medium text-white">
+          Request work from {agentName}
+        </h3>
+        {capabilities.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {capabilities.map((capability) => (
+              <span
+                key={capability}
+                className="rounded-full bg-black/30 px-2 py-0.5 text-[10px] text-white/70"
+              >
+                {capability}
+              </span>
+            ))}
+          </div>
+        )}
+        <textarea
+          autoFocus
+          value={summary}
+          onChange={(event) =>
+            setSummary(event.target.value.slice(0, maxLength))
+          }
+          placeholder="What would you like this Agent to do?"
+          className="mt-3 h-24 w-full resize-none rounded-lg border border-gray-700 bg-black/40 px-3 py-2 text-sm text-white placeholder:text-gray-500"
+        />
+        <p className="mt-1 text-right text-[10px] text-gray-500">
+          {summary.length}/{maxLength}
+        </p>
+        <p className="mt-2 text-[11px] leading-snug text-gray-400">
+          The Agent may accept or decline. This request does not grant new
+          permissions.
+        </p>
+        <div className="mt-3 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-gray-600 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canSend}
+            onClick={() => canSend && onSubmit(trimmed)}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium ${
+              canSend
+                ? "bg-blue-600 text-white hover:bg-blue-500"
+                : "cursor-not-allowed bg-gray-700 text-gray-400"
+            }`}
+          >
+            Send request
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -3,11 +3,14 @@ import React, { useState, useEffect, useRef, useCallback } from "react"
 import { useRouter } from "next/router"
 
 import { LOCAL_PEER_ID } from "@common/consts"
+import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
 
+import AgentWorkRequestComposer from "./AgentWorkRequestComposer"
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
 import WorkspaceSnapshots from "./WorkspaceSnapshots"
 import { buildAgentInvitePrompt } from "../common/agentInvite"
+import type { UserInfo } from "../common/types"
 import {
   umamiEvent,
   trackAnalyticsEvent,
@@ -124,6 +127,7 @@ export default function RoomContent({
     sendTextMessage,
     sendFileMessage,
     sendActionMessage,
+    sendCollabRequest,
     muteSelf,
     toggleScreenShare,
     retryVerification,
@@ -139,6 +143,16 @@ export default function RoomContent({
   })
 
   const screenshareAllowed = resolvedRoomType === "screenshare"
+
+  // #113: Human → Agent structured work request entry point. The callback is
+  // passed ONLY for remote connected Agents; Humans and self never get it.
+  const [workRequestTarget, setWorkRequestTarget] = useState<UserInfo | null>(
+    null
+  )
+  const requestWorkFor = (p: UserInfo) =>
+    setWorkRequestTarget(
+      p.kind === "agent" && p.peerId !== LOCAL_PEER_ID ? p : null
+    )
 
   const roomAgents = participants.filter((p) => p.kind === "agent")
   const meetingNotesAgentName = meetingNotes.active
@@ -661,6 +675,7 @@ export default function RoomContent({
                         onMuteSelf={muteSelf}
                         onToggleScreenShare={wrappedToggleScreenShare}
                         screenshareAllowed={screenshareAllowed}
+                        onRequestWork={() => requestWorkFor(p)}
                         className="w-20"
                         compact
                       />
@@ -686,6 +701,7 @@ export default function RoomContent({
                       screenShareEnabled={p.screenShareEnabled}
                       onMuteSelf={muteSelf}
                       onToggleScreenShare={wrappedToggleScreenShare}
+                      onRequestWork={() => requestWorkFor(p)}
                       screenshareAllowed={screenshareAllowed}
                       className="w-40 flex-none"
                     />
@@ -741,6 +757,19 @@ export default function RoomContent({
           />
         </div>
       </div>
+
+      {workRequestTarget && (
+        <AgentWorkRequestComposer
+          agentName={workRequestTarget.name}
+          capabilities={workRequestTarget.capabilities}
+          maxLength={MAX_COLLAB_SUMMARY_LENGTH}
+          onCancel={() => setWorkRequestTarget(null)}
+          onSubmit={(summary) => {
+            sendCollabRequest(workRequestTarget.peerId, summary)
+            setWorkRequestTarget(null)
+          }}
+        />
+      )}
     </main>
   )
 }

--- a/app/src/components/UserCard.request-work.test.tsx
+++ b/app/src/components/UserCard.request-work.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import UserCard from "./UserCard"
+
+function base(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "Agent B",
+    kind: "agent" as const,
+    room: "room",
+    peerId: "agent-b",
+    onRequestWork: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe("UserCard Request work entry (#113)", () => {
+  it("shows Request work for a remote Agent when the callback is provided", () => {
+    const { getByText } = render(<UserCard {...base()} />)
+    expect(getByText("Request work")).toBeTruthy()
+  })
+
+  it("never shows Request work for Humans", () => {
+    const { queryByText } = render(
+      <UserCard
+        {...base({ name: "Alice", kind: "human", peerId: "human-1" })}
+      />
+    )
+    expect(queryByText("Request work")).toBeNull()
+  })
+
+  it("never shows Request work for the local self card", () => {
+    const { queryByText } = render(
+      <UserCard {...base({ peerId: "local-peer" })} />
+    )
+    expect(queryByText("Request work")).toBeNull()
+  })
+
+  it("compact layout still provides the action for remote Agents", () => {
+    const onRequestWork = vi.fn()
+    const { getByText } = render(
+      <UserCard {...base({ compact: true })} onRequestWork={onRequestWork} />
+    )
+    fireEvent.click(getByText("Request work"))
+    expect(onRequestWork).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -13,6 +13,9 @@ interface UserCardProps extends UserInfo {
   onToggleScreenShare?: () => void
   screenshareAllowed?: boolean
   compact?: boolean
+  /** #113: present only for REMOTE connected Agents — enables the Human
+   * "Request work" entry point. Never rendered for Humans or self. */
+  onRequestWork?: () => void
 }
 
 export default function UserCard(user: UserCardProps) {
@@ -92,6 +95,15 @@ export default function UserCard(user: UserCardProps) {
             <span className="mt-1 rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
               🤖 Agent
             </span>
+          )}
+          {user.kind === "agent" && user.onRequestWork && !isSelf && (
+            <button
+              type="button"
+              onClick={user.onRequestWork}
+              className="mt-1 rounded-full bg-blue-600/80 px-2 py-0.5 text-[9px] text-white hover:bg-blue-500"
+            >
+              Request work
+            </button>
           )}
           {isSelf && (
             <div className="mt-1 flex gap-1">
@@ -245,6 +257,15 @@ export default function UserCard(user: UserCardProps) {
             <span className="rounded-full bg-black/30 px-1.5 py-0.5 text-[9px] text-white/70">
               +{(user.capabilities?.length ?? 0) - 3}
             </span>
+          )}
+          {user.kind === "agent" && user.onRequestWork && !isSelf && (
+            <button
+              type="button"
+              onClick={user.onRequestWork}
+              className="rounded-full bg-blue-600/80 px-2 py-0.5 text-[10px] text-white hover:bg-blue-500"
+            >
+              Request work
+            </button>
           )}
         </div>
 

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -1369,6 +1369,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
             requestId?: unknown
             targetParticipantId?: unknown
             summary?: unknown
+            details?: unknown
+            attachmentIds?: unknown
           }
         )
         if (ingest.status === "rejected")
@@ -1904,6 +1906,11 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       requestId?: unknown
       targetParticipantId?: unknown
       summary?: unknown
+      // Agent-originated requests may carry bounded details and references
+      // to existing room attachments; validateCollabEvent preserves both on
+      // the canonical event. The Human WS path never supplies them.
+      details?: unknown
+      attachmentIds?: unknown
     }
   ): Promise<
     | {

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -48,6 +48,7 @@ import type {
   RoomState,
   ParticipantKind,
   RoomSurfaceV1,
+  CollabEvent,
 } from "../room/types"
 
 const RECONNECT_GRACE_MS = 30 * 1000
@@ -286,6 +287,15 @@ type ClientMessage =
       type: "action"
       actionType: string
       actionPayload?: Record<string, string>
+    }
+  | {
+      // #113: Human-originated structured work request. Sender identity is
+      // derived from the authenticated WebSocket attachment, never the
+      // payload. Same CollabEvent/CollabRegistry path as Agent→Agent.
+      type: "collab-request"
+      requestId: string
+      targetParticipantId: string
+      summary: string
     }
   | { type: "mute"; muted: boolean }
   | { type: "unpublish"; trackName: string }
@@ -1346,12 +1356,37 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (participant.kind !== "agent")
         return this.json({ error: "agent_only" }, 403)
       participant.lastSeenAt = Date.now()
+      const eventInput = request.event ?? {}
+      const eventKind = (eventInput as { kind?: unknown }).kind
+
+      // #113: REQUESTS share one ingestion path with Human-originated
+      // requests (validate → registry dedup → append → broadcast → waiters).
+      if (eventKind === "request") {
+        const ingest = await this.ingestCollabWorkRequest(
+          room,
+          participant,
+          eventInput as {
+            requestId?: unknown
+            targetParticipantId?: unknown
+            summary?: unknown
+          }
+        )
+        if (ingest.status === "rejected")
+          return this.json({ error: ingest.error }, 400)
+        return this.json({
+          requestId: ingest.event.requestId,
+          sequence: ingest.sequence,
+          ...(ingest.status === "duplicate" ? { duplicate: true } : {}),
+          expiresAt: room.expiresAt,
+        })
+      }
+
       // Restore correlation state from the durable log first (no-op after
       // the first call in this DO instance's lifetime) so late responses and
       // retried sends stay correct even after an eviction/restart.
       this.warmCollabRegistry(room)
       const validated = validateCollabEvent(
-        request.event ?? {},
+        eventInput,
         {
           senderParticipantId: participant.id,
           participants: room.participants,
@@ -1363,48 +1398,32 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         return this.json({ error: validated.error }, 400)
 
       let event = validated.event
-      if (event.kind === "request") {
-        const outcome = this.collabRegistry.recordRequest(
-          event,
-          room.nextMessageSequence + 1
-        )
-        // Retried send (same requestId): report the original append instead
-        // of creating a second, double-execution-inducing event.
-        if (outcome.action === "duplicate")
-          return this.json({
-            requestId: event.requestId,
-            duplicate: true,
-            sequence: outcome.sequence,
-            expiresAt: room.expiresAt,
-          })
-      } else {
-        // Idempotency is decided BEFORE any append/wake: a retried identical
-        // response/result returns the original sequence without producing a
-        // second event.
-        const precheck = this.collabRegistry.precheckResponse(
-          event.requestId,
-          event.kind,
-          participant.id
-        )
-        if (precheck.action === "rejected")
-          return this.json({ error: precheck.error }, 403)
-        if (precheck.action === "duplicate")
-          return this.json({
-            requestId: event.requestId,
-            duplicate: true,
-            sequence: precheck.sequence,
-            expiresAt: room.expiresAt,
-          })
-        const routing = this.collabRegistry.routingFor(
-          event.requestId,
-          participant.id
-        )
-        if (!routing) return this.json({ error: "unknown_request" }, 403)
-        event = {
-          ...event,
-          fromParticipantId: routing.fromParticipantId,
-          targetParticipantId: routing.targetParticipantId,
-        }
+      // Idempotency is decided BEFORE any append/wake: a retried identical
+      // response/result returns the original sequence without producing a
+      // second event.
+      const precheck = this.collabRegistry.precheckResponse(
+        event.requestId,
+        event.kind,
+        participant.id
+      )
+      if (precheck.action === "rejected")
+        return this.json({ error: precheck.error }, 403)
+      if (precheck.action === "duplicate")
+        return this.json({
+          requestId: event.requestId,
+          duplicate: true,
+          sequence: precheck.sequence,
+          expiresAt: room.expiresAt,
+        })
+      const routing = this.collabRegistry.routingFor(
+        event.requestId,
+        participant.id
+      )
+      if (!routing) return this.json({ error: "unknown_request" }, 403)
+      event = {
+        ...event,
+        fromParticipantId: routing.fromParticipantId,
+        targetParticipantId: routing.targetParticipantId,
       }
 
       const roomMessage = this.appendMessage(room, {
@@ -1421,12 +1440,11 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
             : undefined,
         createdAt: Date.now(),
       })
-      if (event.kind !== "request")
-        this.collabRegistry.commitResponse(
-          event.requestId,
-          event.kind,
-          roomMessage.sequence
-        )
+      this.collabRegistry.commitResponse(
+        event.requestId,
+        event.kind,
+        roomMessage.sequence
+      )
       await this.saveRoom(room)
       await this.scheduleNextAlarm(room)
       await this.broadcast({ type: "message", message: roomMessage })
@@ -1873,6 +1891,79 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     return this.json({ ok: true })
   }
 
+  // #113 shared request ingestion: Agent→Agent and Human→Agent work
+  // requests take the identical validate → registry dedup (BEFORE any
+  // append) → append → persist → broadcast → waiter-delivery path. The
+  // sender is whichever authenticated participant the caller resolved; the
+  // registry records fromParticipantId from that sender so Agent responses
+  // correlate back to Human requesters exactly as they do for Agents.
+  private async ingestCollabWorkRequest(
+    room: RoomRecord,
+    sender: RoomParticipant,
+    input: {
+      requestId?: unknown
+      targetParticipantId?: unknown
+      summary?: unknown
+    }
+  ): Promise<
+    | {
+        status: "recorded" | "duplicate"
+        sequence: number
+        event: CollabEvent
+      }
+    | { status: "rejected"; error: string }
+  > {
+    this.warmCollabRegistry(room)
+    const validated = validateCollabEvent(
+      { kind: "request", ...input },
+      {
+        senderParticipantId: sender.id,
+        participants: room.participants,
+        attachments: room.attachments,
+      },
+      { generateRequestId: () => crypto.randomUUID() }
+    )
+    if (validated.ok === false)
+      return { status: "rejected", error: validated.error }
+    const outcome = this.collabRegistry.recordRequest(
+      validated.event,
+      room.nextMessageSequence + 1
+    )
+    // Retried send (same requestId): report the original append instead of
+    // creating a second, double-execution-inducing event.
+    if (outcome.action === "duplicate")
+      return {
+        status: "duplicate",
+        sequence: outcome.sequence,
+        event: validated.event,
+      }
+    const roomMessage = this.appendMessage(room, {
+      id: crypto.randomUUID(),
+      peerId: sender.id,
+      name: sender.name,
+      kind: sender.kind,
+      type: "action",
+      actionType: COLLAB_ACTION_TYPE,
+      collab: validated.event,
+      targets:
+        validated.event.targetParticipantId !== sender.id
+          ? [validated.event.targetParticipantId]
+          : undefined,
+      createdAt: Date.now(),
+    })
+    await this.saveRoom(room)
+    await this.scheduleNextAlarm(room)
+    await this.broadcast({ type: "message", message: roomMessage })
+    // Addressed-event semantics unchanged: only the targeted resident
+    // Runtime wakes; other Agents see a non-addressed context event.
+    this.resolveAgentWaiters(room)
+    return {
+      status: "recorded",
+      sequence: roomMessage.sequence,
+      event: validated.event,
+    }
+  }
+
   private async handleClientMessage(
     socket: WebSocket,
     attachment: ConnectionAttachment,
@@ -1999,6 +2090,42 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       await this.scheduleNextAlarm(room)
       await this.broadcastState(room)
       await this.attemptCleanupNow(room.pendingMediaCleanup)
+      return
+    }
+
+    // #113: Human-originated structured work request. The sender is the
+    // authenticated WebSocket attachment — payload never carries identity.
+    if (message.type === "collab-request") {
+      const reject = (error: string) =>
+        socket.send(JSON.stringify({ type: "error", error }))
+      if (participant.kind !== "human") {
+        reject("collab_sender_not_human")
+        return
+      }
+      const target = room.participants[message.targetParticipantId] ?? null
+      if (!target || !target.connected) {
+        reject("collab_target_not_in_room")
+        return
+      }
+      if (target.kind !== "agent") {
+        reject("collab_target_not_agent")
+        return
+      }
+      const ingest = await this.ingestCollabWorkRequest(room, participant, {
+        requestId: message.requestId,
+        targetParticipantId: message.targetParticipantId,
+        summary: message.summary,
+      })
+      if (ingest.status === "rejected") {
+        reject(ingest.error)
+        return
+      }
+      if (ingest.status === "duplicate") {
+        reject("collab_duplicate_request_id")
+        return
+      }
+      // The canonical RoomMessage was already broadcast; the Human UI learns
+      // of it through the ordinary message path (no optimistic echo here).
       return
     }
 

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { LOCAL_PEER_ID } from "@common/consts"
 import { mergeRoomAndEphemeralMessages } from "@common/messageReconciliation"
 import { ActionType, Message, UserInfo } from "@common/types"
+import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
 
 import type {
   SfuMeetingNotesState,
@@ -1377,6 +1378,32 @@ export function useSfuChatRoom(
     [sendSocketMessage]
   )
 
+  // #113: Human-originated structured work request to a connected Agent.
+  // Returns the generated requestId (empty string when rejected locally).
+  // The canonical RoomMessage arrives via the ordinary broadcast — no
+  // optimistic echo here.
+  const sendCollabRequest = useCallback(
+    (targetParticipantId: string, summary: string): string => {
+      const trimmed = summary.trim()
+      if (
+        !targetParticipantId ||
+        !trimmed ||
+        trimmed.length > MAX_COLLAB_SUMMARY_LENGTH
+      )
+        return ""
+      if (websocketRef.current?.readyState !== WebSocket.OPEN) return ""
+      const requestId = crypto.randomUUID()
+      sendSocketMessage({
+        type: "collab-request",
+        requestId,
+        targetParticipantId,
+        summary: trimmed,
+      })
+      return requestId
+    },
+    [sendSocketMessage]
+  )
+
   const startMeetingNotes = useCallback(
     (agentParticipantId: string) => {
       sendSocketMessage({
@@ -1510,6 +1537,7 @@ export function useSfuChatRoom(
     sendTextMessage,
     sendFileMessage,
     sendActionMessage,
+    sendCollabRequest,
     muteSelf,
     toggleScreenShare,
     retryVerification,

--- a/experiments/human-agent-structured-request.md
+++ b/experiments/human-agent-structured-request.md
@@ -1,0 +1,41 @@
+# Human → Agent structured collaboration requests (#113)
+
+Shortest path closing #106's "Human or Agent may originate a request": the
+browser gains one WS message and a tiny composer; everything downstream is
+the existing collab fabric.
+
+## Flow
+
+```text
+Human (browser) —selects resident Agent B—
+  { type: "collab-request", requestId, targetParticipantId, summary }
+→ RoomSession validates via validateCollabEvent (human sender from the
+  authenticated attachment; target must be a CONNECTED agent)
+→ CollabRegistry records human → agent correlation (dedup BEFORE append)
+→ ONE action/collab RoomMessage, targets=[B]
+→ B's resident Runtime wakes with an addressed COLLABORATION WORK TURN
+→ B decides accept/decline; performs local work with its own capabilities
+→ accepted / declined / completed / failed correlate back to the Human
+→ existing lifecycle cards render in the chat timeline
+```
+
+## Boundary
+
+Request ≠ permission. Capability ≠ authorization. Free4Chat never invokes
+B's tools, never holds B's credentials, never approves B's actions. The
+Agent's own Harness policy decides everything. Sender identity always comes
+from the authenticated WebSocket attachment; requestId is correlation only.
+
+## Persistence
+
+Room messages + in-memory CollabRegistry only. DO eviction/restart rebuilds
+Human→Agent correlation from the bounded log exactly like Agent→Agent;
+outside the horizon, responses fail closed as unknown_request.
+
+## Experiment sketch
+
+Two machines: Human browser + one resident Agent (e.g., Hermes with browser
+capability). Human sends "Open production and verify the signed-in dashboard
+loads without console errors." Accept → screenshot via surface publish or
+attachment → completed result referencing the artifact. Human joins mid-flow
+optionally to observe lifecycle cards.


### PR DESCRIPTION
Closes #113 — the last #106 semantic gap: **Human → Agent** structured collaboration requests, reusing the exact primitive Agent→Agent handoff already runs on (#109).

## Wire shape (browser WS)

```json
{ "type": "collab-request", "requestId": "<crypto.randomUUID()>", "targetParticipantId": "<agent participant id>", "summary": "<bounded human text>" }
```

v0 carries no details/attachmentIds/action payload. The server derives the sender from the authenticated WebSocket attachment — the payload never names a requester.

## Sender identity & target rules

`handleClientMessage` resolves the sender from the WS connection attachment and requires `kind === "human"` (`collab_sender_not_human`). Target must exist, be `connected`, and be an agent — else `collab_target_not_in_room` / `collab_target_not_agent`. If a target vanishes between render and validation the request is rejected; it is never silently retargeted. All rejections are fail-closed WS error frames following the existing `{type:"error",error}` convention — no message is appended.

## Reused ingestion (no parallel system)

Request ingestion was extracted into one shared private path, `ingestCollabWorkRequest`, used by BOTH `agent-send-collab` requests and the new Human WS message: warm registry → `validateCollabEvent(kind:"request")` → `CollabRegistry.recordRequest` with duplicate-detection BEFORE any append → ONE normal `action`/`collab` RoomMessage with `targets=[B]` → save → broadcast → waiter delivery. Responses/results (`accepted|declined|completed|failed`) are untouched and keep their precheck/routing semantics. No separate Human registry/storage exists.

## Dedup & rebuild

Duplicate requestIds collapse before append (WS gets `collab_duplicate_request_id`; no second message, no second work turn). Correlation lives in bounded room.messages: after DO eviction/restart, `CollabRegistry.rebuild` restores Human A → Agent B identically to Agent→Agent; requests beyond the horizon fail closed as `unknown_request`.

## Response correlation proves peer parity

Registry records `from=Human A, target=Agent B`; B's accepted/completed routes back toward the Human via the unchanged `routingFor/precheckResponse/commitResponse` rules. The runtime regression asserts the completed envelope targets `human-a` including its artifact reference.

## UI entry point

Remote connected Agents get a "Request work" button in both normal and compact UserCard layouts (Humans/self never do), opening a small composer: agent name, advertised capability chips as metadata, bounded textarea bound to `MAX_COLLAB_SUMMARY_LENGTH` (same constant as the server), Cancel/Send with empty-summary disable, and the copy "The Agent may accept or decline. This request does not grant new permissions." Hook API: `sendCollabRequest(targetParticipantId, summary): string` generates the requestId, bounds/trims locally, requires an open socket, returns the id — and never optimistically fabricates a message; the chat timeline + existing collab cards remain the lifecycle UI.

## Request ≠ authorization

Free4Chat only transports intent. It never invokes B's browser/shell/filesystem/GitHub, holds B's credentials, or approves B's tools. Capability chips stay advisory discovery metadata. Room messages remain untrusted input; the targeted Harness decides everything per its own policy.

## Persistence / MCP / Runtime

No new durable primitive: existing RoomRecord, bounded room.messages, in-memory CollabRegistry, existing rebuild behavior. MCP server untouched. Agent Runtime production source untouched — Human-originated requests arrive as the same addressed collab RoomEvent, so the COLLABORATION WORK TURN prompt path works unchanged (regression-tested); no version bump anywhere.

## Tests & gates

App vitest **196/196** across 20 files incl. new suites: runtime fake-room regressions (addressed wake identifies the HUMAN sender; accepted/completed correlate back to `human-a` incl. attachment; duplicate requestId appends nothing; wrong-agent response rejected `not_request_target`; restart+rebuild restores routing; non-target Agent C receives only non-addressed context events) and UI suites (composer validation/bound/copy/cancel; UserCard visibility matrix for remote-agent/Human/self/compact). prettier/eslint/tsc green, `cf-build` green.
agent-runtime **130/130** (format:check/lint/tsc/build/pack:check green) — test-only additions there; no Runtime source changes, so no package version bump.

## Explicit non-goals

Planner/DAG/orchestrator/task queue/scheduler/timeouts/retries · assignment/ranking/@capability routing · approval engine · remote function invocation/shell/browser RPC · credential sharing · cancellation/progress protocols/deadlines · task history/R2/D1/KV/global directory/marketplace/availability · workspace-snapshot expansion · Voice/TTS · any Agent realtime-media change (subscribe-only preserved).