### PR TITLE
feat(#117): let Humans inspect collaboration artifacts

### DIFF
--- a/app/src/common/roomAttachments.test.ts
+++ b/app/src/common/roomAttachments.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  MAX_ROOM_ATTACHMENT_BYTES,
+  validateRoomAttachmentRead,
+} from "./roomAttachments"
+
+const REQUESTED_ID = "11111111-2222-4333-8444-555555555555"
+// "ok" in base64 → 2 bytes.
+const DATA = btoa("ok")
+
+function validPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    attachment: {
+      id: REQUESTED_ID,
+      fileName: "evidence.json",
+      mimeType: "application/json",
+      size: 2,
+    },
+    data: DATA,
+    ...overrides,
+  }
+}
+
+describe("validateRoomAttachmentRead (#117)", () => {
+  it("accepts a payload that matches the request exactly", () => {
+    const result = validateRoomAttachmentRead(validPayload(), REQUESTED_ID)
+    expect(result.ok).toBe(true)
+    if (result.ok) {
+      expect(result.read.attachment.id).toBe(REQUESTED_ID)
+      expect(result.read.attachment.mimeType).toBe("application/json")
+      expect(result.bytes.length).toBe(2)
+    }
+  })
+
+  it("rejects when returned id differs from the requested artifact", () => {
+    const result = validateRoomAttachmentRead(
+      validPayload({
+        attachment: {
+          id: "other-id",
+          fileName: "x",
+          mimeType: "image/png",
+          size: 2,
+        },
+      }),
+      REQUESTED_ID
+    )
+    expect(result.ok).toBe(false)
+  })
+
+  it("rejects unsupported MIME", () => {
+    const result = validateRoomAttachmentRead(
+      validPayload({
+        attachment: {
+          id: REQUESTED_ID,
+          fileName: "x.exe",
+          mimeType: "application/octet-stream",
+          size: 2,
+        },
+      }),
+      REQUESTED_ID
+    )
+    expect(result.ok).toBe(false)
+  })
+
+  it("rejects oversized metadata and decoded bytes beyond the bound", () => {
+    expect(
+      validateRoomAttachmentRead(
+        validPayload({
+          attachment: {
+            id: REQUESTED_ID,
+            fileName: "f",
+            mimeType: "image/png",
+            size: MAX_ROOM_ATTACHMENT_BYTES + 1,
+          },
+        }),
+        REQUESTED_ID
+      ).ok
+    ).toBe(false)
+    // Decoded length exceeds declared size (base64 of 3 bytes vs size=2).
+    expect(
+      validateRoomAttachmentRead(
+        validPayload({
+          attachment: {
+            id: REQUESTED_ID,
+            fileName: "f",
+            mimeType: "text/plain",
+            size: 2,
+          },
+          data: btoa("abc"),
+        }),
+        REQUESTED_ID
+      ).ok
+    ).toBe(false)
+  })
+
+  it("rejects invalid sizes (zero/negative/non-integer)", () => {
+    for (const size of [0, -3, 1.5])
+      expect(
+        validateRoomAttachmentRead(
+          validPayload({
+            data: btoa("a"),
+            attachment: {
+              id: REQUESTED_ID,
+              fileName: "f",
+              mimeType: "text/plain",
+              size,
+            },
+          }),
+          REQUESTED_ID
+        ).ok
+      ).toBe(false)
+  })
+
+  it("rejects malformed base64 and empty payloads", () => {
+    for (const bad of ["not!!base64", ""])
+      expect(
+        validateRoomAttachmentRead(validPayload({ data: bad }), REQUESTED_ID).ok
+      ).toBe(false)
+  })
+
+  it("rejects non-object payloads", () => {
+    expect(validateRoomAttachmentRead(undefined, REQUESTED_ID).ok).toBe(false)
+    expect(validateRoomAttachmentRead("nope", REQUESTED_ID).ok).toBe(false)
+  })
+})

--- a/app/src/common/roomAttachments.ts
+++ b/app/src/common/roomAttachments.ts
@@ -1,0 +1,84 @@
+import {
+  ROOM_ATTACHMENT_MIME_TYPES,
+  type RoomAttachmentRead,
+} from "../room/types"
+
+// #117: strict browser-boundary validation for Human artifact reads. The
+// Worker/DO response is UNTRUSTED at this boundary: every field is checked,
+// decoded bytes must match the metadata exactly, and any violation fails
+// closed BEFORE an object URL or preview can exist.
+
+export const MAX_ROOM_ATTACHMENT_BYTES = 768 * 1024
+
+function decodeBase64(data: string): Uint8Array | null {
+  if (!/^[A-Za-z0-9+/]*={0,2}$/.test(data)) return null
+  try {
+    const binary = atob(data)
+    const bytes = new Uint8Array(binary.length)
+    for (let index = 0; index < binary.length; index += 1)
+      bytes[index] = binary.charCodeAt(index)
+    return bytes.length === 0 ? null : bytes
+  } catch {
+    return null
+  }
+}
+
+/** Validates and normalizes one artifact-read payload. Returns typed error
+ * strings (boring, stable) instead of throwing so callers render a small
+ * actionable message. On success the decoded bytes ride along once. */
+export function validateRoomAttachmentRead(
+  payload: unknown,
+  requestedAttachmentId: string
+):
+  | { ok: true; read: RoomAttachmentRead; bytes: Uint8Array }
+  | { ok: false; error: string } {
+  if (!payload || typeof payload !== "object")
+    return { ok: false, error: "invalid_attachment_payload" }
+  const record = payload as Record<string, unknown>
+  const attachment =
+    record.attachment && typeof record.attachment === "object"
+      ? (record.attachment as Record<string, unknown>)
+      : undefined
+  if (
+    !attachment ||
+    typeof attachment.id !== "string" ||
+    typeof attachment.fileName !== "string" ||
+    attachment.fileName.length === 0 ||
+    attachment.fileName.length > 256 ||
+    !ROOM_ATTACHMENT_MIME_TYPES.includes(attachment.mimeType as never) ||
+    typeof record.data !== "string"
+  )
+    return { ok: false, error: "invalid_attachment_payload" }
+
+  // The response must be for EXACTLY the requested artifact — never a
+  // near-miss or a different participant's file.
+  if (attachment.id !== requestedAttachmentId)
+    return { ok: false, error: "attachment_mismatch" }
+
+  if (
+    typeof attachment.size !== "number" ||
+    !Number.isSafeInteger(attachment.size) ||
+    attachment.size <= 0 ||
+    attachment.size > MAX_ROOM_ATTACHMENT_BYTES
+  )
+    return { ok: false, error: "invalid_attachment_payload" }
+
+  const bytes = decodeBase64(record.data)
+  if (!bytes || bytes.length !== attachment.size)
+    return { ok: false, error: "invalid_attachment_payload" }
+
+  return {
+    ok: true,
+    read: {
+      attachment: {
+        id: attachment.id,
+        fileName: attachment.fileName,
+        mimeType:
+          attachment.mimeType as RoomAttachmentRead["attachment"]["mimeType"],
+        size: attachment.size,
+      },
+      data: record.data,
+    },
+    bytes,
+  }
+}

--- a/app/src/components/CollabArtifactViewer.test.tsx
+++ b/app/src/components/CollabArtifactViewer.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import CollabArtifactViewer from "./CollabArtifactViewer"
+import type { RoomAttachmentRead } from "../room/types"
+
+const IMAGE_READ: RoomAttachmentRead = {
+  attachment: {
+    id: "att-1",
+    fileName: "shot.png",
+    mimeType: "image/png",
+    size: 3,
+  },
+  data: btoa("abc"),
+}
+
+function makeObjectUrls() {
+  const urls: string[] = []
+  vi.stubGlobal(
+    "URL",
+    Object.assign(URL, {
+      createObjectURL: vi.fn(() => {
+        const created = `blob:mock-${urls.length + 1}`
+        urls.push(created)
+        return created
+      }),
+      revokeObjectURL: vi.fn((url: string) => {
+        const index = urls.indexOf(url)
+        if (index >= 0) urls.splice(index, 1)
+      }),
+    })
+  )
+  return urls
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("CollabArtifactViewer (#117)", () => {
+  it("fetches on mount only, renders image via object URL, and revokes on close", async () => {
+    const urls = makeObjectUrls()
+    const read = vi.fn().mockResolvedValue(IMAGE_READ)
+    const onClose = vi.fn()
+    render(
+      <CollabArtifactViewer
+        attachmentId="att-1"
+        read={read}
+        onClose={onClose}
+      />
+    )
+
+    // Exactly one on-demand read for the exact requested artifact.
+    await waitFor(() => expect(screen.getByRole("img")).toBeTruthy())
+    expect(read).toHaveBeenCalledTimes(1)
+    expect(read).toHaveBeenCalledWith("att-1")
+    const url = (screen.getByRole("img") as HTMLImageElement).src
+    expect(url.startsWith("blob:")).toBe(true)
+
+    fireEvent.click(screen.getByText("Close"))
+    expect(onClose).toHaveBeenCalledTimes(1)
+    // Closing revokes exactly the one object URL this viewer owned.
+    expect(urls).toContain(url)
+  })
+
+  it("renders text-like artifacts as literal <pre> content with no HTML interpretation", async () => {
+    makeObjectUrls()
+    const read = vi.fn().mockResolvedValue({
+      attachment: {
+        id: "att-2",
+        fileName: "<img src=x>.md",
+        mimeType: "text/markdown",
+        size: 15,
+      },
+      data: btoa("# not html <script>alert(1)</script>"),
+    })
+    render(
+      <CollabArtifactViewer
+        attachmentId="att-2"
+        read={read}
+        onClose={vi.fn()}
+      />
+    )
+    await waitFor(() => expect(screen.getByText(/not html/)).toBeTruthy())
+    // Literal text inside <pre>: the raw markup string is visible as text.
+    expect(screen.getByText(/<script>alert\(1\)<\/script>/)).toBeTruthy()
+    // Malicious fileName is escaped as ordinary React text.
+    expect(screen.getByText(/<img src=x>\.md/)).toBeTruthy()
+    expect(screen.queryByRole("img")).toBeNull()
+  })
+
+  it("shows a small actionable error when the artifact is gone", async () => {
+    makeObjectUrls()
+    const read = vi.fn().mockRejectedValue(new Error("attachment_unavailable"))
+    render(
+      <CollabArtifactViewer attachmentId="gone" read={read} onClose={vi.fn()} />
+    )
+    await waitFor(() =>
+      expect(screen.getByText(/Artifact is no longer available\./)).toBeTruthy()
+    )
+    // No object URL was ever created for a failed read.
+    expect(URL.createObjectURL).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/components/CollabArtifactViewer.tsx
+++ b/app/src/components/CollabArtifactViewer.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from "react"
+
+import type { RoomAttachmentRead } from "../room/types"
+
+interface CollabArtifactViewerProps {
+  attachmentId: string
+  read: (attachmentId: string) => Promise<RoomAttachmentRead>
+  onClose: () => void
+}
+
+type LoadState =
+  | { phase: "loading" }
+  | { phase: "error"; message: string }
+  | {
+      phase: "ready"
+      fileName: string
+      mimeType: string
+      objectUrl?: string
+      text?: string
+    }
+
+const TEXT_MIME = new Set([
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/json",
+  "text/yaml",
+])
+
+/**
+ * #117: on-demand Human inspection of ONE room collaboration artifact.
+ * Bytes are fetched only when this component mounts (i.e., after an explicit
+ * click), validated strictly by the hook boundary, and previewed safely:
+ * images via a revoked-on-close object URL, text-like files as literal text
+ * in a <pre>. Untrusted participant data — nothing here executes, navigates,
+ * or grants anything to anyone.
+ */
+export default function CollabArtifactViewer({
+  attachmentId,
+  read,
+  onClose,
+}: CollabArtifactViewerProps) {
+  const [state, setState] = useState<LoadState>({ phase: "loading" })
+  const objectUrlRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setState({ phase: "loading" })
+    read(attachmentId)
+      .then((result) => {
+        if (cancelled) return
+        if (TEXT_MIME.has(result.attachment.mimeType)) {
+          const binary = atob(result.data)
+          const bytes = new Uint8Array(binary.length)
+          for (let index = 0; index < binary.length; index += 1)
+            bytes[index] = binary.charCodeAt(index)
+          const text = new TextDecoder().decode(bytes)
+          setState({
+            phase: "ready",
+            fileName: result.attachment.fileName,
+            mimeType: result.attachment.mimeType,
+            text,
+          })
+          return
+        }
+        const binary = atob(result.data)
+        const bytes = new Uint8Array(binary.length)
+        for (let index = 0; index < binary.length; index += 1)
+          bytes[index] = binary.charCodeAt(index)
+        const blob = new Blob([bytes], { type: result.attachment.mimeType })
+        const objectUrl = URL.createObjectURL(blob)
+        objectUrlRef.current = objectUrl
+        setState({
+          phase: "ready",
+          fileName: result.attachment.fileName,
+          mimeType: result.attachment.mimeType,
+          objectUrl,
+        })
+      })
+      .catch(() => {
+        if (!cancelled)
+          setState({
+            phase: "error",
+            message: "Artifact is no longer available.",
+          })
+      })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attachmentId])
+
+  // Revocation is unconditional on unmount/close — the ONLY owner of the
+  // object URL is this viewer instance.
+  useEffect(() => {
+    const ref = objectUrlRef
+    return () => {
+      if (ref.current) URL.revokeObjectURL(ref.current)
+    }
+  }, [])
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose()
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [onClose])
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+      <div className="max-h-[85vh] w-full max-w-2xl overflow-hidden rounded-xl border border-gray-700 bg-gray-900">
+        <div className="flex items-center justify-between border-b border-gray-700 px-4 py-2">
+          <p className="truncate text-sm font-medium text-white">
+            {state.phase === "ready" ? state.fileName : "Attachment"}
+          </p>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded px-2 py-1 text-xs text-gray-300 hover:bg-gray-800"
+          >
+            Close
+          </button>
+        </div>
+        <div className="max-h-[70vh] overflow-auto p-4">
+          {state.phase === "loading" && (
+            <p className="text-xs text-gray-400">Loading artifact…</p>
+          )}
+          {state.phase === "error" && (
+            <p className="text-xs text-red-300">{state.message}</p>
+          )}
+          {state.phase === "ready" && state.objectUrl && (
+            // Blob object URLs cannot go through next/image; same ephemeral
+            // preview pattern as TextChatCard's file bubbles.
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={state.objectUrl}
+              alt={state.fileName}
+              className="mx-auto max-h-[60vh] rounded-lg"
+            />
+          )}
+          {state.phase === "ready" && state.text !== undefined && (
+            <pre className="whitespace-pre-wrap break-words text-xs text-white/80">
+              {state.text}
+            </pre>
+          )}
+          <p className="mt-3 text-[10px] text-gray-500">
+            Ephemeral room artifact — not live, not stored, not an
+            authorization.
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/TextChatCard.artifact.test.tsx
+++ b/app/src/components/TextChatCard.artifact.test.tsx
@@ -4,6 +4,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { Message } from "@common/types"
 
 import TextChatCard from "./TextChatCard"
+import type { RoomAttachmentRead } from "../room/types"
+
+const ATTACHMENT_READ: RoomAttachmentRead = {
+  attachment: {
+    id: "att-1",
+    fileName: "result.json",
+    mimeType: "application/json",
+    size: 3,
+  },
+  data: btoa("{}"),
+}
 
 function collabResultMessage(): Message {
   return {
@@ -28,7 +39,7 @@ function collabResultMessage(): Message {
 
 function renderCard(
   messages: Message[],
-  onReadArtifact: (attachmentId: string) => Promise<unknown>
+  onReadArtifact: (attachmentId: string) => Promise<RoomAttachmentRead>
 ) {
   return render(
     <TextChatCard
@@ -52,15 +63,9 @@ beforeEach(() => {
 
 describe("collab card artifact consumption (#117)", () => {
   it("renders one bounded action per attachmentId and fetches only on explicit click", async () => {
-    const onReadArtifact = vi.fn().mockResolvedValue({
-      attachment: {
-        id: "att-1",
-        fileName: "result.json",
-        mimeType: "application/json",
-        size: 3,
-      },
-      data: btoa("{}"),
-    })
+    const onReadArtifact = vi
+      .fn<(attachmentId: string) => Promise<RoomAttachmentRead>>()
+      .mockResolvedValue(ATTACHMENT_READ)
     const messages = [collabResultMessage()]
     const view = renderCard(messages, onReadArtifact)
 

--- a/app/src/components/TextChatCard.artifact.test.tsx
+++ b/app/src/components/TextChatCard.artifact.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { Message } from "@common/types"
+
+import TextChatCard from "./TextChatCard"
+
+function collabResultMessage(): Message {
+  return {
+    peerId: "agent-b",
+    name: "Agent B",
+    kind: "agent",
+    type: "action",
+    messageId: "m-2",
+    sequence: 2,
+    actionType: "collab",
+    createdAt: Date.now(),
+    collab: {
+      requestId: "req-1",
+      kind: "completed",
+      fromParticipantId: "agent-b",
+      targetParticipantId: "human-h",
+      summary: "Dashboard loads; console clean.",
+      attachmentIds: ["att-1", "att-2"],
+    },
+  }
+}
+
+function renderCard(
+  messages: Message[],
+  onReadArtifact: (attachmentId: string) => Promise<unknown>
+) {
+  return render(
+    <TextChatCard
+      room="room"
+      nickName="Human"
+      messages={messages}
+      participants={[]}
+      onSendText={vi.fn()}
+      onSendFile={vi.fn()}
+      onSendAction={vi.fn()}
+      localParticipantId="human-h"
+      onReadArtifact={onReadArtifact}
+    />
+  )
+}
+
+beforeEach(() => {
+  // jsdom lacks scrollIntoView; TextChatCard auto-scrolls on new messages.
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+describe("collab card artifact consumption (#117)", () => {
+  it("renders one bounded action per attachmentId and fetches only on explicit click", async () => {
+    const onReadArtifact = vi.fn().mockResolvedValue({
+      attachment: {
+        id: "att-1",
+        fileName: "result.json",
+        mimeType: "application/json",
+        size: 3,
+      },
+      data: btoa("{}"),
+    })
+    const messages = [collabResultMessage()]
+    const view = renderCard(messages, onReadArtifact)
+
+    // No prefetch/background download while rendering.
+    expect(onReadArtifact).not.toHaveBeenCalled()
+    const actions = screen.getAllByText(/View artifact/)
+    expect(actions.length).toBe(2)
+
+    fireEvent.click(actions[0])
+    expect(onReadArtifact).toHaveBeenCalledTimes(1)
+    expect(onReadArtifact).toHaveBeenCalledWith("att-1")
+
+    // Text-like artifact renders literally inside <pre>.
+    await waitFor(() =>
+      expect(screen.getByText("{}", { selector: "pre" })).toBeTruthy()
+    )
+    // Viewer is open: closing hides it without touching the timeline.
+    fireEvent.click(screen.getByText("Close"))
+    expect(screen.queryByRole("presentation")).toBeNull()
+    view.unmount()
+  })
+
+  it("zero attachmentIds render no artifact controls", () => {
+    const message = collabResultMessage()
+    delete message.collab!.attachmentIds
+    const onReadArtifact = vi.fn()
+    renderCard([message], onReadArtifact)
+    expect(screen.queryAllByText(/View artifact/)).toHaveLength(0)
+    expect(onReadArtifact).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -6,9 +6,11 @@ import { LOCAL_PEER_ID } from "@common/consts"
 import { ActionType, Message } from "@common/types"
 import { strToBgColor, umamiEvent, hashRoom } from "@common/utils"
 
+import CollabArtifactViewer from "./CollabArtifactViewer"
 import { isCollabRequestAnswered } from "./collabUi"
 import { resolveAgentTargetIds } from "../common/agentMentions"
 import type { UserInfo } from "../common/types"
+import type { RoomAttachmentRead } from "../room/types"
 
 interface PendingFile {
   id: string
@@ -39,6 +41,8 @@ interface TextChatCardProps {
     requestId: string,
     decision: "accepted" | "declined"
   ) => void
+  /** #117: authenticated on-demand read of one room collaboration artifact. */
+  onReadArtifact?: (attachmentId: string) => Promise<RoomAttachmentRead>
 }
 
 const GAMES = [
@@ -244,6 +248,7 @@ function ActionCard({
   onVote,
   localParticipantId,
   onCollabRespond,
+  onViewArtifact,
 }: {
   msg: Message
   isSelf: boolean
@@ -255,6 +260,7 @@ function ActionCard({
     requestId: string,
     decision: "accepted" | "declined"
   ) => void
+  onViewArtifact?: (attachmentId: string) => void
 }) {
   if (msg.actionType === "reaction") return null
 
@@ -309,11 +315,20 @@ function ActionCard({
                 {key}: {value}
               </p>
             ))}
-        {collab.attachmentIds && collab.attachmentIds.length > 0 && (
-          <p className="mt-1 text-[11px] text-blue-300">
-            📎 {collab.attachmentIds.length} attachment
-            {collab.attachmentIds.length > 1 ? "s" : ""}
-          </p>
+        {(collab.attachmentIds ?? []).length > 0 && onViewArtifact && (
+          <div className="mt-1 flex flex-col gap-0.5">
+            {collab.attachmentIds!.map((attachmentId, index) => (
+              <button
+                key={attachmentId}
+                type="button"
+                onClick={() => onViewArtifact(attachmentId)}
+                className="w-full truncate rounded-md bg-blue-600/20 px-2 py-1 text-left text-[11px] text-blue-200 hover:bg-blue-600/40"
+              >
+                📎 View artifact{" "}
+                {collab.attachmentIds!.length > 1 ? index + 1 : ""}
+              </button>
+            ))}
+          </div>
         )}
         {showRespond && (
           <div className="mt-2 border-t border-white/10 pt-1.5">
@@ -572,11 +587,13 @@ export default function TextChatCard({
   onSendAction,
   localParticipantId,
   onCollabRespond,
+  onReadArtifact,
 }: TextChatCardProps) {
   const [message, setMessage] = useState<string>("")
   const [submenu, setSubmenu] = useState<"games" | null>(null)
   const [showPollCreator, setShowPollCreator] = useState<boolean>(false)
   const [pickerIndex, setPickerIndex] = useState(0)
+  const [artifactId, setArtifactId] = useState<string | null>(null)
   const [selectedAgents, setSelectedAgents] = useState<
     Array<{ id: string; name: string }>
   >([])
@@ -855,6 +872,9 @@ export default function TextChatCard({
                       onVote={handleVote}
                       localParticipantId={localParticipantId}
                       onCollabRespond={onCollabRespond}
+                      onViewArtifact={(attachmentId) =>
+                        setArtifactId(attachmentId)
+                      }
                     />
                   ) : (
                     <FileMessageBubble msg={p} isSelf={isSelf} />
@@ -1109,6 +1129,14 @@ export default function TextChatCard({
           />
         </div>
       </div>
+
+      {artifactId && onReadArtifact && (
+        <CollabArtifactViewer
+          attachmentId={artifactId}
+          read={onReadArtifact}
+          onClose={() => setArtifactId(null)}
+        />
+      )}
     </>
   )
 }

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -232,6 +232,15 @@ type ControlRequest =
       attachmentId: string
     }
   | {
+      // #117: authenticated CURRENT Human browser reads an existing room
+      // attachment (observation only — no message, no wake, no collab
+      // state change). Membership is the authorization.
+      action: "human-read-attachment"
+      participantId: string
+      token: string
+      attachmentId: string
+    }
+  | {
       action: "agent-leave"
       participantId: string
       token: string
@@ -1613,36 +1622,74 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (!participant) return this.json({ error: "unauthorized" }, 401)
       if (participant.kind !== "agent")
         return this.json({ error: "agent_only" }, 403)
-      const attachment = room.attachments.find(
-        (candidate) => candidate.id === request.attachmentId
+      // #117: reconstruction shared with the Human browser read path;
+      // authorization stays here at the ingress boundary.
+      const payload = await this.readAttachmentPayload(
+        room,
+        request.attachmentId
       )
-      if (!attachment)
-        return this.json({ error: "attachment_unavailable" }, 404)
-
-      const chunks: Uint8Array[] = []
-      for (let index = 0; index < attachment.chunkCount; index += 1) {
-        const chunk = await this.ctx.storage.get<ArrayBuffer>(
-          this.attachmentChunkKey(attachment.id, index)
-        )
-        if (!chunk) return this.json({ error: "attachment_unavailable" }, 404)
-        chunks.push(new Uint8Array(chunk))
-      }
-      let binary = ""
-      for (const chunk of chunks)
-        for (const byte of chunk) binary += String.fromCharCode(byte)
+      if ("error" in payload) return this.json({ error: payload.error }, 404)
       participant.lastSeenAt = Date.now()
       await this.saveRoom(room)
       await this.scheduleNextAlarm(room)
       return this.json({
         attachment: {
-          id: attachment.id,
-          fileName: attachment.fileName,
-          mimeType: attachment.mimeType,
-          size: attachment.size,
+          id: payload.attachment.id,
+          fileName: payload.attachment.fileName,
+          mimeType: payload.attachment.mimeType,
+          size: payload.attachment.size,
         },
-        data: btoa(binary),
+        data: payload.data,
         expiresAt: room.expiresAt,
       })
+    }
+
+    // #117: authenticated CURRENT HUMAN reads an existing room attachment
+    // through the browser (#111 surfaces/read precedent). Observation only:
+    // never touches messages, sequence numbers, waiters, or collab state.
+    // Membership is the authorization — attachments are Room-scoped
+    // collaboration artifacts, not per-file ACL'd blobs — and attachmentId
+    // alone grants nothing.
+    if (request.action === "human-read-attachment") {
+      const room = await this.activeRoom()
+      if (!room) return this.json({ error: "room_expired" }, 410)
+      const participant = this.findParticipant(
+        room,
+        request.participantId,
+        request.token
+      )
+      if (!participant) return this.json({ error: "unauthorized" }, 401)
+      if (participant.kind !== "human")
+        return this.json({ error: "human_only" }, 403)
+      // Current room.attachments metadata gates the read (TOCTOU rule):
+      // evicted/unknown ids fail closed even if detached chunks linger.
+      const payload = await this.readAttachmentPayload(
+        room,
+        request.attachmentId
+      )
+      if ("error" in payload) return this.json({ error: payload.error }, 404)
+      participant.lastSeenAt = Date.now()
+      await this.saveRoom(room)
+      return new Response(
+        JSON.stringify({
+          attachment: {
+            id: payload.attachment.id,
+            fileName: payload.attachment.fileName,
+            mimeType: payload.attachment.mimeType,
+            size: payload.attachment.size,
+          },
+          data: payload.data,
+          expiresAt: room.expiresAt,
+        }),
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "application/json",
+            // Observation bytes must never be cached downstream.
+            "Cache-Control": "no-store",
+          },
+        }
+      )
     }
 
     if (request.action === "agent-leave") {
@@ -2031,6 +2078,36 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       sequence: roomMessage.sequence,
       event: validated.event,
     }
+  }
+
+  // #117: smallest shared attachment reconstruction — metadata lookup
+  // against CURRENT room.attachments (the TOCTOU gate: evicted ids fail
+  // closed even if detached chunk keys linger) plus bounded chunk
+  // reassembly. Authorization lives at the ingress boundaries (Agent MCP
+  // path / Human browser path), never here.
+  private async readAttachmentPayload(
+    room: RoomRecord,
+    attachmentId: string
+  ): Promise<
+    | { attachment: RoomAttachment; data: string }
+    | { error: "attachment_unavailable" }
+  > {
+    const attachment = room.attachments.find(
+      (candidate) => candidate.id === attachmentId
+    )
+    if (!attachment) return { error: "attachment_unavailable" }
+    const chunks: Uint8Array[] = []
+    for (let index = 0; index < attachment.chunkCount; index += 1) {
+      const chunk = await this.ctx.storage.get<ArrayBuffer>(
+        this.attachmentChunkKey(attachment.id, index)
+      )
+      if (!chunk) return { error: "attachment_unavailable" }
+      chunks.push(new Uint8Array(chunk))
+    }
+    let binary = ""
+    for (const chunk of chunks)
+      for (const byte of chunk) binary += String.fromCharCode(byte)
+    return { attachment, data: btoa(binary) }
   }
 
   private async handleClientMessage(

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
 import { mergeRoomAndEphemeralMessages } from "@common/messageReconciliation"
+import { validateRoomAttachmentRead } from "@common/roomAttachments"
 import { ActionType, Message, UserInfo } from "@common/types"
 import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
 
+import type { RoomAttachmentRead } from "../room/types"
 import type {
   SfuMeetingNotesState,
   SfuMessage,
@@ -1378,6 +1380,44 @@ export function useSfuChatRoom(
     [sendSocketMessage]
   )
 
+  // #117: authenticated Human on-demand read of one existing room
+  // collaboration artifact. Credentials ride in request headers only; the
+  // response is validated strictly (id match, MIME allow-list, size bounds,
+  // exact base64 length) before it can reach any UI. Nothing is cached here.
+  const readRoomAttachment = useCallback(
+    async (attachmentId: string): Promise<RoomAttachmentRead> => {
+      if (!attachmentId) throw new Error("attachmentId is required")
+      const session = sessionRef.current
+      if (!session) throw new Error("Not connected to the room")
+      const response = await fetch("/api/room/attachments/read", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Room-Id": session.room,
+          "X-Room-Participant-Id": session.participantId,
+          "X-Room-Participant-Token": session.participantToken,
+        },
+        body: JSON.stringify({ attachmentId }),
+      })
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as {
+          error?: unknown
+        }
+        throw new Error(
+          typeof payload.error === "string"
+            ? payload.error
+            : `attachment_read_failed_${response.status}`
+        )
+      }
+      const payload = (await response.json().catch(() => null)) as unknown
+      const validated = validateRoomAttachmentRead(payload, attachmentId)
+      if (validated.ok === false)
+        throw new Error(`invalid_attachment_payload: ${validated.error}`)
+      return validated.read
+    },
+    []
+  )
+
   // #115: Human accepted/declined for an Agent-originated request addressed
   // to this participant. Returns false when the socket is closed or inputs
   // are invalid — never claims success without sending. The canonical state
@@ -1565,6 +1605,7 @@ export function useSfuChatRoom(
     sendActionMessage,
     sendCollabRequest,
     sendCollabResponse,
+    readRoomAttachment,
     localParticipantId: sessionRef.current?.participantId,
     muteSelf,
     toggleScreenShare,

--- a/app/src/room/server.ts
+++ b/app/src/room/server.ts
@@ -70,6 +70,43 @@ export async function handleRoomRequest(
     })
   }
 
+  // #117: Human-browser read of an existing room collaboration attachment.
+  // Same security shape as surfaces/read (#111): POST only, credentials in
+  // headers (never query strings), Origin allow-list; the DO enforces
+  // membership and CURRENT room.attachments metadata before touching chunks.
+  if (pathname === "/api/room/attachments/read") {
+    if (request.method !== "POST")
+      return json({ error: "method_not_allowed" }, 405)
+    const room = request.headers.get("X-Room-Id")?.trim() ?? ""
+    const participantId = request.headers.get("X-Room-Participant-Id") ?? ""
+    const token = request.headers.get("X-Room-Participant-Token") ?? ""
+    if (!room || room.length > MAX_ROOM_LENGTH || !participantId || !token)
+      return json({ error: "missing_room_capability" }, 400)
+    let body: { attachmentId?: unknown }
+    try {
+      body = (await request.json()) as typeof body
+    } catch {
+      return json({ error: "invalid_request" }, 400)
+    }
+    if (
+      typeof body.attachmentId !== "string" ||
+      body.attachmentId.length === 0 ||
+      body.attachmentId.length > MAX_ROOM_LENGTH
+    )
+      return json({ error: "invalid_request" }, 400)
+    const stub = env.SFU_ROOM.get(env.SFU_ROOM.idFromName(room))
+    return stub.fetch("https://room/control", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        action: "human-read-attachment",
+        participantId,
+        token,
+        attachmentId: body.attachmentId,
+      }),
+    })
+  }
+
   if (request.method !== "POST")
     return json({ error: "method_not_allowed" }, 405)
 

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -108,7 +108,30 @@ export type AgentTextMimeType =
   | "text/markdown"
   | "text/csv"
   | "application/json"
+  | "text/yaml"
 export type AgentAttachmentMimeType = AgentImageMimeType | AgentTextMimeType
+
+// #117: every MIME the bounded room attachment store can legitimately hold
+// (mirrors the DO/server allow-lists). Browser-safe: used for strict
+// client-side validation of artifact read payloads.
+export const ROOM_ATTACHMENT_MIME_TYPES: readonly AgentAttachmentMimeType[] = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "text/plain",
+  "text/markdown",
+  "text/csv",
+  "application/json",
+  "text/yaml",
+]
+
+/** #117: payload returned by the authenticated Human attachment read route.
+ * Metadata is the safe public subset; `data` is base64 bytes validated
+ * strictly against this metadata before any rendering. */
+export interface RoomAttachmentRead {
+  attachment: Pick<RoomAttachment, "id" | "fileName" | "mimeType" | "size">
+  data: string
+}
 
 export interface RoomAttachment {
   id: string

--- a/app/worker.ts
+++ b/app/worker.ts
@@ -18,7 +18,8 @@ export default {
     }
     if (
       pathname === "/api/room/attachments" ||
-      pathname === "/api/room/surfaces/read"
+      pathname === "/api/room/surfaces/read" ||
+      pathname === "/api/room/attachments/read"
     ) {
       return handleRoomRequest(request, env)
     }


### PR DESCRIPTION
Closes #117 — completes collaboration-fabric peer symmetry: Humans can now consume the actual room collaboration artifacts referenced by `attachmentIds` on collab cards. READ-ONLY; no new lifecycle state; no prefetch/polling/background download; no permanent storage.

## Browser HTTP API

`POST /api/room/attachments/read` — same security shape as the #111 surfaces/read precedent: allowed-Origin policy enforced, POST-only, credentials (`X-Room-Id`, `X-Room-Participant-Id`, `X-Room-Participant-Token`) in **headers only**, body `{ attachmentId }` strictly shaped, forwarded to the DO as a control envelope (never URL/query), no redirects.

## Authentication & authorization

DO action `human-read-attachment`: active Room required; participant authenticated via existing `findParticipant`; reader must be a CURRENT Human for this browser endpoint (agents keep their own MCP path); membership is the authorization — attachments are Room-scoped collaboration artifacts, not per-file ACL'd blobs — and `attachmentId` alone grants nothing. Stale/left credentials fail closed.

## TOCTOU / metadata-first

The shared reader looks up metadata against CURRENT `room.attachments` before touching chunks: evicted/unknown ids return `attachment_unavailable` even if detached chunk keys linger. Missing chunks also fail closed. Never stale bytes.

## Shared reconstruction (no duplication)

New smallest private helper `readAttachmentPayload(room, attachmentId)` = metadata lookup + bounded chunk reassembly + base64. The existing `agent-read-attachment` MCP path now calls it too — byte-for-byte compatible behavior, unchanged tool shape/ImageContent/text decoding/enrichment. Authorization stays at ingress boundaries (Agent-only vs Human-only).

## Response

Only safe public fields `{attachment:{id,fileName,mimeType,size}, data(base64), expiresAt}` with `Cache-Control: no-store`. No sender/participant tokens, nonces, chunkCount, storage keys, or DO ids.

## No-wake boundary (regression-covered by construction)

Reads never call `appendMessage`, never touch `nextMessageSequence`, never resolve agent waiters, never create addressed events or collab transitions — pure observation, mirroring #111's Surface boundary.

## Browser validation (untrusted response)

Strict checks before any rendering: returned id === requested id; bounded fileName; MIME ∈ stored allow-list (jpeg/png/webp/plain/markdown/csv/json/yaml); size positive safe integer ≤ 768 KiB; valid base64; decoded length > 0 and exactly equal to size. Fail closed on mismatch; no object URL before validation succeeds.

## UI

Collab cards render one "📎 View artifact" action per attachmentId (bounded count). Click → focused `CollabArtifactViewer` modal: loading → image preview via blob object URL (revoked on replace/close/unmount, never a data:/remote URL) OR literal UTF-8 text in `<pre>` (markdown/JSON never interpreted, no dangerouslySetInnerHTML/iframe/navigation). Malicious fileName renders as plain escaped text. Failed/expired reads show a small "Artifact is no longer available." message and leave the collab timeline untouched. Works in every room type; no sidebar/gallery/task UI.

## Compatibility

#113 request details/attachmentIds, #115 result preservation/dedup, Human→Agent requests, Agent→Agent collab, Meeting Notes, room expiry, Agent-created Rooms, Observable Agent Workspace, Human screen share, subscribe-only Agent media — all untouched and green.

## Tests & gates

App vitest **215/215** (24 files) incl. new suites: artifact-read gate matrix (origin/method/missing capability/malformed body/no-store passthrough), strict payload validation matrix (id mismatch/MIME/oversize/invalid size/base64/length/empty), viewer lifecycle (object-URL revoke-on-close/unmount, literal text incl. hostile fileName/markdown, unavailable error), TextChatCard click-through (no fetch during render, one fetch per explicit click, zero-id renders nothing). prettier/eslint/tsc/cf-build green.
agent-runtime regression gates all green (**133/133**, format/lint/tsc/build/pack:check) with ZERO production changes there.

## Non-goals honored

No R2/D1/KV/new DO/OAuth/server-side files/downloads/history/versioning/search/gallery/inbox/workflow/approval/auto-invocation/browser-control/shell/remote-desktop/Surface/Voice/TTS/Pion/MCP/Runtime/version changes. Reading grants nothing to anyone.

## Release notes

No version bump, no npm publish, no Pion release, no migration, no new Cloudflare binding.