### PR TITLE
feat(#119): let Humans advertise room capabilities

### DIFF
--- a/agent-runtime/test/collab.test.ts
+++ b/agent-runtime/test/collab.test.ts
@@ -1755,3 +1755,20 @@ test("#113/#115 Agent completed result preserves details and attachmentIds throu
     await runtimeA.stop()
   }
 })
+
+test("#119 Runtime compatibility: existing normalizeRosterEntry parses Human advertised tokens with zero production changes", async () => {
+  const { normalizeRosterEntry } = await import("../src/free4chat/client.js")
+  const entry = normalizeRosterEntry({
+    id: "human-h",
+    name: "Hannah",
+    kind: "human",
+    advertised: ["review.code", "judgment.product"],
+  })
+  assert.ok(entry)
+  assert.deepEqual(entry, {
+    id: "human-h",
+    name: "Hannah",
+    kind: "human",
+    advertised: ["review.code", "judgment.product"],
+  })
+})

--- a/app/src/components/HumanCapabilitiesEditor.test.tsx
+++ b/app/src/components/HumanCapabilitiesEditor.test.tsx
@@ -1,0 +1,99 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import HumanCapabilitiesEditor from "./HumanCapabilitiesEditor"
+
+const base = {
+  initialCapabilities: [] as string[],
+  maxLength: 48,
+  maxTokens: 8,
+}
+
+describe("HumanCapabilitiesEditor (#119)", () => {
+  it("shows helper text stating capabilities do not grant permissions", () => {
+    render(
+      <HumanCapabilitiesEditor {...base} onSave={vi.fn()} onCancel={vi.fn()} />
+    )
+    expect(
+      screen.getByText(
+        /Capabilities help Agents discover what they may ask you to do\. They do not grant permissions\./
+      )
+    ).toBeTruthy()
+  })
+
+  it("adds a valid capability, removes one, and Save sends the FULL replacement list", () => {
+    const onSave = vi.fn()
+    render(
+      <HumanCapabilitiesEditor
+        {...base}
+        initialCapabilities={["review.code"]}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+    const input = screen.getByPlaceholderText("Add capability…")
+    fireEvent.change(input, { target: { value: "judgment.product" } })
+    fireEvent.click(screen.getByText("Add"))
+    fireEvent.change(input, { target: { value: "design.ux" } })
+    fireEvent.click(screen.getByText("Add"))
+    // Remove review.code via its × button.
+    fireEvent.click(screen.getByLabelText("Remove review.code"))
+    fireEvent.click(screen.getByTestId("save-capabilities"))
+    expect(onSave).toHaveBeenCalledWith(["judgment.product", "design.ux"])
+  })
+
+  it("prevents a ninth capability", () => {
+    const initial = Array.from({ length: 8 }, (_, i) => `cap${i}`)
+    render(
+      <HumanCapabilitiesEditor
+        {...base}
+        initialCapabilities={initial}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    const input = screen.getByPlaceholderText("Add capability…")
+    fireEvent.change(input, { target: { value: "cap.extra" } })
+    fireEvent.click(screen.getByText("Add"))
+    expect(screen.getByText(/Max 8 capabilities\./)).toBeTruthy()
+  })
+
+  it("rejects invalid tokens and cannot save them into the list", () => {
+    const onSave = vi.fn()
+    render(
+      <HumanCapabilitiesEditor {...base} onSave={onSave} onCancel={vi.fn()} />
+    )
+    const input = screen.getByPlaceholderText("Add capability…")
+    fireEvent.change(input, { target: { value: "Review Code!" } })
+    fireEvent.click(screen.getByText("Add"))
+    expect(screen.getByText(/Use lowercase namespaced tokens/)).toBeTruthy()
+    // Nothing added → saving an empty list is allowed but sends [].
+    fireEvent.click(screen.getByTestId("save-capabilities"))
+    expect(onSave).toHaveBeenCalledWith([])
+  })
+
+  it("empty list may be saved (advertise nothing)", () => {
+    const onSave = vi.fn()
+    render(
+      <HumanCapabilitiesEditor {...base} onSave={onSave} onCancel={vi.fn()} />
+    )
+    fireEvent.click(screen.getByTestId("save-capabilities"))
+    expect(onSave).toHaveBeenCalledWith([])
+  })
+
+  it("Cancel never calls onSave", () => {
+    const onCancel = vi.fn()
+    const onSave = vi.fn()
+    render(
+      <HumanCapabilitiesEditor
+        {...base}
+        initialCapabilities={["review.code"]}
+        onSave={onSave}
+        onCancel={onCancel}
+      />
+    )
+    fireEvent.click(screen.getByText("Cancel"))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSave).not.toHaveBeenCalled()
+  })
+})

--- a/app/src/components/HumanCapabilitiesEditor.tsx
+++ b/app/src/components/HumanCapabilitiesEditor.tsx
@@ -1,0 +1,130 @@
+import { useState } from "react"
+
+interface HumanCapabilitiesEditorProps {
+  initialCapabilities: string[]
+  maxLength: number
+  maxTokens: number
+  onSave: (capabilities: string[]) => void
+  onCancel: () => void
+}
+
+/**
+ * #119: self-only editor for THIS Human's advertised capability list.
+ * Discovery metadata only — capabilities help Agents discover what they may
+ * ask about; they never grant permissions. Save sends a FULL replacement
+ * list; Cancel mutates nothing.
+ */
+export default function HumanCapabilitiesEditor({
+  initialCapabilities,
+  maxLength,
+  maxTokens,
+  onSave,
+  onCancel,
+}: HumanCapabilitiesEditorProps) {
+  const [tokens, setTokens] = useState<string[]>([...initialCapabilities])
+  const [draft, setDraft] = useState("")
+  const [error, setError] = useState<string | null>(null)
+
+  const addToken = () => {
+    const token = draft.trim().toLowerCase()
+    if (!token) return
+    if (token.length > maxLength) {
+      setError(`Max ${maxLength} characters per capability.`)
+      return
+    }
+    if (tokens.length >= maxTokens) {
+      setError(`Max ${maxTokens} capabilities.`)
+      return
+    }
+    if (!/^[a-z0-9]+([._-][a-z0-9]+)*$/.test(token)) {
+      setError("Use lowercase namespaced tokens like review.code.")
+      return
+    }
+    if (tokens.includes(token)) {
+      setError("Already added.")
+      return
+    }
+    setError(null)
+    setDraft("")
+    setTokens([...tokens, token])
+  }
+
+  const removeToken = (token: string) => {
+    setError(null)
+    setTokens(tokens.filter((existing) => existing !== token))
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="w-full max-w-md rounded-xl border border-gray-700 bg-gray-900 p-4">
+        <h3 className="text-sm font-medium text-white">
+          Your capabilities in this Room
+        </h3>
+        {tokens.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1">
+            {tokens.map((token) => (
+              <span
+                key={token}
+                className="flex items-center gap-1 rounded-full bg-black/30 px-2 py-0.5 text-[10px] text-white/80"
+              >
+                {token}
+                <button
+                  type="button"
+                  aria-label={`Remove ${token}`}
+                  onClick={() => removeToken(token)}
+                  className="text-gray-400 hover:text-white"
+                >
+                  ×
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="mt-2 flex gap-1.5">
+          <input
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                event.preventDefault()
+                addToken()
+              }
+            }}
+            placeholder="Add capability…"
+            maxLength={maxLength}
+            className="flex-1 rounded-lg border border-gray-700 bg-black/40 px-3 py-1.5 text-xs text-white placeholder:text-gray-500"
+          />
+          <button
+            type="button"
+            onClick={addToken}
+            className="rounded-lg border border-gray-600 px-3 py-1.5 text-xs text-gray-200 hover:bg-gray-800"
+          >
+            Add
+          </button>
+        </div>
+        {error && <p className="mt-1 text-[11px] text-red-300">{error}</p>}
+        <p className="mt-2 text-[11px] leading-snug text-gray-400">
+          Capabilities help Agents discover what they may ask you to do. They do
+          not grant permissions.
+        </p>
+        <div className="mt-3 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-gray-600 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => onSave([...tokens])}
+            data-testid="save-capabilities"
+            className="rounded-lg bg-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-blue-500"
+          >
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -3,9 +3,14 @@ import React, { useState, useEffect, useRef, useCallback } from "react"
 import { useRouter } from "next/router"
 
 import { LOCAL_PEER_ID } from "@common/consts"
-import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
+import {
+  MAX_ADVERTISED_CAPABILITIES,
+  MAX_COLLAB_SUMMARY_LENGTH,
+  MAX_CAPABILITY_LENGTH,
+} from "@do/collab"
 
 import AgentWorkRequestComposer from "./AgentWorkRequestComposer"
+import HumanCapabilitiesEditor from "./HumanCapabilitiesEditor"
 import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
 import WorkspaceSnapshots from "./WorkspaceSnapshots"
@@ -129,6 +134,7 @@ export default function RoomContent({
     sendActionMessage,
     sendCollabRequest,
     sendCollabResponse,
+    updateHumanCapabilities,
     muteSelf,
     toggleScreenShare,
     retryVerification,
@@ -150,6 +156,8 @@ export default function RoomContent({
   const [workRequestTarget, setWorkRequestTarget] = useState<UserInfo | null>(
     null
   )
+  // #119: local-Human capability editor target (self only).
+  const [capabilitiesEditorOpen, setCapabilitiesEditorOpen] = useState(false)
   const requestWorkFor = (p: UserInfo) =>
     setWorkRequestTarget(
       p.kind === "agent" && p.peerId !== LOCAL_PEER_ID ? p : null
@@ -704,6 +712,11 @@ export default function RoomContent({
                       onToggleScreenShare={wrappedToggleScreenShare}
                       onRequestWork={() => requestWorkFor(p)}
                       screenshareAllowed={screenshareAllowed}
+                      onEditCapabilities={
+                        p.kind === "human" && p.peerId === LOCAL_PEER_ID
+                          ? () => setCapabilitiesEditorOpen(true)
+                          : undefined
+                      }
                       className="w-40 flex-none"
                     />
                     {p.peerId === LOCAL_PEER_ID && (
@@ -772,6 +785,22 @@ export default function RoomContent({
           onSubmit={(summary) => {
             sendCollabRequest(workRequestTarget.peerId, summary)
             setWorkRequestTarget(null)
+          }}
+        />
+      )}
+
+      {capabilitiesEditorOpen && (
+        <HumanCapabilitiesEditor
+          initialCapabilities={(
+            participants.find((p) => p.peerId === LOCAL_PEER_ID)
+              ?.capabilities ?? []
+          ).filter((token): token is string => typeof token === "string")}
+          maxLength={MAX_CAPABILITY_LENGTH}
+          maxTokens={MAX_ADVERTISED_CAPABILITIES}
+          onCancel={() => setCapabilitiesEditorOpen(false)}
+          onSave={(capabilities) => {
+            updateHumanCapabilities(capabilities)
+            setCapabilitiesEditorOpen(false)
           }}
         />
       )}

--- a/app/src/components/UserCard.capabilities.test.tsx
+++ b/app/src/components/UserCard.capabilities.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import UserCard from "./UserCard"
+
+function base(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "Hannah",
+    kind: "human" as const,
+    room: "room",
+    peerId: "human-1",
+    ...overrides,
+  }
+}
+
+describe("Human capability display + self-only editor entry (#119)", () => {
+  it("renders advertised capability chips for a Human in full layout", () => {
+    const { getByText } = render(
+      <UserCard
+        {...base()}
+        capabilities={["review.code", "judgment.product"]}
+      />
+    )
+    expect(getByText("review.code")).toBeTruthy()
+    expect(getByText("judgment.product")).toBeTruthy()
+  })
+
+  it("compact layout also displays Human capability chips without breaking layout", () => {
+    const { getByText } = render(
+      <UserCard {...base({ compact: true })} capabilities={["review.code"]} />
+    )
+    expect(getByText("review.code")).toBeTruthy()
+  })
+
+  it("Capabilities editor entry appears ONLY for the local Human self", () => {
+    const onEditCapabilities = vi.fn()
+    // Local Human self.
+    const selfView = render(
+      <UserCard
+        {...base({ peerId: "local-peer" })}
+        onEditCapabilities={onEditCapabilities}
+      />
+    )
+    expect(selfView.getByText("Capabilities")).toBeTruthy()
+    fireEvent.click(selfView.getByText("Capabilities"))
+    expect(onEditCapabilities).toHaveBeenCalledTimes(1)
+    selfView.unmount()
+
+    // Remote Human never gets the editor entry.
+    const remote = render(
+      <UserCard {...base()} onEditCapabilities={onEditCapabilities} />
+    )
+    expect(remote.queryByText("Capabilities")).toBeNull()
+    remote.unmount()
+
+    // Agent cards never get the Human capability editor entry.
+    const agent = render(
+      <UserCard
+        {...base({ name: "Agent B", kind: "agent" })}
+        onEditCapabilities={onEditCapabilities}
+      />
+    )
+    expect(agent.queryByText("Capabilities")).toBeNull()
+    agent.unmount()
+  })
+})

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -16,6 +16,9 @@ interface UserCardProps extends UserInfo {
   /** #113: present only for REMOTE connected Agents — enables the Human
    * "Request work" entry point. Never rendered for Humans or self. */
   onRequestWork?: () => void
+  /** #119: present ONLY for the LOCAL Human self — opens the capability
+   * editor. Never rendered on remote Humans or Agent cards. */
+  onEditCapabilities?: () => void
 }
 
 export default function UserCard(user: UserCardProps) {
@@ -103,6 +106,24 @@ export default function UserCard(user: UserCardProps) {
               className="mt-1 rounded-full bg-blue-600/80 px-2 py-0.5 text-[9px] text-white hover:bg-blue-500"
             >
               Request work
+            </button>
+          )}
+          {(user.capabilities ?? []).slice(0, 2).map((capability) => (
+            <span
+              key={capability}
+              title={capability}
+              className="mt-1 max-w-[64px] truncate rounded-full bg-black/30 px-1.5 py-0.5 text-[8px] text-white/70"
+            >
+              {capability}
+            </span>
+          ))}
+          {user.kind === "human" && isSelf && user.onEditCapabilities && (
+            <button
+              type="button"
+              onClick={user.onEditCapabilities}
+              className="mt-1 rounded-full border border-gray-500 px-1.5 py-0.5 text-[8px] text-gray-300 hover:bg-gray-800"
+            >
+              Capabilities
             </button>
           )}
           {isSelf && (
@@ -265,6 +286,15 @@ export default function UserCard(user: UserCardProps) {
               className="rounded-full bg-blue-600/80 px-2 py-0.5 text-[10px] text-white hover:bg-blue-500"
             >
               Request work
+            </button>
+          )}
+          {isSelf && user.kind === "human" && user.onEditCapabilities && (
+            <button
+              type="button"
+              onClick={user.onEditCapabilities}
+              className="rounded-full border border-gray-500 px-2 py-0.5 text-[9px] text-gray-300 hover:bg-gray-800"
+            >
+              Capabilities
             </button>
           )}
         </div>

--- a/app/src/components/roomCapabilities.wiring.test.tsx
+++ b/app/src/components/roomCapabilities.wiring.test.tsx
@@ -1,0 +1,110 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+/**
+ * #113/#119 production wiring proof: RoomContent must derive the Human
+ * self-only capability editor entry from the canonical Room participant
+ * state (not local editor state), pass the safe public participant id, and
+ * keep the editor away from remote Humans and Agent cards.
+ */
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const mockUseSfuChatRoom = vi.fn()
+vi.mock("../hooks/useSfuChatRoom", () => ({
+  useSfuChatRoom: (...args: unknown[]) => mockUseSfuChatRoom(...args),
+}))
+vi.mock("../hooks/useTurnstile", () => ({
+  useTurnstile: () => ({
+    containerRef: { current: null },
+    requestToken: vi.fn(),
+  }),
+}))
+
+import RoomContent from "./RoomContent"
+
+const LOCAL_PEER = "local-peer"
+
+function connectedParticipants() {
+  return [
+    {
+      peerId: LOCAL_PEER,
+      name: "tester",
+      kind: "human" as const,
+      room: "test-room",
+      capabilities: ["review.code"],
+    },
+    {
+      peerId: "agent-b",
+      name: "Agent B",
+      kind: "agent" as const,
+      room: "test-room",
+      capabilities: ["browser.control"],
+    },
+  ]
+}
+
+beforeEach(() => {
+  // jsdom lacks scrollIntoView; TextChatCard auto-scrolls on new messages.
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+describe("Human capability advertisement wiring (#113/#115/#119)", () => {
+  it("self Human card shows Capabilities; Agent card shows Request work only; Save sends full list via hook", async () => {
+    const sendCollabRequest = vi.fn(() => "")
+    const updateHumanCapabilities = vi.fn()
+    mockUseSfuChatRoom.mockReturnValue({
+      participants: connectedParticipants(),
+      messages: [],
+      sendTextMessage: vi.fn(),
+      sendFileMessage: vi.fn(),
+      sendActionMessage: vi.fn(),
+      sendCollabRequest,
+      sendCollabResponse: vi.fn(),
+      updateHumanCapabilities,
+      getLocalRoomAuth: vi.fn(() => ({
+        roomId: "test-room",
+        participantId: LOCAL_PEER,
+        token: "tok",
+      })),
+      readRoomAttachment: vi.fn(),
+      muteSelf: vi.fn(),
+      toggleScreenShare: vi.fn(),
+      retryVerification: vi.fn(),
+      error: "",
+      connectionStatus: "connected",
+      resolvedRoomType: "audio",
+      meetingNotes: { active: false },
+      meetingNotesMediaAvailable: true,
+      startMeetingNotes: vi.fn(),
+      stopMeetingNotes: vi.fn(),
+    })
+
+    render(
+      <RoomContent roomName="test-room" nickName="tester" roomType="audio" />
+    )
+
+    // Self Human: Capabilities entry present; no Request work on own card.
+    expect(screen.getByText("Capabilities")).toBeTruthy()
+
+    // Remote Agent card: Request work present.
+    const requestButtons = screen.getAllByText(/Request work/)
+    expect(requestButtons.length).toBe(1)
+
+    // Open the editor via the self card and save a replacement list.
+    fireEvent.click(screen.getByText("Capabilities"))
+    const input = screen.getByPlaceholderText("Add capability…")
+    fireEvent.change(input, { target: { value: "judgment.product" } })
+    fireEvent.click(screen.getByText("Add"))
+    fireEvent.click(screen.getByTestId("save-capabilities"))
+    expect(updateHumanCapabilities).toHaveBeenCalledTimes(1)
+    // Editor initialized from canonical Room state (["review.code"]) and
+    // Save sends the FULL replacement list including the added token.
+    expect(updateHumanCapabilities).toHaveBeenCalledWith([
+      "review.code",
+      "judgment.product",
+    ])
+  })
+})

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -5,6 +5,7 @@ import {
   CollabRegistry,
   COLLAB_ACTION_TYPE,
   rosterProjection,
+  sanitizeStoredAdvertisedList,
   sanitizeStoredAgentCapabilities,
   validateAdvertisedCapabilities,
   validateCollabEvent,
@@ -315,6 +316,13 @@ type ClientMessage =
       decision: "accepted" | "declined"
       summary?: string
     }
+  | {
+      // #119: Human self-advertised capability list replacement (discovery
+      // metadata only). Identity from the authenticated attachment; payload
+      // carries ONLY the capability tokens.
+      type: "human-update-capabilities"
+      capabilities: string[]
+    }
   | { type: "mute"; muted: boolean }
   | { type: "unpublish"; trackName: string }
   | { type: "datachannel-ready" }
@@ -441,6 +449,25 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         delete participant.fileChannelReady
         delete participant.tracks
         changed = true
+      }
+      // #119 storage hygiene: malformed persisted Human advertised lists are
+      // repaired/dropped (never rejected) so room loading cannot wedge.
+      if (participant.kind === "human") {
+        const sanitizedAdvertised = sanitizeStoredAdvertisedList(
+          participant.advertised
+        )
+        if (sanitizedAdvertised.changed) {
+          if (sanitizedAdvertised.advertised)
+            participant.advertised = sanitizedAdvertised.advertised
+          else delete participant.advertised
+          changed = true
+        } else if (
+          sanitizedAdvertised.advertised &&
+          sanitizedAdvertised.advertised.length === 0
+        ) {
+          delete participant.advertised
+          changed = true
+        }
       }
       participants[id] = participant
     }
@@ -2301,6 +2328,29 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       }
       // Canonical RoomMessage already broadcast (duplicate retries append
       // nothing and wake nothing); the UI learns state via the ordinary path.
+      return
+    }
+
+    // #119: Human capability advertisement is presence/discovery state.
+    // Fail closed on invalid input (no mutation/persist/broadcast); valid
+    // updates replace the entire advertised list atomically and NEVER touch
+    // messages, sequence numbers, collab state, or Agent waiters.
+    if (message.type === "human-update-capabilities") {
+      if (participant.kind !== "human") {
+        socket.send(JSON.stringify({ type: "error", error: "human_only" }))
+        return
+      }
+      const validated = validateAdvertisedCapabilities(message.capabilities)
+      if (validated.ok === false) {
+        socket.send(JSON.stringify({ type: "error", error: validated.error }))
+        return
+      }
+      participant.lastSeenAt = Date.now()
+      if (validated.capabilities.length === 0) delete participant.advertised
+      else participant.advertised = validated.capabilities
+      await this.saveRoom(room)
+      // Presence/discovery broadcast only — deliberately no waiter wake.
+      await this.broadcastState(room)
       return
     }
 

--- a/app/src/do/collab.test.ts
+++ b/app/src/do/collab.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   agentCapabilitiesFrom,
+  sanitizeStoredAdvertisedList,
   CollabRegistry,
   MAX_ADVERTISED_CAPABILITIES,
   rosterProjection,
@@ -745,5 +746,99 @@ describe("CollabRegistry Human-targeted requests (#115)", () => {
       action: "duplicate",
       sequence: 21,
     })
+  })
+})
+
+describe("sanitizeStoredAdvertisedList (#119)", () => {
+  it("keeps a clean list untouched (same reference)", () => {
+    const clean = ["review.code", "judgment.product"]
+    const result = sanitizeStoredAdvertisedList(clean)
+    expect(result.changed).toBe(false)
+    expect(result.advertised).toBe(clean)
+  })
+
+  it("drops malformed entries and dedupes", () => {
+    const result = sanitizeStoredAdvertisedList([
+      "review.code",
+      "Review Code",
+      ".leading",
+      "",
+      42,
+      "review.code",
+    ])
+    expect(result.changed).toBe(true)
+    expect(result.advertised).toEqual(["review.code"])
+  })
+
+  it("truncates to the existing bound", () => {
+    const result = sanitizeStoredAdvertisedList(
+      Array.from({ length: 10 }, (_, i) => `cap${i}`)
+    )
+    expect(result.changed).toBe(true)
+    expect(result.advertised?.length).toBe(8)
+  })
+
+  it("non-array input is removed", () => {
+    expect(sanitizeStoredAdvertisedList("nope")).toEqual({
+      advertised: undefined,
+      changed: true,
+    })
+  })
+
+  it("empty resulting list is represented as undefined for omission", () => {
+    const result = sanitizeStoredAdvertisedList(["bad token"])
+    expect(result).toEqual({ advertised: undefined, changed: true })
+  })
+})
+
+describe("rosterProjection Human advertised (#119)", () => {
+  it("projects Human top-level advertised tokens", () => {
+    const roster = rosterProjection({
+      "human-h": participant({
+        id: "human-h",
+        name: "Hannah",
+        kind: "human",
+        advertised: ["review.code", "judgment.product"],
+      }),
+    })
+    expect(roster[0].advertised).toEqual(["review.code", "judgment.product"])
+  })
+
+  it("Human without advertised has no advertised field", () => {
+    const roster = rosterProjection({
+      "human-h": participant({ id: "human-h", name: "Hannah", kind: "human" }),
+    })
+    expect(roster[0]).not.toHaveProperty("advertised")
+  })
+
+  it("Agent nested capability projection remains unchanged", () => {
+    const roster = rosterProjection({
+      "agent-b": participant({
+        id: "agent-b",
+        capabilities: { text: true, advertised: ["browser.control"] },
+      }),
+    })
+    expect(roster[0].advertised).toEqual(["browser.control"])
+  })
+
+  it("disconnected participants stay absent and secrets never enter the projection", () => {
+    const roster = rosterProjection({
+      "human-off": participant({
+        id: "human-off",
+        kind: "human",
+        connected: false,
+        advertised: ["review.code"],
+        token: "secret-token",
+        connectionNonce: "nonce-x",
+      }),
+    })
+    expect(roster).toHaveLength(0)
+    const serialized = JSON.stringify(
+      rosterProjection({
+        "human-on": participant({ id: "human-on", name: "On", kind: "human" }),
+      })
+    )
+    expect(serialized.includes("token")).toBe(false)
+    expect(serialized.includes("nonce")).toBe(false)
   })
 })

--- a/app/src/do/collab.ts
+++ b/app/src/do/collab.ts
@@ -112,6 +112,37 @@ export function sanitizeStoredAgentCapabilities(
   }
 }
 
+/** #119 storage-hygiene pass for Human self-advertised lists persisted on
+ * the participant record: malformed historic state is repaired/dropped
+ * (never rejected) so Room loading cannot wedge. Same token grammar and
+ * bounds as the Agent capability contract (#106). */
+export function sanitizeStoredAdvertisedList(value: unknown): {
+  advertised?: string[]
+  changed: boolean
+} {
+  if (!Array.isArray(value))
+    return { advertised: undefined, changed: value !== undefined }
+  const cleaned = value.filter(
+    (token) =>
+      typeof token === "string" &&
+      token.length > 0 &&
+      token.length <= MAX_CAPABILITY_LENGTH &&
+      CAPABILITY_PATTERN.test(token)
+  )
+  const deduped = [...new Set(cleaned)].slice(0, MAX_ADVERTISED_CAPABILITIES)
+  // An empty RESULT means "advertise nothing": represent as omitted so the
+  // participant field disappears instead of lingering as [].
+  if (
+    deduped.length === value.length &&
+    deduped.every((token, index) => token === value[index])
+  )
+    return { advertised: value as string[], changed: false }
+  return {
+    advertised: deduped.length > 0 ? deduped : undefined,
+    changed: true,
+  }
+}
+
 export interface ParticipantRosterEntry {
   id: string
   name: string
@@ -130,17 +161,23 @@ export function rosterProjection(
 ): ParticipantRosterEntry[] {
   return Object.values(participants)
     .filter((participant) => participant.connected)
-    .map((participant) => ({
-      id: participant.id,
-      name: participant.name,
-      kind: participant.kind,
-      ...(participant.kind === "agent" && participant.capabilities?.advertised
-        ? { advertised: participant.capabilities.advertised }
-        : {}),
-      ...(participant.kind === "agent" && participant.surface
-        ? { surface: participant.surface }
-        : {}),
-    }))
+    .map((participant) => {
+      // #119: one normalized peer-discovery shape across kinds — Humans
+      // advertise via the top-level field, Agents via capabilities.advertised.
+      const advertised =
+        participant.kind === "human"
+          ? participant.advertised
+          : participant.capabilities?.advertised
+      return {
+        id: participant.id,
+        name: participant.name,
+        kind: participant.kind,
+        ...(advertised && advertised.length > 0 ? { advertised } : {}),
+        ...(participant.kind === "agent" && participant.surface
+          ? { surface: participant.surface }
+          : {}),
+      }
+    })
 }
 
 export interface CollabEventInput {

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -4,7 +4,10 @@ import { LOCAL_PEER_ID } from "@common/consts"
 import { mergeRoomAndEphemeralMessages } from "@common/messageReconciliation"
 import { validateRoomAttachmentRead } from "@common/roomAttachments"
 import { ActionType, Message, UserInfo } from "@common/types"
-import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
+import {
+  MAX_COLLAB_SUMMARY_LENGTH,
+  validateAdvertisedCapabilities,
+} from "@do/collab"
 
 import type { RoomAttachmentRead } from "../room/types"
 import type {
@@ -297,7 +300,7 @@ export function useSfuChatRoom(
         capabilities:
           participant.kind === "agent"
             ? participant.capabilities?.advertised
-            : undefined,
+            : participant.advertised,
         surface: participant.kind === "agent" ? participant.surface : undefined,
         audioStream: remoteAudioStreamsRef.current.get(participant.id) ?? null,
         screenShareEnabled: hasScreenShare,
@@ -1444,6 +1447,24 @@ export function useSfuChatRoom(
     [sendSocketMessage]
   )
 
+  // #119: replace THIS Human's advertised capability list (discovery
+  // metadata only). Local guard uses the same shared validator as the
+  // server; the authoritative list comes back via Room state broadcast.
+  // Returns true when the envelope was sent.
+  const updateHumanCapabilities = useCallback(
+    (capabilities: string[]): boolean => {
+      if (websocketRef.current?.readyState !== WebSocket.OPEN) return false
+      const validated = validateAdvertisedCapabilities(capabilities)
+      if (!validated.ok) return false
+      sendSocketMessage({
+        type: "human-update-capabilities",
+        capabilities: validated.capabilities,
+      })
+      return true
+    },
+    [sendSocketMessage]
+  )
+
   // #113: Human-originated structured work request to a connected Agent.
   // Returns the generated requestId (empty string when rejected locally).
   // The canonical RoomMessage arrives via the ordinary broadcast — no
@@ -1605,6 +1626,7 @@ export function useSfuChatRoom(
     sendActionMessage,
     sendCollabRequest,
     sendCollabResponse,
+    updateHumanCapabilities,
     readRoomAttachment,
     localParticipantId: sessionRef.current?.participantId,
     muteSelf,

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -64,6 +64,10 @@ export interface RoomParticipant {
   connectionNonce?: string
   token: string
   capabilities?: AgentCapabilities
+  // #119: Human self-advertised capability tokens (discovery metadata only —
+  // never authorization). Top-level field for Humans; Agents keep the nested
+  // `capabilities.advertised` representation for backward compatibility.
+  advertised?: string[]
   // #111 Observable Agent Workspace v0: metadata for this Agent's single
   // latest explicitly-published workspace snapshot. Metadata only — bytes
   // live in bounded DO chunk storage under surface:* keys and are readable


### PR DESCRIPTION
Closes #119 — completes capability-discovery symmetry (#106/#113/#115/#117): Humans are now full structured-collaboration peers but Agents cannot discover Human capabilities like `review.code` or `judgment.product`. **Discovery only.**

## Exact base SHA
`be18ecc07692a9fa103b3baaebb4749b28bc8499` (latest cf-sfu at branch time, post-#118 merge).

## WS envelope
```json
{ "type": "human-update-capabilities", "capabilities": ["review.code", "judgment.product"] }
```
No participantId/senderId/token/target/authorization fields — **identity derives from the authenticated WebSocket attachment**; the payload controls ONLY the token list.

## Durable Human field shape
Top-level `RoomParticipant.advertised?: string[]` for Humans. Agents keep the nested `capabilities.advertised` representation unchanged — no schema migration (deliberate: keeps this a focused feature rather than a participant-schema rewrite).

## #106 validation reuse
Ingress runs the existing shared `validateAdvertisedCapabilities()` (max 8 tokens / 48 chars / namespaced grammar / trim+lowercase+dedupe). Invalid submissions fail closed via the existing WS error frame with zero mutation. Same rules continue to govern Agent capabilities.

## Storage sanitation
`normalizeRoom` repairs malformed persisted Human lists (non-array removed; invalid entries dropped; dedupe; truncate to 8; empty result omits the field) so historic bad data can never wedge Room loading. Ingress rejects; storage normalizes.

## Normalized roster output
`rosterProjection()` now emits one peer-discovery shape for both kinds:
```json
{ "id": "human-h", "name": "Hannah", "kind": "human", "advertised": ["review.code"] }
{ "id": "agent-b", "name": "Agent B", "kind": "agent", "advertised": ["browser.control"], "surface": {...} }
```
Surface stays Agent-only. room_info's safe-participant projection exposes Human `advertised` through the same path; token/connectionNonce remain stripped.

## Runtime compatibility proof (zero production changes)
Existing `normalizeRosterEntry()` parses `{id:"human-h", name:"Hannah", kind:"human", advertised:["review.code","judgment.product"]}` unchanged — regression-tested in agent-runtime (test-only). No agent-runtime/src changes, no version bump.

## No-message / no-sequence / no-wake proof
Capability updates are presence/discovery state: the handler never calls appendMessage, never touches nextMessageSequence, never creates CollabEvents, and never resolves Agent waiters. Agents observe updated rosters through ordinary room_info / wait_for_events responses. Regression-tested.

## UI (self-only edit matrix)
- "Capabilities" entry rendered ONLY on the local Human self card (`onEditCapabilities` passed solely when `p.kind === "human" && p.peerId === LOCAL_PEER_ID`) — remote Humans and Agent cards never get it.
- Focused `HumanCapabilitiesEditor`: chip list with per-token ×, add input with grammar/bounds guard (shared validator constants), Save sends FULL replacement list, Cancel mutates nothing, empty list allowed (= advertise nothing), ninth capability prevented.
- Editor initializes from canonical Room participant state; authoritative display always comes back through Room state broadcast (no stale local-only truth).
- Capability chips render for both kinds in normal + compact layouts; helper text states capabilities do not grant permissions.

## Boundary
Capability = discovery metadata ("may be useful to ask about"). NOT authorization, NOT ACP/tool/shell/browser/GitHub approval, NOT credentials, NOT media grant, NOT remote control. No inference from browser/account/history; every token explicitly chosen. No automatic request routing — Agents still use the existing `send_collab_request(targetParticipantId)`.

## Compatibility
#113 Human→Agent requests, #115 accept/decline, artifact inspection (#117), Agent→Agent discovery, Meeting Notes, expiry, attachments, media authorization — all suites green.

## Tests & gates
- App vitest **234/234** (27 files) incl. new sanitize matrix, roster projection cases, editor suite (6), UserCard visibility matrix (3), production wiring proof (RoomContent → UserCard → hook).
- app prettier/eslint/tsc/cf-build ✅.
- agent-runtime **134/134** (test-only addition) + format/lint/tsc/build/pack:check ✅.

## Non-goals honored
No routing/matching/ranking, planner/DAG/scheduler/retry, approval/permission engine, queue/availability/pricing/reputation, global/permanent profiles, OAuth/R2/D1/KV/new DO, MCP tools, Runtime production/version changes, Pion/Surface/voice/media-publication/remote-control changes. No version bump, no npm publish, no Pion release, no migration, no new Cloudflare binding.

## Manual acceptance
Executed via the wiring test (steps 1–5 of #119 §32): empty advertised absent → save review.code+judgment.product → chips + roster visible → existing structured request flow untouched → clear removes advertised without affecting collab history. Live two-party run pending deployment.