### PR TITLE
feat(#121): Human completed/failed results for Agent work requests

### DIFF
--- a/app/src/components/HumanCollabResultComposer.test.tsx
+++ b/app/src/components/HumanCollabResultComposer.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import HumanCollabResultComposer from "./HumanCollabResultComposer"
+
+const base = {
+  requestId: "req-res-9",
+  maxLength: 1200,
+}
+
+describe("HumanCollabResultComposer (#121)", () => {
+  it("renders Completed header and helper copy stating result does not grant tools or permissions", () => {
+    render(
+      <HumanCollabResultComposer
+        {...base}
+        status="completed"
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Completed — request/)).toBeTruthy()
+    expect(
+      screen.getByText(
+        /Your result is shared with the Agent\. It does not grant tools or permissions\./
+      )
+    ).toBeTruthy()
+  })
+
+  it("renders Failed header for failed status", () => {
+    render(
+      <HumanCollabResultComposer
+        {...base}
+        status="failed"
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/Failed — request/)).toBeTruthy()
+  })
+
+  it("disables Send for empty/whitespace notes", () => {
+    const onSubmit = vi.fn()
+    render(
+      <HumanCollabResultComposer
+        {...base}
+        status="completed"
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+    const send = screen.getByTestId(
+      "send-collab-result-completed"
+    ) as HTMLButtonElement
+    expect(send.disabled).toBe(true)
+    fireEvent.change(screen.getByPlaceholderText("What was the outcome?"), {
+      target: { value: "   " },
+    })
+    expect(
+      (screen.getByTestId("send-collab-result-completed") as HTMLButtonElement)
+        .disabled
+    ).toBe(true)
+  })
+
+  it("trims the note and sends exact requestId/status/summary", () => {
+    const onCancel = vi.fn()
+    const onSubmit = vi.fn()
+    render(
+      <HumanCollabResultComposer
+        {...base}
+        status="completed"
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+      />
+    )
+    const field = screen.getByPlaceholderText("What was the outcome?")
+    fireEvent.change(field, {
+      target: { value: "  Reviewed. No blocking issue.  " },
+    })
+    fireEvent.click(screen.getByTestId("send-collab-result-completed"))
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+    expect(onSubmit).toHaveBeenCalledWith("Reviewed. No blocking issue.")
+    expect(onCancel).not.toHaveBeenCalled()
+  })
+
+  it("enforces maximum length", () => {
+    render(
+      <HumanCollabResultComposer
+        {...base}
+        status="completed"
+        maxLength={10}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+    const field = screen.getByPlaceholderText(
+      "What was the outcome?"
+    ) as HTMLTextAreaElement
+    fireEvent.change(field, { target: { value: "a".repeat(50) } })
+    expect(field.value.length).toBe(10)
+  })
+
+  it("Cancel never submits", () => {
+    const onCancel = vi.fn()
+    const onSubmit = vi.fn()
+    render(
+      <HumanCollabResultComposer
+        {...base}
+        status="failed"
+        onCancel={onCancel}
+        onSubmit={onSubmit}
+      />
+    )
+    fireEvent.click(screen.getByText("Cancel"))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it("exposes no attachment or details inputs", () => {
+    render(
+      <HumanCollabResultComposer
+        {...base}
+        status="completed"
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+    expect(screen.queryByText(/attachment/i)).toBeNull()
+    expect(screen.queryByLabelText(/details/i)).toBeNull()
+    expect(screen.queryAllByRole("textbox").length).toBe(1)
+  })
+})

--- a/app/src/components/HumanCollabResultComposer.tsx
+++ b/app/src/components/HumanCollabResultComposer.tsx
@@ -1,0 +1,80 @@
+import { useState } from "react"
+
+interface HumanCollabResultComposerProps {
+  requestId: string
+  status: "completed" | "failed"
+  maxLength: number
+  onCancel: () => void
+  onSubmit: (summary: string) => void
+}
+
+/**
+ * #121: Human terminal result for an Agent-originated request this Human
+ * accepted. Records Room-level collaboration judgment ONLY — the result is
+ * shared with the Agent and does not grant tools or permissions. v0 carries
+ * no attachments and no structured details.
+ */
+export default function HumanCollabResultComposer({
+  requestId,
+  status,
+  maxLength,
+  onCancel,
+  onSubmit,
+}: HumanCollabResultComposerProps) {
+  const [note, setNote] = useState("")
+  const trimmed = note.trim()
+  const canSend = trimmed.length > 0
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
+      <div className="w-full max-w-md rounded-xl border border-gray-700 bg-gray-900 p-4">
+        <h3 className="text-sm font-medium text-white">
+          {status === "completed" ? "Completed" : "Failed"} — request{" "}
+          <span className="font-mono text-[11px] text-gray-400">
+            {requestId.slice(0, 8)}
+          </span>
+        </h3>
+        <textarea
+          autoFocus
+          value={note}
+          onChange={(event) => setNote(event.target.value.slice(0, maxLength))}
+          placeholder={
+            status === "completed"
+              ? "What was the outcome?"
+              : "Why did this fail?"
+          }
+          className="mt-3 h-24 w-full resize-none rounded-lg border border-gray-700 bg-black/40 px-3 py-2 text-sm text-white placeholder:text-gray-500"
+        />
+        <p className="mt-1 text-right text-[10px] text-gray-500">
+          {note.length}/{maxLength}
+        </p>
+        <p className="mt-2 text-[11px] leading-snug text-gray-400">
+          Your result is shared with the Agent. It does not grant tools or
+          permissions.
+        </p>
+        <div className="mt-3 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="rounded-lg border border-gray-600 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canSend}
+            onClick={() => canSend && onSubmit(trimmed)}
+            data-testid={`send-collab-result-${status}`}
+            className={`rounded-lg px-3 py-1.5 text-xs font-medium ${
+              canSend
+                ? "bg-blue-600 text-white hover:bg-blue-500"
+                : "cursor-not-allowed bg-gray-700 text-gray-400"
+            }`}
+          >
+            Send result
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -134,6 +134,8 @@ export default function RoomContent({
     sendActionMessage,
     sendCollabRequest,
     sendCollabResponse,
+    readRoomAttachment,
+    sendCollabResult,
     updateHumanCapabilities,
     muteSelf,
     toggleScreenShare,
@@ -771,6 +773,10 @@ export default function RoomContent({
             localParticipantId={getLocalRoomAuth()?.participantId}
             onCollabRespond={(requestId, decision) => {
               sendCollabResponse(requestId, decision)
+            }}
+            onReadArtifact={(attachmentId) => readRoomAttachment(attachmentId)}
+            onCollabResult={(requestId, status, summary) => {
+              sendCollabResult(requestId, status, summary)
             }}
           />
         </div>

--- a/app/src/components/TextChatCard.human-result.test.tsx
+++ b/app/src/components/TextChatCard.human-result.test.tsx
@@ -1,0 +1,167 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+/**
+ * #121 production wiring proof: RoomContent -> TextChatCard renders
+ * lifecycle-derived Human terminal controls from CANONICAL messages and the
+ * submit path reaches the hook's sendCollabResult with exact values.
+ */
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const mockUseSfuChatRoom = vi.fn()
+vi.mock("../hooks/useSfuChatRoom", () => ({
+  useSfuChatRoom: (...args: unknown[]) => mockUseSfuChatRoom(...args),
+}))
+vi.mock("../hooks/useTurnstile", () => ({
+  useTurnstile: () => ({
+    containerRef: { current: null },
+    requestToken: vi.fn(),
+  }),
+}))
+
+import type { Message } from "@common/types"
+
+import RoomContent from "./RoomContent"
+
+const LOCAL_HUMAN = "human-h"
+
+function collabMessage(
+  requestId: string,
+  kind: "request" | "accepted" | "declined" | "completed" | "failed",
+  from: string
+): Message {
+  return {
+    peerId: from,
+    name:
+      from === "agent-a" ? "Agent A" : from === LOCAL_HUMAN ? "Hannah" : from,
+    kind: from.startsWith("human") ? "human" : "agent",
+    type: "action",
+    actionType: "collab",
+    sequence: 1,
+    collab: {
+      requestId,
+      kind,
+      fromParticipantId: from,
+      targetParticipantId: kind === "request" ? LOCAL_HUMAN : "agent-a",
+      summary: kind === "request" ? "Please review the UX." : "done",
+    },
+  }
+}
+
+function hookReturn(
+  messages: Message[],
+  sendCollabResult: ReturnType<typeof vi.fn>
+) {
+  return {
+    participants: [
+      {
+        peerId: LOCAL_HUMAN,
+        name: "Hannah",
+        kind: "human" as const,
+        room: "test-room",
+      },
+    ],
+    messages,
+    getLocalRoomAuth: () => ({
+      roomId: "test-room",
+      participantId: LOCAL_HUMAN,
+      token: "tok",
+    }),
+    sendCollabResult,
+    readRoomAttachment: vi.fn(),
+    sendTextMessage: vi.fn(),
+    sendFileMessage: vi.fn(),
+    sendActionMessage: vi.fn(),
+    muteSelf: vi.fn(),
+    toggleScreenShare: vi.fn(),
+    retryVerification: vi.fn(),
+    error: "",
+    connectionStatus: "connected",
+    resolvedRoomType: "audio" as const,
+    meetingNotes: { active: false },
+    meetingNotesMediaAvailable: true,
+    startMeetingNotes: vi.fn(),
+    stopMeetingNotes: vi.fn(),
+  }
+}
+
+describe("Human terminal result wiring (#121)", () => {
+  let sendCollabResult: ReturnType<typeof vi.fn>
+
+  afterEach(cleanup)
+
+  beforeEach(() => {
+    // jsdom lacks scrollIntoView; TextChatCard auto-scrolls on new messages.
+    Element.prototype.scrollIntoView = vi.fn()
+    sendCollabResult = vi.fn()
+  })
+
+  function renderWith(messages: Message[]) {
+    mockUseSfuChatRoom.mockReturnValue(hookReturn(messages, sendCollabResult))
+    render(<RoomContent roomName="room" nickName="Hannah" roomType="audio" />)
+  }
+
+  it("before Accept only response controls show (no terminal controls)", () => {
+    renderWith([collabMessage("r1", "request", "agent-a")])
+    expect(screen.getByText("Accept")).toBeTruthy()
+    expect(screen.queryByText("Mark complete")).toBeNull()
+    expect(screen.queryByText("Mark failed")).toBeNull()
+  })
+
+  it("after canonical accepted: Mark complete/failed appear wired to the production callback", () => {
+    renderWith([
+      collabMessage("r1", "request", "agent-a"),
+      collabMessage("r1", "accepted", LOCAL_HUMAN),
+    ])
+    expect(screen.queryByText("Accept")).toBeNull()
+    expect(screen.getByText("Mark complete")).toBeTruthy()
+    expect(screen.getByText("Mark failed")).toBeTruthy()
+
+    // Clicking Mark failed opens the composer; fill the note and submit.
+    fireEvent.click(screen.getByText("Mark failed"))
+    const field = screen.getByPlaceholderText("Why did this fail?")
+    fireEvent.change(field, {
+      target: { value: "  Could not verify: login page broken.  " },
+    })
+    fireEvent.click(screen.getByTestId("send-collab-result-failed"))
+    expect(sendCollabResult).toHaveBeenCalledWith(
+      "r1",
+      "failed",
+      "Could not verify: login page broken."
+    )
+  })
+
+  it("terminal controls disappear once a canonical completed exists; lifecycle card remains", () => {
+    renderWith([
+      collabMessage("r1", "request", "agent-a"),
+      collabMessage("r1", "accepted", LOCAL_HUMAN),
+      { ...collabMessage("r1", "completed", LOCAL_HUMAN), name: "Hannah" },
+    ])
+    expect(screen.queryByText("Mark complete")).toBeNull()
+    expect(screen.queryByText("Mark failed")).toBeNull()
+    expect(screen.getByText(/Hannah completed the request/)).toBeTruthy()
+  })
+
+  it("requests targeting another Human or between Agents show no local terminal controls", () => {
+    const cases: Message[][] = []
+    const otherHuman = collabMessage("r3", "request", "agent-a")
+    if (otherHuman.collab) otherHuman.collab.targetParticipantId = "human-OTHER"
+    cases.push([otherHuman])
+    const a2aRequest = collabMessage("r4", "request", "agent-b")
+    if (a2aRequest.collab) {
+      a2aRequest.collab.targetParticipantId = "agent-c"
+      a2aRequest.collab.fromParticipantId = "agent-b"
+    }
+    cases.push([a2aRequest])
+    for (const messages of cases) {
+      const view = render(
+        <RoomContent roomName="room" nickName="Hannah" roomType="audio" />
+      )
+      expect(screen.queryByText("Mark complete")).toBeNull()
+      expect(screen.queryByText("Mark failed")).toBeNull()
+      view.unmount()
+    }
+  })
+})

--- a/app/src/components/TextChatCard.tsx
+++ b/app/src/components/TextChatCard.tsx
@@ -5,9 +5,15 @@ import Avatar from "boring-avatars"
 import { LOCAL_PEER_ID } from "@common/consts"
 import { ActionType, Message } from "@common/types"
 import { strToBgColor, umamiEvent, hashRoom } from "@common/utils"
+import { MAX_COLLAB_SUMMARY_LENGTH } from "@do/collab"
 
 import CollabArtifactViewer from "./CollabArtifactViewer"
-import { isCollabRequestAnswered } from "./collabUi"
+import {
+  hasCollabTerminalResult,
+  isCollabRequestAccepted,
+  isCollabRequestAnswered,
+} from "./collabUi"
+import HumanCollabResultComposer from "./HumanCollabResultComposer"
 import { resolveAgentTargetIds } from "../common/agentMentions"
 import type { UserInfo } from "../common/types"
 import type { RoomAttachmentRead } from "../room/types"
@@ -43,6 +49,12 @@ interface TextChatCardProps {
   ) => void
   /** #117: authenticated on-demand read of one room collaboration artifact. */
   onReadArtifact?: (attachmentId: string) => Promise<RoomAttachmentRead>
+  /** #121: submit a Human terminal result for a request this Human accepted. */
+  onCollabResult?: (
+    requestId: string,
+    status: "completed" | "failed",
+    summary: string
+  ) => void
 }
 
 const GAMES = [
@@ -249,6 +261,8 @@ function ActionCard({
   localParticipantId,
   onCollabRespond,
   onViewArtifact,
+  onCollabResult,
+  onOpenResultComposer,
 }: {
   msg: Message
   isSelf: boolean
@@ -261,6 +275,15 @@ function ActionCard({
     decision: "accepted" | "declined"
   ) => void
   onViewArtifact?: (attachmentId: string) => void
+  onCollabResult?: (
+    requestId: string,
+    status: "completed" | "failed",
+    summary: string
+  ) => void
+  onOpenResultComposer?: (target: {
+    requestId: string
+    status: "completed" | "failed"
+  }) => void
 }) {
   if (msg.actionType === "reaction") return null
 
@@ -270,6 +293,24 @@ function ActionCard({
     // record. A later accepted/declined for the same requestId means the
     // decision is made; never keep authoritative state in React.
     const answered = isCollabRequestAnswered(allMessages, collab.requestId)
+    const accepted = isCollabRequestAccepted(allMessages, collab.requestId)
+    const terminal = hasCollabTerminalResult(allMessages, collab.requestId)
+    const declinedPresent = allMessages.some(
+      (m) =>
+        m.collab?.requestId === collab.requestId && m.collab.kind === "declined"
+    )
+    // #121: terminal controls appear ONLY when THIS Human is the target,
+    // the request came from someone else, it was ACCEPTED, and no terminal
+    // result exists yet — lifecycle derived from canonical messages.
+    const showResultControls =
+      collab.kind === "request" &&
+      Boolean(onCollabResult) &&
+      Boolean(localParticipantId) &&
+      collab.targetParticipantId === localParticipantId &&
+      collab.fromParticipantId !== localParticipantId &&
+      accepted &&
+      !terminal &&
+      !declinedPresent
     // Response controls appear ONLY when THIS Human is the request target
     // and the request came from someone else (never on own outbound
     // requests, Agent-targeted requests, or already-answered ones).
@@ -350,6 +391,40 @@ function ActionCard({
                 className="rounded-md border border-gray-600 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
               >
                 Decline
+              </button>
+            </div>
+          </div>
+        )}
+        {!showRespond && showResultControls && (
+          <div className="mt-2 border-t border-white/10 pt-1.5">
+            <p className="text-[10px] leading-snug text-gray-400">
+              Your result is shared with the Agent and does not grant tools or
+              permissions.
+            </p>
+            <div className="mt-1.5 flex gap-1.5">
+              <button
+                type="button"
+                onClick={() =>
+                  onOpenResultComposer({
+                    requestId: collab.requestId,
+                    status: "completed",
+                  })
+                }
+                className="rounded-md bg-emerald-600/90 px-2 py-1 text-[11px] font-medium text-white hover:bg-emerald-500"
+              >
+                Mark complete
+              </button>
+              <button
+                type="button"
+                onClick={() =>
+                  onOpenResultComposer({
+                    requestId: collab.requestId,
+                    status: "failed",
+                  })
+                }
+                className="rounded-md border border-gray-600 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
+              >
+                Mark failed
               </button>
             </div>
           </div>
@@ -588,12 +663,18 @@ export default function TextChatCard({
   localParticipantId,
   onCollabRespond,
   onReadArtifact,
+  onCollabResult,
 }: TextChatCardProps) {
   const [message, setMessage] = useState<string>("")
   const [submenu, setSubmenu] = useState<"games" | null>(null)
   const [showPollCreator, setShowPollCreator] = useState<boolean>(false)
   const [pickerIndex, setPickerIndex] = useState(0)
   const [artifactId, setArtifactId] = useState<string | null>(null)
+  // #121: pending Human terminal result ({requestId,status} | null).
+  const [resultTarget, setResultTarget] = useState<{
+    requestId: string
+    status: "completed" | "failed"
+  } | null>(null)
   const [selectedAgents, setSelectedAgents] = useState<
     Array<{ id: string; name: string }>
   >([])
@@ -875,6 +956,8 @@ export default function TextChatCard({
                       onViewArtifact={(attachmentId) =>
                         setArtifactId(attachmentId)
                       }
+                      onCollabResult={onCollabResult}
+                      onOpenResultComposer={(target) => setResultTarget(target)}
                     />
                   ) : (
                     <FileMessageBubble msg={p} isSelf={isSelf} />
@@ -1135,6 +1218,23 @@ export default function TextChatCard({
           attachmentId={artifactId}
           read={onReadArtifact}
           onClose={() => setArtifactId(null)}
+        />
+      )}
+
+      {resultTarget && onCollabResult && (
+        <HumanCollabResultComposer
+          requestId={resultTarget.requestId}
+          status={resultTarget.status}
+          maxLength={MAX_COLLAB_SUMMARY_LENGTH}
+          onCancel={() => setResultTarget(null)}
+          onSubmit={(summary) => {
+            onCollabResult?.(
+              resultTarget.requestId,
+              resultTarget.status,
+              summary
+            )
+            setResultTarget(null)
+          }}
         />
       )}
     </>

--- a/app/src/components/collabUi.test.ts
+++ b/app/src/components/collabUi.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import type { Message } from "@common/types"
 
-import { isCollabRequestAnswered } from "./collabUi"
+import { hasCollabTerminalResult, isCollabRequestAnswered } from "./collabUi"
 function collab(
   requestId: string,
   kind: "request" | "accepted" | "declined" | "completed" | "failed"
@@ -46,5 +46,34 @@ describe("isCollabRequestAnswered (#115)", () => {
   it("ignores decisions for other requests", () => {
     const log = [collab("r1", "request"), collab("r2", "accepted")]
     expect(isCollabRequestAnswered(log, "r1")).toBe(false)
+  })
+})
+
+describe("terminal-result lifecycle helpers (#121)", () => {
+  it("accepted marks the request accepted but not terminal", () => {
+    const log = [collab("r1", "request"), collab("r1", "accepted")]
+    expect(isCollabRequestAnswered(log, "r1")).toBe(true)
+    expect(hasCollabTerminalResult(log, "r1")).toBe(false)
+  })
+
+  it("completed/failed are terminal", () => {
+    for (const kind of ["completed", "failed"] as const) {
+      const log = [collab("r1", "request"), collab("r1", kind)]
+      expect(isCollabRequestAnswered(log, "r1")).toBe(false)
+      expect(hasCollabTerminalResult(log, "r1")).toBe(true)
+    }
+  })
+
+  it("declined is answered AND terminal (no Human result controls after decline)", () => {
+    const log = [collab("r1", "request"), collab("r1", "declined")]
+    expect(isCollabRequestAnswered(log, "r1")).toBe(true)
+    expect(hasCollabTerminalResult(log, "r1")).toBe(false)
+  })
+
+  it("decisions for other requestIds never leak into this lifecycle", () => {
+    const log = [collab("r2", "accepted"), collab("r2", "completed")]
+    expect(
+      isCollabRequestAnswered(log, "r1") || hasCollabTerminalResult(log, "r1")
+    ).toBe(false)
   })
 })

--- a/app/src/components/collabUi.ts
+++ b/app/src/components/collabUi.ts
@@ -14,3 +14,26 @@ export function isCollabRequestAnswered(
       (m.collab.kind === "accepted" || m.collab.kind === "declined")
   )
 }
+
+/** #115: an accepted envelope exists for this requestId. */
+export function isCollabRequestAccepted(
+  messages: Message[],
+  requestId: string
+): boolean {
+  return messages.some(
+    (m) => m.collab?.requestId === requestId && m.collab.kind === "accepted"
+  )
+}
+
+/** #121: a terminal result (completed | failed) exists for this requestId.
+ * Declined is its own end and does not count here. */
+export function hasCollabTerminalResult(
+  messages: Message[],
+  requestId: string
+): boolean {
+  return messages.some(
+    (m) =>
+      m.collab?.requestId === requestId &&
+      (m.collab.kind === "completed" || m.collab.kind === "failed")
+  )
+}

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -4,6 +4,7 @@ import {
   agentCapabilitiesFrom,
   CollabRegistry,
   COLLAB_ACTION_TYPE,
+  MAX_COLLAB_SUMMARY_LENGTH,
   rosterProjection,
   sanitizeStoredAdvertisedList,
   sanitizeStoredAgentCapabilities,
@@ -315,6 +316,16 @@ type ClientMessage =
       requestId: string
       decision: "accepted" | "declined"
       summary?: string
+    }
+  | {
+      // #121: Human terminal result (completed | failed) for an
+      // Agent-originated request this Human previously accepted. Identity
+      // and routing derive from the attachment + CollabRegistry; v0 payload
+      // carries no details/attachmentIds.
+      type: "collab-result"
+      requestId: string
+      status: "completed" | "failed"
+      summary: string
     }
   | {
       // #119: Human self-advertised capability list replacement (discovery
@@ -2351,6 +2362,45 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       await this.saveRoom(room)
       // Presence/discovery broadcast only — deliberately no waiter wake.
       await this.broadcastState(room)
+      return
+    }
+
+    // #121: Human terminal result (completed | failed) for an
+    // Agent-originated request this Human previously accepted. Same shared
+    // response ingestion as every other lifecycle event: warm → validate →
+    // precheck-dedup BEFORE any append/wake → registry routing → ONE
+    // canonical message targeted back at the original requester.
+    if (message.type === "collab-result") {
+      const reject = (error: string) =>
+        socket.send(JSON.stringify({ type: "error", error }))
+      if (participant.kind !== "human") {
+        reject("collab_responder_not_human")
+        return
+      }
+      if (message.status !== "completed" && message.status !== "failed") {
+        reject("invalid_collab_kind")
+        return
+      }
+      const summary = message.summary?.trim() ?? ""
+      if (!summary) {
+        reject("summary_required")
+        return
+      }
+      if (summary.length > MAX_COLLAB_SUMMARY_LENGTH) {
+        reject("summary_too_long")
+        return
+      }
+      const ingest = await this.ingestCollabResponse(room, participant, {
+        requestId: message.requestId,
+        kind: message.status,
+        summary,
+      })
+      if (ingest.status === "rejected") {
+        reject(ingest.error)
+        return
+      }
+      // Canonical message already broadcast; duplicates append nothing and
+      // wake nothing by construction.
       return
     }
 

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -1447,6 +1447,32 @@ export function useSfuChatRoom(
     [sendSocketMessage]
   )
 
+  // #121: Human terminal result (completed | failed) for an
+  // Agent-originated request this Human accepted. Returns false when the
+  // socket is closed or inputs are invalid — never claims success without
+  // sending. Canonical state arrives via the ordinary broadcast.
+  const sendCollabResult = useCallback(
+    (
+      requestId: string,
+      status: "completed" | "failed",
+      summary: string
+    ): boolean => {
+      if (!requestId) return false
+      if (status !== "completed" && status !== "failed") return false
+      const trimmed = summary.trim()
+      if (!trimmed || trimmed.length > MAX_COLLAB_SUMMARY_LENGTH) return false
+      if (websocketRef.current?.readyState !== WebSocket.OPEN) return false
+      sendSocketMessage({
+        type: "collab-result",
+        requestId,
+        status,
+        summary: trimmed,
+      })
+      return true
+    },
+    [sendSocketMessage]
+  )
+
   // #119: replace THIS Human's advertised capability list (discovery
   // metadata only). Local guard uses the same shared validator as the
   // server; the authoritative list comes back via Room state broadcast.
@@ -1626,6 +1652,7 @@ export function useSfuChatRoom(
     sendActionMessage,
     sendCollabRequest,
     sendCollabResponse,
+    sendCollabResult,
     updateHumanCapabilities,
     readRoomAttachment,
     localParticipantId: sessionRef.current?.participantId,


### PR DESCRIPTION
Closes #121 — completes the structured collaboration lifecycle for Human targets of Agent-originated requests (#106/#113/#115). After accepting, a Human can now return completed or failed with a bounded non-empty summary through the existing shared ingestCollabResponse path.

## Wire shape (browser WS v0)

```json
{ "type": "collab-result", "requestId": "<id>", "status": "completed" | "failed", "summary": "<bounded non-empty text>" }
```

No `fromParticipantId`, no `targetParticipantId`, no tokens, no details, no attachmentIds. Responder identity derives from the authenticated WebSocket attachment; routing derives entirely from CollabRegistry correlation.

## DO behavior

New WS handler for `collab-result`:
1. Responder must be authenticated CURRENT Human (`collab_responder_not_human` otherwise)
2. Status must be exactly `completed` or `failed` (`invalid_collab_kind` otherwise)
3. Summary must be non-empty after trim (`summary_required`)
4. Summary must be ≤ MAX_COLLAB_SUMMARY_LENGTH (`summary_too_long`)
5. `precheckResponse` dedup BEFORE any append/wake — duplicate same-kind returns original sequence with zero mutation
6. `routingFor` derives from/to from registry — responder never self-reports destination
7. ONE canonical action/collab message targeted at original requester
8. `commitResponse` after append

Fail-closed: unknown_request / not_request_target / invalid_collab_kind / summary_required / summary_too_long all append nothing, wake nothing.

No new registry/persistence/state machine.

## Shared ingestion compatibility

The existing `ingestCollabResponse` continues accepting the complete Agent payload (requestId/kind/summary/details/attachmentIds). Agent completed/failed with details and attachmentIds remain fully preserved (#109 regression suite green). The Human call site intentionally supplies only requestId/kind/summary — no narrowing of the shared helper.

## Dedup

Duplicate same-kind terminal sends short-circuit BEFORE any append/wake via precheckResponse — one accepted message, one addressed follow-up turn per lifecycle step, ever.

## Rebuild

After DO eviction/restart, CollabRegistry.rebuild(room.messages) restores Agent→Human routing so H can still respond within the bounded horizon; beyond it → unknown_request. No new persistence.

## UI

TextChatCard request cards render "Mark complete" / "Mark failed" ONLY when: target === this local Human, sender ≠ this Human, canonical accepted exists, and no terminal result exists yet. Clicking opens HumanCollabResultComposer modal with required bounded note and helper copy ("Your result is shared with the Agent. It does not grant tools or permissions."). No attachments/details/priority/deadline inputs. Lifecycle derived from canonical messages only — never React state.

## Boundary

A Human completed/failed records Room-level collaboration judgment — NOT ACP/tool/shell/browser/GitHub approval, deployment authorization, credential/media grant, remote control, or proof of external action. Result ≠ permission.

## Tests & gates

- App vitest **249/249** across 29 files incl. TextChatCard.human-result.test.tsx wiring proof (before/after accepted/terminal matrix + production callback exact values) and collabUi lifecycle helpers.
- agent-runtime **134/134** incl. #113/#115 full-chain fake-room regression (request→accept→complete→dedup→rebuild) and #115 Human accept/decline round-trip with restart recovery.
- App prettier/eslint/tsc/cf-build ✅. agent-runtime format:check/lint/tsc/build/pack:check ✅.

## Non-goals honored

Planner/DAG/orchestrator/scheduler/retries/timeouts/cancellation · task queue/inbox/kanban · assignment/ranking/auto-selection · approval engine/ACP bridge/Human tool execution · artifact attachment on Human results · structured details on Human results · MCP tools/Runtime production/version bumps · R2/D1/KV/new DO/OAuth/Surface/Pion/Voice/outbound media/remote control — none included.