### PR TITLE
feat(#123): let Humans attach room artifacts to collab work requests

### DIFF
--- a/app/src/common/roomAttachments.test.ts
+++ b/app/src/common/roomAttachments.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   MAX_ROOM_ATTACHMENT_BYTES,
   validateRoomAttachmentRead,
+  validateUploadedRoomAttachment,
 } from "./roomAttachments"
 
 const REQUESTED_ID = "11111111-2222-4333-8444-555555555555"
@@ -122,5 +123,74 @@ describe("validateRoomAttachmentRead (#117)", () => {
   it("rejects non-object payloads", () => {
     expect(validateRoomAttachmentRead(undefined, REQUESTED_ID).ok).toBe(false)
     expect(validateRoomAttachmentRead("nope", REQUESTED_ID).ok).toBe(false)
+  })
+})
+
+const UPLOAD_ID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
+function uploadedPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    attachment: {
+      id: UPLOAD_ID,
+      fileName: "notes.md",
+      mimeType: "text/markdown",
+      size: 10,
+    },
+    ...overrides,
+  }
+}
+
+function uploadWith(patch: Record<string, unknown>) {
+  return validateUploadedRoomAttachment({
+    attachment: { ...uploadedPayload().attachment, ...patch },
+  })
+}
+
+describe("validateUploadedRoomAttachment (#123)", () => {
+  it("accepts well-formed metadata within every bound", () => {
+    const uploaded = validateUploadedRoomAttachment(uploadedPayload())
+    expect(uploaded).not.toBeNull()
+    expect(uploaded?.id).toBe(UPLOAD_ID)
+    expect(uploaded?.fileName).toBe("notes.md")
+    expect(uploaded?.mimeType).toBe("text/markdown")
+    expect(uploaded?.size).toBe(10)
+  })
+
+  it("rejects malformed payloads and attachment shapes", () => {
+    for (const bad of [undefined, null, "nope", {}, { attachment: "nope" }])
+      expect(validateUploadedRoomAttachment(bad)).toBeNull()
+  })
+
+  it("bounds ids between 1 and 64 chars", () => {
+    expect(uploadWith({ id: "" })).toBeNull()
+    expect(uploadWith({ id: "a".repeat(65) })).toBeNull()
+    expect(uploadWith({ id: "a".repeat(64) })).not.toBeNull()
+  })
+
+  it("bounds file names between 1 and 256 chars", () => {
+    expect(uploadWith({ fileName: "" })).toBeNull()
+    expect(uploadWith({ fileName: "f".repeat(257) })).toBeNull()
+    expect(uploadWith({ fileName: "f".repeat(256) })).not.toBeNull()
+  })
+
+  it("enforces the shared MIME allow-list", () => {
+    expect(uploadWith({ mimeType: "application/octet-stream" })).toBeNull()
+    expect(uploadWith({ mimeType: "text/html" })).toBeNull()
+    expect(uploadWith({ mimeType: "image/png" })).not.toBeNull()
+    expect(uploadWith({ mimeType: "text/yaml" })).not.toBeNull()
+  })
+
+  it("rejects invalid sizes and accepts the exact byte ceiling", () => {
+    for (const size of [
+      0,
+      -3,
+      10.5,
+      NaN,
+      Infinity,
+      MAX_ROOM_ATTACHMENT_BYTES + 1,
+    ])
+      expect(uploadWith({ size })).toBeNull()
+    expect(uploadWith({ size: MAX_ROOM_ATTACHMENT_BYTES })).not.toBeNull()
+    expect(uploadWith({ size: 1 })).not.toBeNull()
   })
 })

--- a/app/src/common/roomAttachments.ts
+++ b/app/src/common/roomAttachments.ts
@@ -1,5 +1,6 @@
 import {
   ROOM_ATTACHMENT_MIME_TYPES,
+  type AgentAttachmentMimeType,
   type RoomAttachmentRead,
 } from "../room/types"
 
@@ -9,6 +10,54 @@ import {
 // closed BEFORE an object URL or preview can exist.
 
 export const MAX_ROOM_ATTACHMENT_BYTES = 768 * 1024
+
+const MAX_UPLOADED_ATTACHMENT_ID_CHARS = 64
+const MAX_UPLOADED_FILE_NAME_CHARS = 256
+
+export interface UploadedRoomAttachment {
+  id: string
+  fileName: string
+  mimeType: AgentAttachmentMimeType
+  size: number
+}
+
+/** #123: strict browser-boundary validation for one upload-response
+ * attachment payload (POST /api/room/attachments). Same fail-closed rules
+ * as artifact reads, minus the base64 bytes. Returns null on ANY violation. */
+export function validateUploadedRoomAttachment(
+  payload: unknown
+): UploadedRoomAttachment | null {
+  if (!payload || typeof payload !== "object") return null
+  const record = payload as Record<string, unknown>
+  const attachment =
+    record.attachment && typeof record.attachment === "object"
+      ? (record.attachment as Record<string, unknown>)
+      : undefined
+  if (
+    !attachment ||
+    typeof attachment.id !== "string" ||
+    attachment.id.length === 0 ||
+    attachment.id.length > MAX_UPLOADED_ATTACHMENT_ID_CHARS ||
+    typeof attachment.fileName !== "string" ||
+    attachment.fileName.length === 0 ||
+    attachment.fileName.length > MAX_UPLOADED_FILE_NAME_CHARS ||
+    !ROOM_ATTACHMENT_MIME_TYPES.includes(attachment.mimeType as never)
+  )
+    return null
+  if (
+    typeof attachment.size !== "number" ||
+    !Number.isSafeInteger(attachment.size) ||
+    attachment.size <= 0 ||
+    attachment.size > MAX_ROOM_ATTACHMENT_BYTES
+  )
+    return null
+  return {
+    id: attachment.id,
+    fileName: attachment.fileName,
+    mimeType: attachment.mimeType as AgentAttachmentMimeType,
+    size: attachment.size,
+  }
+}
 
 function decodeBase64(data: string): Uint8Array | null {
   if (!/^[A-Za-z0-9+/]*={0,2}$/.test(data)) return null

--- a/app/src/components/AgentWorkRequestComposer.test.tsx
+++ b/app/src/components/AgentWorkRequestComposer.test.tsx
@@ -1,7 +1,8 @@
-import { fireEvent, render, screen } from "@testing-library/react"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import AgentWorkRequestComposer from "./AgentWorkRequestComposer"
+import { MAX_ROOM_ATTACHMENT_BYTES } from "../common/roomAttachments"
 
 const base = {
   agentName: "Agent B",
@@ -56,7 +57,7 @@ describe("AgentWorkRequestComposer (#113)", () => {
     const enabled = screen.getByText("Send request") as HTMLButtonElement
     expect(enabled.disabled).toBe(false)
     fireEvent.click(enabled)
-    expect(onSubmit).toHaveBeenCalledWith("Verify the dashboard")
+    expect(onSubmit).toHaveBeenCalledWith("Verify the dashboard", [])
   })
 
   it("bounds input to maxLength and reports length", () => {
@@ -89,5 +90,191 @@ describe("AgentWorkRequestComposer (#113)", () => {
     fireEvent.click(screen.getByText("Cancel"))
     expect(onCancel).toHaveBeenCalledTimes(1)
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+})
+
+function makeFile(name: string, opts: { size?: number } = {}) {
+  const f = new File(["x"], name, { type: "text/plain" })
+  if (opts.size !== undefined)
+    Object.defineProperty(f, "size", { value: opts.size })
+  return f
+}
+
+function chooseFiles(files: File[]) {
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement
+  Object.defineProperty(input, "files", { value: files, configurable: true })
+  fireEvent.change(input)
+}
+
+describe("AgentWorkRequestComposer submit result handling (#123)", () => {
+  async function fillSummaryAndSubmit(
+    onSubmit: (summary: string, files: File[]) => Promise<boolean>
+  ) {
+    render(
+      <AgentWorkRequestComposer
+        {...base}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText("What would you like this Agent to do?"),
+      {
+        target: { value: "Verify the dashboard" },
+      }
+    )
+    fireEvent.click(screen.getByTestId("send-collab-request"))
+  }
+
+  it("keeps the composer open with a visible error when onSubmit resolves false", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(false)
+    await fillSummaryAndSubmit(onSubmit)
+    expect(
+      await screen.findByText("Could not send request. Try again.")
+    ).toBeTruthy()
+    expect(screen.getByTestId("send-collab-request")).toBeTruthy()
+    expect(
+      (screen.getByTestId("send-collab-request") as HTMLButtonElement).disabled
+    ).toBe(false)
+    expect(onSubmit).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the composer open with a visible error when uploads throw", async () => {
+    const onSubmit = vi.fn().mockRejectedValue(new Error("network down"))
+    await fillSummaryAndSubmit(onSubmit)
+    expect(await screen.findByText("Upload failed. Try again.")).toBeTruthy()
+    expect(screen.getByTestId("send-collab-request")).toBeTruthy()
+  })
+
+  it("shows no error when onSubmit resolves true", async () => {
+    const onSubmit = vi.fn().mockResolvedValue(true)
+    await fillSummaryAndSubmit(onSubmit)
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("send-collab-request") as HTMLButtonElement)
+          .disabled
+      ).toBe(false)
+    )
+    expect(screen.queryByText(/Try again\./)).toBeNull()
+  })
+})
+
+describe("AgentWorkRequestComposer artifact selection (#123)", () => {
+  function rendered() {
+    return render(
+      <AgentWorkRequestComposer
+        {...base}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+  }
+
+  it("adds supported artifacts up to three and reports the cap beyond it", () => {
+    const { container } = rendered()
+    chooseFiles([
+      makeFile("a.txt"),
+      makeFile("b.txt"),
+      makeFile("c.txt"),
+      makeFile("d.txt"),
+    ])
+    expect(screen.getByText("a.txt")).toBeTruthy()
+    expect(screen.getByText("b.txt")).toBeTruthy()
+    expect(screen.getByText("c.txt")).toBeTruthy()
+    expect(screen.getByText("Maximum 3 artifacts per request.")).toBeTruthy()
+    expect(screen.queryByText("d.txt")).toBeNull()
+    expect(
+      container.querySelectorAll('button[aria-label^="Remove"]').length
+    ).toBe(3)
+  })
+
+  it("rejects unsupported extensions with a visible error", () => {
+    rendered()
+    chooseFiles([makeFile("evil.exe")])
+    expect(screen.getByText("Unsupported file type: evil.exe")).toBeTruthy()
+    expect(screen.queryByText("evil.exe")).toBeNull()
+  })
+
+  it("rejects empty artifacts", () => {
+    rendered()
+    chooseFiles([makeFile("empty.txt", { size: 0 })])
+    expect(screen.getByText("Empty file: empty.txt")).toBeTruthy()
+    expect(screen.queryByText("empty.txt")).toBeNull()
+  })
+
+  it("rejects oversized artifacts against the shared byte limit", () => {
+    rendered()
+    chooseFiles([
+      makeFile("big.txt", { size: MAX_ROOM_ATTACHMENT_BYTES + 1 }),
+      makeFile("ok.txt", { size: 10 }),
+    ])
+    expect(
+      screen.getByText(
+        `File exceeds ${Math.floor(
+          MAX_ROOM_ATTACHMENT_BYTES / 1024
+        )} KiB: big.txt`
+      )
+    ).toBeTruthy()
+    expect(screen.getByText("ok.txt")).toBeTruthy()
+  })
+
+  it("removes a selected artifact via its remove control", () => {
+    rendered()
+    chooseFiles([makeFile("keep.txt"), makeFile("drop.txt")])
+    fireEvent.click(screen.getByLabelText("Remove drop.txt"))
+    expect(screen.queryByText("drop.txt")).toBeNull()
+    expect(screen.getByText("keep.txt")).toBeTruthy()
+  })
+})
+
+describe("AgentWorkRequestComposer artifact selection (#123 follow-ups)", () => {
+  it("accepts .log artifacts as part of the actual allow-list", () => {
+    render(
+      <AgentWorkRequestComposer
+        {...base}
+        onCancel={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+    chooseFiles([makeFile("app.log")])
+    expect(screen.getByText("app.log")).toBeTruthy()
+  })
+})
+
+describe("AgentWorkRequestComposer submitting state (#123)", () => {
+  it("disables Send while a submission is in flight and restores it afterwards", async () => {
+    let resolveSubmit!: (value: boolean) => void
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSubmit = resolve
+        })
+    )
+    render(
+      <AgentWorkRequestComposer
+        {...base}
+        onCancel={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText("What would you like this Agent to do?"),
+      { target: { value: "Verify the dashboard" } }
+    )
+    const sendButton = screen.getByTestId(
+      "send-collab-request"
+    ) as HTMLButtonElement
+    expect(sendButton.disabled).toBe(false)
+    fireEvent.click(sendButton)
+    expect(
+      (screen.getByTestId("send-collab-request") as HTMLButtonElement).disabled
+    ).toBe(true)
+    resolveSubmit(true)
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId("send-collab-request") as HTMLButtonElement)
+          .disabled
+      ).toBe(false)
+    )
   })
 })

--- a/app/src/components/AgentWorkRequestComposer.tsx
+++ b/app/src/components/AgentWorkRequestComposer.tsx
@@ -1,16 +1,34 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
+
+import { MAX_ROOM_ATTACHMENT_BYTES } from "@common/roomAttachments"
 
 interface AgentWorkRequestComposerProps {
   agentName: string
   capabilities?: string[]
   maxLength: number
   onCancel: () => void
-  onSubmit: (summary: string) => void
+  onSubmit: (summary: string, files: File[]) => Promise<boolean>
 }
 
+const MAX_ARTIFACTS = 3
+const ALLOWED_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+  ".txt",
+  ".md",
+  ".csv",
+  ".json",
+  ".log",
+  ".yaml",
+  ".yml",
+])
+
 /**
- * #113: Human → Agent structured work request composer. Deliberately tiny:
- * one bounded summary field. The Agent may accept or decline; submitting
+ * #113/#123: Human → Agent structured work request composer. One bounded
+ * summary field plus optional file attachments (up to 3, existing Room
+ * attachment MIME/size limits). The Agent may accept or decline; submitting
  * grants no new permissions and never invokes the Agent's tools directly.
  */
 export default function AgentWorkRequestComposer({
@@ -21,8 +39,63 @@ export default function AgentWorkRequestComposer({
   onSubmit,
 }: AgentWorkRequestComposerProps) {
   const [summary, setSummary] = useState("")
+  const [files, setFiles] = useState<File[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const trimmed = summary.trim()
-  const canSend = trimmed.length > 0
+  const canSend = trimmed.length > 0 && !submitting
+
+  const selectFiles = (selected: FileList | null) => {
+    if (!selected) return
+    setError(null)
+    const next = [...files]
+    for (const file of Array.from(selected)) {
+      if (next.length >= MAX_ARTIFACTS) {
+        setError("Maximum 3 artifacts per request.")
+        break
+      }
+      const ext = file.name.slice(file.name.lastIndexOf(".")).toLowerCase()
+      if (!ALLOWED_EXTENSIONS.has(ext)) {
+        setError(`Unsupported file type: ${file.name}`)
+        continue
+      }
+      if (file.size === 0) {
+        setError(`Empty file: ${file.name}`)
+        continue
+      }
+      if (file.size > MAX_ROOM_ATTACHMENT_BYTES) {
+        setError(
+          `File exceeds ${Math.floor(MAX_ROOM_ATTACHMENT_BYTES / 1024)} KiB: ${
+            file.name
+          }`
+        )
+        continue
+      }
+      next.push(file)
+    }
+    setFiles(next)
+  }
+
+  const removeFile = (index: number) => {
+    setFiles((prev) => prev.filter((_, i) => i !== index))
+  }
+
+  const handleSubmit = async () => {
+    if (!canSend || submitting) return
+    setError(null)
+    setSubmitting(true)
+    try {
+      const sent = await onSubmit(trimmed, files)
+      // Only an explicit true lets the parent close this composer; any
+      // other outcome leaves it open with actionable feedback.
+      if (!sent) setError("Could not send request. Try again.")
+    } catch {
+      setError("Upload failed. Try again.")
+    } finally {
+      setSubmitting(false)
+    }
+  }
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
@@ -54,6 +127,48 @@ export default function AgentWorkRequestComposer({
         <p className="mt-1 text-right text-[10px] text-gray-500">
           {summary.length}/{maxLength}
         </p>
+        <div className="mt-2">
+          <label className="text-[11px] font-medium text-gray-400">
+            Attach context (optional, max 3)
+          </label>
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            accept=".png,.jpg,.jpeg,.webp,.txt,.md,.csv,.json,.log,.yaml,.yml"
+            onChange={(event) => selectFiles(event.target.files)}
+            className="hidden"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={files.length >= 3 || submitting}
+            className="mt-1 w-full rounded-lg border border-gray-600 px-3 py-1.5 text-xs text-gray-300 hover:bg-gray-800 disabled:opacity-40"
+          >
+            Choose files…
+          </button>
+          {files.length > 0 && (
+            <ul className="mt-1.5 space-y-0.5">
+              {files.map((file, i) => (
+                <li
+                  key={i}
+                  className="flex items-center justify-between text-[10px] text-gray-400"
+                >
+                  <span className="truncate">{file.name}</span>
+                  <button
+                    type="button"
+                    onClick={() => removeFile(i)}
+                    aria-label={`Remove ${file.name}`}
+                    className="text-gray-500 hover:text-white"
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        {error && <p className="mt-1 text-[11px] text-red-300">{error}</p>}
         <p className="mt-2 text-[11px] leading-snug text-gray-400">
           The Agent may accept or decline. This request does not grant new
           permissions.
@@ -68,15 +183,16 @@ export default function AgentWorkRequestComposer({
           </button>
           <button
             type="button"
-            disabled={!canSend}
-            onClick={() => canSend && onSubmit(trimmed)}
+            data-testid="send-collab-request"
+            disabled={!canSend || submitting}
+            onClick={handleSubmit}
             className={`rounded-lg px-3 py-1.5 text-xs font-medium ${
-              canSend
+              canSend && !submitting
                 ? "bg-blue-600 text-white hover:bg-blue-500"
                 : "cursor-not-allowed bg-gray-700 text-gray-400"
             }`}
           >
-            Send request
+            {submitting ? "Sending…" : "Send request"}
           </button>
         </div>
       </div>

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -133,6 +133,7 @@ export default function RoomContent({
     sendFileMessage,
     sendActionMessage,
     sendCollabRequest,
+    uploadRoomAttachment,
     sendCollabResponse,
     readRoomAttachment,
     sendCollabResult,
@@ -788,9 +789,24 @@ export default function RoomContent({
           capabilities={workRequestTarget.capabilities}
           maxLength={MAX_COLLAB_SUMMARY_LENGTH}
           onCancel={() => setWorkRequestTarget(null)}
-          onSubmit={(summary) => {
-            sendCollabRequest(workRequestTarget.peerId, summary)
+          onSubmit={async (summary, files) => {
+            // Sequential upload of each artifact through the existing
+            // authenticated Room attachment endpoint.
+            const attachmentIds: string[] = []
+            for (const file of files) {
+              const meta = await uploadRoomAttachment(file)
+              attachmentIds.push(meta.id)
+            }
+            // sendCollabRequest returns "" when the WS is closed or local
+            // validation fails; propagate that so the composer stays open.
+            const requestId = sendCollabRequest(
+              workRequestTarget.peerId,
+              summary,
+              attachmentIds.length > 0 ? attachmentIds : undefined
+            )
+            if (!requestId) return false
             setWorkRequestTarget(null)
+            return true
           }}
         />
       )}

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -307,6 +307,7 @@ type ClientMessage =
       requestId: string
       targetParticipantId: string
       summary: string
+      attachmentIds?: string[]
     }
   | {
       // #115: Human accepted/declined for an Agent-originated request whose
@@ -2299,6 +2300,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         requestId: message.requestId,
         targetParticipantId: message.targetParticipantId,
         summary: message.summary,
+        attachmentIds: message.attachmentIds,
       })
       if (ingest.status === "rejected") {
         reject(ingest.error)

--- a/app/src/do/collab.test.ts
+++ b/app/src/do/collab.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import {
   agentCapabilitiesFrom,
@@ -840,5 +840,62 @@ describe("rosterProjection Human advertised (#119)", () => {
     )
     expect(serialized.includes("token")).toBe(false)
     expect(serialized.includes("nonce")).toBe(false)
+  })
+})
+
+describe("#123 attachment refs against CURRENT attachments", () => {
+  it("preserves a CURRENT attachment ref through validation and registry append", () => {
+    const result = validateCollabEvent(
+      {
+        kind: "request",
+        requestId: "req-cur",
+        targetParticipantId: "agent-b",
+        summary: "Inspect",
+        attachmentIds: ["att-1"],
+      },
+      collabContext()
+    )
+    expect(result.ok).toBe(true)
+    const registry = new CollabRegistry()
+    if (!result.ok) return
+    expect(registry.recordRequest(result.event, 31)).toEqual({
+      action: "recorded",
+      sequence: 31,
+    })
+  })
+
+  it("rejects unknown refs before any registry append or waiter wake", () => {
+    const registry = new CollabRegistry()
+    const wake = vi.fn()
+    const rejected = validateCollabEvent(
+      {
+        kind: "request",
+        requestId: "req-unk",
+        targetParticipantId: "agent-b",
+        summary: "Inspect",
+        attachmentIds: ["att-ghost"],
+      },
+      collabContext()
+    )
+    expect(rejected).toMatchObject({
+      ok: false,
+      error: "unknown_attachment",
+    })
+    expect(registry.find("req-unk")).toBeUndefined()
+    expect(wake).not.toHaveBeenCalled()
+  })
+
+  it("rejects mixed valid and unknown refs without partial preservation", () => {
+    const mixed = validateCollabEvent(
+      {
+        kind: "request",
+        requestId: "req-mix",
+        targetParticipantId: "agent-b",
+        summary: "Inspect",
+        attachmentIds: ["att-1", "att-ghost"],
+      },
+      collabContext()
+    )
+    expect(mixed.ok).toBe(false)
   })
 })

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -243,3 +243,185 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
     unmount()
   })
 })
+
+describe("useSfuChatRoom room attachments (#123)", () => {
+  class RecordingWebSocket {
+    static OPEN = 1
+    static instances: RecordingWebSocket[] = []
+    readyState = 1
+    onopen: (() => void) | null = null
+    onmessage: ((event: { data: string }) => void) | null = null
+    onerror: (() => void) | null = null
+    onclose: (() => void) | null = null
+    sent: string[] = []
+    constructor(public url: string) {
+      RecordingWebSocket.instances.push(this)
+    }
+    send(data: string) {
+      this.sent.push(data)
+    }
+    close() {}
+  }
+
+  let fetchMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
+      FakePeerConnection
+    class FakeMediaStream {
+      private tracks: FakeTrack[]
+      constructor(tracks: FakeTrack[] = []) {
+        this.tracks = tracks
+      }
+      getAudioTracks() {
+        return this.tracks
+      }
+      getTracks() {
+        return this.tracks
+      }
+    }
+    ;(global as unknown as { MediaStream: unknown }).MediaStream =
+      FakeMediaStream
+    RecordingWebSocket.instances.length = 0
+    ;(global as unknown as { WebSocket: unknown }).WebSocket =
+      RecordingWebSocket
+
+    const getUserMedia = vi.fn().mockResolvedValue({
+      getAudioTracks: () => [new FakeTrack()],
+    })
+    Object.defineProperty(global.navigator, "mediaDevices", {
+      value: { getUserMedia },
+      configurable: true,
+    })
+
+    fetchMock = vi.fn((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.endsWith("/api/sfu/session")) {
+        return jsonResponse({
+          participantId: "participant-1",
+          participantToken: "participant-token",
+          sessionId: "session-1",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      }
+      if (url.endsWith("/api/sfu/datachannels/establish")) {
+        return jsonResponse({})
+      }
+      if (url.endsWith("/api/sfu/datachannels/new")) {
+        return jsonResponse({ dataChannels: [{ id: 1 }] })
+      }
+      if (url.endsWith("/api/sfu/tracks")) {
+        return jsonResponse({})
+      }
+      if (url.endsWith("/api/room/attachments")) {
+        return jsonResponse({
+          attachment: {
+            id: "att-123",
+            fileName: "app.log",
+            mimeType: "text/plain",
+            size: 5,
+          },
+        })
+      }
+      return jsonResponse({})
+    })
+    global.fetch = fetchMock as unknown as typeof fetch
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  async function connect(room: string) {
+    const rendered = renderHook(() =>
+      useSfuChatRoom(room, "uploader", "audio", {})
+    )
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([input]) =>
+          String(input).endsWith("/api/sfu/session")
+        )
+      ).toBe(true)
+    )
+    return rendered
+  }
+
+  function makeLogFile() {
+    return new File(["line"], "app.log", { type: "" })
+  }
+
+  it("uploads .log text artifacts with the authoritative MIME from agentTextMime", async () => {
+    const { result, unmount } = await connect("room-attach-a")
+    const uploaded = await waitFor(() =>
+      result.current.uploadRoomAttachment(makeLogFile())
+    )
+    expect(uploaded.id).toBe("att-123")
+    const attachCall = fetchMock.mock.calls.find(([input]) =>
+      String(input).endsWith("/api/room/attachments")
+    )
+    const headers = attachCall![1].headers as Record<string, string>
+    expect(headers["Content-Type"]).toBe("text/plain")
+    unmount()
+  })
+
+  it("wires upload metadata id into sendCollabRequest attachmentIds over an open socket", async () => {
+    const { result, unmount } = await connect("room-attach-b")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const uploaded = await waitFor(() =>
+      result.current.uploadRoomAttachment(makeLogFile())
+    )
+    const requestId = result.current.sendCollabRequest(
+      "agent-b",
+      "Check the logs",
+      [uploaded.id]
+    )
+    expect(requestId).not.toBe("")
+    const ws = RecordingWebSocket.instances.at(-1)!
+    const envelopes = ws.sent.map(
+      (raw) => JSON.parse(raw) as Record<string, unknown>
+    )
+    const envelope = envelopes.find((m) => m.type === "collab-request")
+    expect(envelope).toBeTruthy()
+    expect(envelope?.["attachmentIds"]).toEqual([uploaded.id])
+    expect(envelope?.["targetParticipantId"]).toBe("agent-b")
+    unmount()
+  })
+
+  it("sends nothing when the WebSocket is not open", async () => {
+    class ClosedSocket extends RecordingWebSocket {
+      readyState = 3
+    }
+    ;(global as unknown as { WebSocket: unknown }).WebSocket = ClosedSocket
+    RecordingWebSocket.instances.length = 0
+    const { result, unmount } = await connect("room-attach-c")
+    expect(result.current.sendCollabRequest("agent-b", "hi")).toBe("")
+    const ws = RecordingWebSocket.instances.at(-1)!
+    expect(ws.sent).toEqual([])
+    unmount()
+  })
+
+  it("surfaces upload failures from the shared response path", async () => {
+    const { result, unmount } = await connect("room-attach-d")
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.endsWith("/api/room/attachments")) {
+        return jsonResponse({ error: "unsupported_attachment_type" }, 415)
+      }
+      if (url.endsWith("/api/sfu/session")) {
+        return jsonResponse({
+          participantId: "participant-1",
+          participantToken: "participant-token",
+          sessionId: "session-1",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      }
+      return jsonResponse({})
+    })
+    await expect(
+      result.current.uploadRoomAttachment(makeLogFile())
+    ).rejects.toThrow("unsupported_attachment_type")
+    unmount()
+  })
+})

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -2,9 +2,13 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import { LOCAL_PEER_ID } from "@common/consts"
 import { mergeRoomAndEphemeralMessages } from "@common/messageReconciliation"
-import { validateRoomAttachmentRead } from "@common/roomAttachments"
+import {
+  validateRoomAttachmentRead,
+  validateUploadedRoomAttachment,
+} from "@common/roomAttachments"
 import { ActionType, Message, UserInfo } from "@common/types"
 import {
+  MAX_COLLAB_ATTACHMENT_REFS,
   MAX_COLLAB_SUMMARY_LENGTH,
   validateAdvertisedCapabilities,
 } from "@do/collab"
@@ -1496,7 +1500,11 @@ export function useSfuChatRoom(
   // The canonical RoomMessage arrives via the ordinary broadcast — no
   // optimistic echo here.
   const sendCollabRequest = useCallback(
-    (targetParticipantId: string, summary: string): string => {
+    (
+      targetParticipantId: string,
+      summary: string,
+      attachmentIds?: string[]
+    ): string => {
       const trimmed = summary.trim()
       if (
         !targetParticipantId ||
@@ -1504,6 +1512,18 @@ export function useSfuChatRoom(
         trimmed.length > MAX_COLLAB_SUMMARY_LENGTH
       )
         return ""
+      // Local guard: attachmentIds must be absent or a non-empty array of at
+      // most MAX_COLLAB_ATTACHMENT_REFS non-empty bounded strings with no
+      // duplicates. The server remains authoritative.
+      if (attachmentIds !== undefined) {
+        const ids = attachmentIds
+        if (!Array.isArray(ids)) return ""
+        for (const id of ids)
+          if (typeof id !== "string" || id.length === 0 || id.length > 64)
+            return ""
+        if (new Set(ids).size !== ids.length) return ""
+        if (ids.length > MAX_COLLAB_ATTACHMENT_REFS) return ""
+      }
       if (websocketRef.current?.readyState !== WebSocket.OPEN) return ""
       const requestId = crypto.randomUUID()
       sendSocketMessage({
@@ -1511,10 +1531,58 @@ export function useSfuChatRoom(
         requestId,
         targetParticipantId,
         summary: trimmed,
+        ...(attachmentIds && attachmentIds.length > 0 ? { attachmentIds } : {}),
       })
       return requestId
     },
     [sendSocketMessage]
+  )
+
+  // #123: upload one file as an ephemeral Room artifact for collab context.
+  // Returns safe public metadata including the attachmentId needed to
+  // reference it in a collab request.
+  const uploadRoomAttachment = useCallback(
+    async (
+      file: File
+    ): Promise<{
+      id: string
+      fileName: string
+      mimeType: string
+      size: number
+    }> => {
+      const session = sessionRef.current
+      if (!session) throw new Error("Not connected to the room")
+      const response = await fetch("/api/room/attachments", {
+        method: "POST",
+        headers: {
+          "Content-Type":
+            agentTextMime(file) ?? (file.type || "application/octet-stream"),
+          "X-Room-Id": session.room,
+          "X-Room-Participant-Id": session.participantId,
+          "X-Room-Participant-Token": session.participantToken,
+          "X-File-Name": encodeURIComponent(file.name),
+        },
+        body: file,
+      })
+      if (!response.ok) {
+        const payload = (await response.json().catch(() => ({}))) as {
+          error?: unknown
+        }
+        throw new Error(
+          typeof payload.error === "string"
+            ? payload.error
+            : `attachment_upload_failed_${response.status}`
+        )
+      }
+      // Upload responses are UNTRUSTED here too: metadata is re-checked
+      // against the shared limits before its id may be referenced.
+      const uploaded = validateUploadedRoomAttachment(
+        await response.json().catch(() => null)
+      )
+      if (!uploaded) throw new Error("invalid_attachment_payload")
+      return uploaded
+    },
+    []
   )
 
   const startMeetingNotes = useCallback(
@@ -1651,6 +1719,7 @@ export function useSfuChatRoom(
     sendFileMessage,
     sendActionMessage,
     sendCollabRequest,
+    uploadRoomAttachment,
     sendCollabResponse,
     sendCollabResult,
     updateHumanCapabilities,


### PR DESCRIPTION
Closes #123

## What

Extends Human-originated structured work requests (#113) with optional collaboration artifacts:

- **DO (`RoomSession`)**: WS `collab-request` envelope gains optional `attachmentIds?: string[]`, forwarded to the shared `ingestCollabWorkRequest`; validation against current room attachments already exists via `validateCollabEvent` (#113 path) — no new server-side validation logic.
- **Hook (`useSfuChatRoom`)**: new `uploadRoomAttachment(file)` posting to the existing authenticated `/api/room/attachments` endpoint (participant credentials in headers, strict response validation, 768 KiB cap); `sendCollabRequest(targetParticipantId, summary, attachmentIds?)` gains a local guard (≤ `MAX_COLLAB_ATTACHMENT_REFS`, non-empty bounded strings, no duplicates).
- **Composer (`AgentWorkRequestComposer`)**: optional file picker — max 3 files, extension allow-list matching the server MIME types, per-file remove buttons; async contract `onSubmit(summary, files) => Promise<boolean>` with submitting state; stays open on failure.
- **Parent wiring (`RoomContent`)**: uploads selected artifacts sequentially through `uploadRoomAttachment`, sends the collab request with the collected ids, closes only on success.

## Not changed

- No Runtime production code changes; no MCP changes; no new persistence.
- Server-side DO behavior is unchanged for requests without `attachmentIds`.

## Tests

- app: prettier / eslint / tsc clean; vitest 29 files / 249 tests green.
- agent-runtime (untouched): format / lint / tsc clean; node:test 134/134 green.
