### PR TITLE
fix(#83 follow-up): parse voiceReply grant + media switch in roomInfo clients

### DIFF
--- a/agent-runtime/src/free4chat/client.ts
+++ b/agent-runtime/src/free4chat/client.ts
@@ -184,9 +184,23 @@ export class McpFree4ChatClient implements Free4ChatClient {
         ? { startedAt: rawMeetingNotes.startedAt }
         : {}),
     }
+    const rawVoiceReply =
+      result.voiceReply && typeof result.voiceReply === "object"
+        ? (result.voiceReply as Record<string, unknown>)
+        : {}
     return {
-      voiceReply: { active: false },
-      voiceReplyMediaAvailable: false,
+      // Same fail-closed discipline as meetingNotes above: only explicit
+      // values are trusted; anything malformed deactivates the grant.
+      voiceReply: {
+        active: rawVoiceReply.active === true,
+        ...(typeof rawVoiceReply.agentParticipantId === "string"
+          ? { agentParticipantId: rawVoiceReply.agentParticipantId }
+          : {}),
+        ...(typeof rawVoiceReply.startedAt === "number"
+          ? { startedAt: rawVoiceReply.startedAt }
+          : {}),
+      },
+      voiceReplyMediaAvailable: result.voiceReplyMediaAvailable === true,
       exists: result.exists === true,
       ...(Array.isArray(result.participants)
         ? {

--- a/agent-runtime/src/free4chat/modernClient.ts
+++ b/agent-runtime/src/free4chat/modernClient.ts
@@ -276,9 +276,23 @@ export class ModernMcpFree4ChatClient implements Free4ChatClient {
       result.meetingNotes && typeof result.meetingNotes === "object"
         ? (result.meetingNotes as Record<string, unknown>)
         : {}
+    const rawVoiceReply =
+      result.voiceReply && typeof result.voiceReply === "object"
+        ? (result.voiceReply as Record<string, unknown>)
+        : {}
     return {
-      voiceReply: { active: false },
-      voiceReplyMediaAvailable: false,
+      // Same fail-closed discipline as meetingNotes below: only explicit
+      // values are trusted; anything malformed deactivates the grant.
+      voiceReply: {
+        active: rawVoiceReply.active === true,
+        ...(typeof rawVoiceReply.agentParticipantId === "string"
+          ? { agentParticipantId: rawVoiceReply.agentParticipantId }
+          : {}),
+        ...(typeof rawVoiceReply.startedAt === "number"
+          ? { startedAt: rawVoiceReply.startedAt }
+          : {}),
+      },
+      voiceReplyMediaAvailable: result.voiceReplyMediaAvailable === true,
       exists: result.exists === true,
       ...(Array.isArray(result.participants)
         ? { participants: parseRoster(result.participants) }

--- a/agent-runtime/test/modernClient.test.ts
+++ b/agent-runtime/test/modernClient.test.ts
@@ -713,3 +713,85 @@ test("read_surface parses the real server envelope and rejects mismatches", asyn
     globalThis.fetch = originalFetch
   }
 })
+
+test("roomInfo parses an active voiceReply grant round-trip", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async (_input, init) => {
+    const body = JSON.parse(String(init?.body)) as {
+      params?: { name?: string }
+    }
+    assert.equal(body.params?.name, "room_info")
+    return mcpEnvelope({
+      exists: true,
+      voiceReply: {
+        active: true,
+        agentParticipantId: "agent-9",
+        startedAt: 1712345678901,
+      },
+      voiceReplyMediaAvailable: true,
+    })
+  }
+
+  try {
+    const client = new ModernMcpFree4ChatClient("https://example.test/mcp")
+    const info = await client.roomInfo("room")
+    assert.deepEqual(info.voiceReply, {
+      active: true,
+      agentParticipantId: "agent-9",
+      startedAt: 1712345678901,
+    })
+    assert.equal(info.voiceReplyMediaAvailable, true)
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
+test("roomInfo fails closed on missing or malformed voiceReply fields", async () => {
+  const originalFetch = globalThis.fetch
+  const cases: Array<{
+    payload: Record<string, unknown>
+    expectedVoiceReply: Record<string, unknown>
+    expectedMediaAvailable: boolean
+  }> = [
+    {
+      payload: {},
+      expectedVoiceReply: { active: false },
+      expectedMediaAvailable: false,
+    },
+    {
+      payload: { voiceReply: "nope", voiceReplyMediaAvailable: "yes" },
+      expectedVoiceReply: { active: false },
+      expectedMediaAvailable: false,
+    },
+    {
+      // The grant itself stays room-truth even when the media switch is off.
+      payload: {
+        voiceReply: { active: true },
+        voiceReplyMediaAvailable: false,
+      },
+      expectedVoiceReply: { active: true },
+      expectedMediaAvailable: false,
+    },
+    {
+      // Malformed optional keys are dropped entirely; only explicit values
+      // survive.
+      payload: {
+        voiceReply: { active: true, agentParticipantId: 42, startedAt: "x" },
+        voiceReplyMediaAvailable: true,
+      },
+      expectedVoiceReply: { active: true },
+      expectedMediaAvailable: true,
+    },
+  ]
+  for (const { payload, expectedVoiceReply, expectedMediaAvailable } of cases) {
+    globalThis.fetch = async () => mcpEnvelope(payload)
+    try {
+      const client = new ModernMcpFree4ChatClient("https://example.test/mcp")
+      const info = await client.roomInfo("room")
+      assert.deepEqual(info.voiceReply, expectedVoiceReply)
+      assert.equal(info.voiceReplyMediaAvailable, expectedMediaAvailable)
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+  }
+})


### PR DESCRIPTION
Refs #83 — urgent follow-up to #127 (merged): live manual testing after enabling **Voice replies** showed the Agent replying with text but the browser hearing **no audio** (both room `<audio>` elements had no tracks).

## Root cause

`McpFree4ChatClient.roomInfo()` and `ModernMcpFree4ChatClient.roomInfo()` hardcoded
`voiceReply: { active: false }` and `voiceReplyMediaAvailable: false` instead of parsing
the fields the deployed RoomSession state / MCP `room_info` payload really returns.
`MeetingNotesController.poll()` therefore could never reach `vrAuthorized`, so the TTS →
outbound publish path never started.

## Fix

Parse both fields in both clients with the same strict fail-closed discipline already used
for `meetingNotes`:

- `voiceReply.active` only on an explicit `true`; malformed `agentParticipantId` /
  `startedAt` are dropped entirely instead of failing open
- `voiceReplyMediaAvailable` only on an explicit `true`

## Regression coverage

- Grant round-trip: payload with an active grant parses deep-equal, media switch true
- Fail-closed matrix: missing payload · non-object grant · active-grant-with-switch-off
  (grant stays room-truth) · malformed optional keys dropped

## Constraints honored

- No deploy configuration changes; no OpenAI TTS; Doubao TTS 2.0 config untouched
- Runtime-only diff: 3 files (`client.ts`, `modernClient.ts`, `modernClient.test.ts`)
- Gates green at head `4a09ce0`: npm test 213/213 · lint · type-check · build · CI success

Do **not** merge until web ChatGPT explicitly APPROVEs / says SAFE TO MERGE for the exact
head SHA with CI green.
