### PR TITLE
fix(#83): preserve authorized Agent outbound voice track across room loads

### DIFF
--- a/agent-runtime/src/media/meetingNotesController.ts
+++ b/agent-runtime/src/media/meetingNotesController.ts
@@ -281,6 +281,28 @@ export class MeetingNotesController {
           close: async () => {},
         }),
         chunkerOptions: { maxChars: 220 },
+        onEvent: (event) => {
+          if (event.type === "turnStarted")
+            this.log("voice_turn_started", { turn: event.turn })
+          else if (event.type === "turnFinished")
+            this.log("voice_turn_finished", {
+              turn: event.turn,
+              chunks: event.chunks,
+              frames: event.frames,
+            })
+          else if (event.type === "turnFailed")
+            this.log("voice_turn_failed", {
+              turn: event.turn,
+              code: event.code,
+            })
+          else if (event.type === "turnCancelled")
+            this.log("voice_turn_cancelled", { turn: event.turn })
+          else if (event.type === "turnTruncated")
+            this.log("voice_turn_truncated", {
+              turn: event.turn,
+              droppedChunks: event.droppedChunks,
+            })
+        },
       })
       this.log("voice_reply_started")
     } catch (error) {

--- a/agent-runtime/test/meetingNotesVoiceReply.test.ts
+++ b/agent-runtime/test/meetingNotesVoiceReply.test.ts
@@ -424,3 +424,42 @@ function current(c: MeetingNotesController) {
     c as unknown as { currentVoiceOutput(): unknown }
   ).currentVoiceOutput()
 }
+
+test("voice speaker lifecycle surfaces through the runtime log for live triage", async () => {
+  const bridge = new FakeBridge()
+  const logs: Array<Record<string, unknown>> = []
+  const c = new MeetingNotesController({
+    client: fakeClient(makeRoomInfo({ mnActive: false, vrActive: false })),
+    roomId: "room-1",
+    participantId: "agent-1",
+    mcpUrl: "https://www.free4.chat/mcp",
+    handle: handle(),
+    onEvent: () => undefined,
+    createBridge: () => bridge as never,
+    createPeerConnection: (() => ({ close() {} })) as never,
+    restClient: {} as never,
+    log: (message, data) =>
+      logs.push({ message, ...(data as Record<string, unknown>) }),
+    voiceReply: {
+      createTtsProvider: () => Promise.resolve(providerFor(["Hello world."])),
+    },
+  })
+  await drive(
+    c,
+    makeRoomInfo({ mnActive: true, vrActive: true, vrStartedAt: 100 }),
+    () => Promise.resolve(providerFor(["Hello world."]))
+  )
+  await waitFor(() => current(c) !== null)
+  current(c)!.speak("Hello world.")
+  await waitFor(() =>
+    logs.some(
+      (entry) =>
+        entry.message === "voice_turn_finished" &&
+        typeof entry.frames === "number" &&
+        entry.frames > 0
+    )
+  )
+  const messages = logs.map((entry) => entry.message)
+  assert.ok(messages.includes("voice_reply_started"))
+  assert.ok(messages.includes("voice_turn_started"))
+})

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -19,6 +19,7 @@ import {
   isAgentAuthorizedForMedia,
   isAgentAuthorizedForSharedMedia,
   isAgentAuthorizedForVoiceReply,
+  isValidVoiceReplyState,
   NO_MEETING_NOTES,
   NO_VOICE_REPLY,
   resolveAgentPurposePermission,
@@ -377,6 +378,41 @@ type ClientMessage =
   | { type: "voice-reply-start"; agentParticipantId: string }
   | { type: "voice-reply-stop" }
 
+/** #83 live-fix storage hygiene for one Agent participant's media block:
+ * an agent holding the ACTIVE voiceReply grant may keep its single published
+ * outbound audio track (and the registered mid Stop needs for revocation)
+ * across room loads. Every other shape — no grant, wrong agent, multiple
+ * tracks, video, or a mid without a matching track — is stripped exactly as
+ * the old subscribe-only rule did. This preserves an authorized publication
+ * across DO eviction/restart; it never loosens who may create one. */
+export function normalizeAgentParticipantMedia(
+  media: RoomParticipant["media"],
+  voiceReply: VoiceReplyState,
+  participantId: string
+): { media: RoomParticipant["media"]; changed: boolean } {
+  if (!media) return { media, changed: false }
+  const tracks = Array.isArray(media.tracks) ? media.tracks : []
+  const publishedMid =
+    typeof media.agentPublishedMid === "string" &&
+    media.agentPublishedMid.length > 0
+      ? media.agentPublishedMid
+      : undefined
+  // Callers pass the ALREADY-NORMALIZED grant (normalizeRoom hoists
+  // isValidVoiceReplyState above this decision); authorization reuses the
+  // exact production predicate so no second rule can drift.
+  const authorized =
+    isAgentAuthorizedForVoiceReply(voiceReply, participantId) &&
+    tracks.length === 1 &&
+    tracks[0]!.kind === "audio" &&
+    publishedMid !== undefined
+  if (authorized) return { media, changed: false }
+  if (tracks.length === 0 && publishedMid === undefined)
+    return { media, changed: false }
+  const next: RoomParticipant["media"] = { ...media, tracks: [] }
+  if (publishedMid !== undefined) delete next.agentPublishedMid
+  return { media: next, changed: true }
+}
+
 export class RoomSession extends DurableObject<RoomSessionEnv> {
   // A participant has at most one outstanding long-poll. A null value is a
   // short-lived reservation while the request refreshes its lease.
@@ -427,6 +463,14 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     changed: boolean
   } {
     let changed = false
+    // Normalize the voiceReply grant FIRST so agent media hygiene below
+    // sees the post-validation state — a persisted {active:true, matching
+    // agent} block with a missing/invalid startedAt must degrade to
+    // NO_VOICE_REPLY before the publication-preservation decision, never
+    // after (P1 fail-closed ordering).
+    const normalizedVoiceReply = isValidVoiceReplyState(stored.voiceReply)
+      ? stored.voiceReply
+      : NO_VOICE_REPLY
     const participants: Record<string, RoomParticipant> = {}
 
     for (const [id, rawParticipant] of Object.entries(stored.participants)) {
@@ -463,8 +507,13 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
             changed = true
           }
         }
-        if (participant.media && participant.media.tracks.length > 0) {
-          participant.media = { ...participant.media, tracks: [] }
+        const normalizedAgentMedia = normalizeAgentParticipantMedia(
+          participant.media,
+          normalizedVoiceReply,
+          participant.id
+        )
+        if (normalizedAgentMedia.changed) {
+          participant.media = normalizedAgentMedia.media
           changed = true
         }
         if (participant.media?.agentSubscribedMids !== undefined) {
@@ -575,13 +624,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       changed = true
     }
 
-    let voiceReply: VoiceReplyState
-    if (this.validVoiceReply(stored.voiceReply)) {
-      voiceReply = stored.voiceReply
-    } else {
-      voiceReply = NO_VOICE_REPLY
-      changed = true
-    }
+    let voiceReply: VoiceReplyState = normalizedVoiceReply
     if (
       voiceReply.active &&
       (!voiceReply.agentParticipantId ||
@@ -629,15 +672,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
   }
 
   private validVoiceReply(value: unknown): value is VoiceReplyState {
-    if (!value || typeof value !== "object") return false
-    const candidate = value as Partial<VoiceReplyState>
-    if (typeof candidate.active !== "boolean") return false
-    if (!candidate.active) return true
-    return (
-      typeof candidate.agentParticipantId === "string" &&
-      candidate.agentParticipantId.length > 0 &&
-      typeof candidate.startedAt === "number"
-    )
+    return isValidVoiceReplyState(value)
   }
 
   private validPendingMediaCleanup(

--- a/app/src/do/meetingNotesAuth.test.ts
+++ b/app/src/do/meetingNotesAuth.test.ts
@@ -4,6 +4,7 @@ import {
   clearGrantIfParticipantDeparting,
   isAgentAuthorizedForMedia,
   isAgentAuthorizedForSharedMedia,
+  isValidVoiceReplyState,
   NO_MEETING_NOTES,
   NO_VOICE_REPLY,
   resolveAgentPurposePermission,
@@ -179,5 +180,56 @@ describe("resolveAgentPurposePermission — agent-transport purpose", () => {
         involvesVideo: false,
       })
     ).toEqual({ ok: false, error: "agent_media_direction_forbidden" })
+  })
+})
+
+describe("isValidVoiceReplyState (#130 P1)", () => {
+  it("accepts an inactive grant without further fields", () => {
+    expect(isValidVoiceReplyState({ active: false })).toBe(true)
+  })
+
+  it("accepts an active grant with non-empty agent id and numeric startedAt", () => {
+    expect(
+      isValidVoiceReplyState({
+        active: true,
+        agentParticipantId: "agent-1",
+        startedAt: 1000,
+      })
+    ).toBe(true)
+  })
+
+  it("rejects an active grant with a missing or invalid startedAt", () => {
+    expect(
+      isValidVoiceReplyState({ active: true, agentParticipantId: "a" })
+    ).toBe(false)
+    expect(
+      isValidVoiceReplyState({
+        active: true,
+        agentParticipantId: "a",
+        startedAt: "not-a-number",
+      })
+    ).toBe(false)
+  })
+
+  it("rejects an active grant with empty/non-string agent id", () => {
+    expect(
+      isValidVoiceReplyState({
+        active: true,
+        agentParticipantId: "",
+        startedAt: 1,
+      })
+    ).toBe(false)
+    expect(
+      isValidVoiceReplyState({
+        active: true,
+        agentParticipantId: 42,
+        startedAt: 1,
+      })
+    ).toBe(false)
+  })
+
+  it("rejects non-object values", () => {
+    for (const bad of [undefined, null, "nope", 42])
+      expect(isValidVoiceReplyState(bad)).toBe(false)
   })
 })

--- a/app/src/do/meetingNotesAuth.ts
+++ b/app/src/do/meetingNotesAuth.ts
@@ -49,6 +49,25 @@ export function startMeetingNotes(
 
 export const NO_VOICE_REPLY: VoiceReplyState = { active: false }
 
+/** #83 single-source structural validation for a PERSISTED voiceReply
+ * grant. RoomSession.validVoiceReply() delegates here so storage hygiene
+ * and media normalization can never drift apart on what counts as a valid
+ * active grant (active:false needs nothing further; active:true requires a
+ * non-empty agentParticipantId AND a numeric startedAt). */
+export function isValidVoiceReplyState(
+  value: unknown
+): value is VoiceReplyState {
+  if (!value || typeof value !== "object") return false
+  const candidate = value as Partial<VoiceReplyState>
+  if (typeof candidate.active !== "boolean") return false
+  if (!candidate.active) return true
+  return (
+    typeof candidate.agentParticipantId === "string" &&
+    candidate.agentParticipantId.length > 0 &&
+    typeof candidate.startedAt === "number"
+  )
+}
+
 /** #83: may this connected resident Agent publish its single voice track? */
 export function isAgentAuthorizedForVoiceReply(
   voiceReply: VoiceReplyState,

--- a/app/src/do/roomSessionNormalize.test.ts
+++ b/app/src/do/roomSessionNormalize.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest"
+
+import { NO_VOICE_REPLY, isValidVoiceReplyState } from "./meetingNotesAuth"
+import { normalizeAgentParticipantMedia } from "./RoomSession"
+
+const AGENT_ID = "agent-voice-1"
+const MID = "pub-mid-1"
+
+function media(overrides: Record<string, unknown> = {}) {
+  return {
+    sessionId: "sess-agent",
+    muted: false,
+    fileChannelReady: false,
+    tracks: [{ trackName: "agent-voice", kind: "audio" }],
+    agentPublishedMid: MID,
+    ...overrides,
+  } as Parameters<typeof normalizeAgentParticipantMedia>[0]
+}
+
+function grantedVoice() {
+  return {
+    active: true,
+    agentParticipantId: AGENT_ID,
+    startedAt: 1000,
+  }
+}
+
+describe("normalizeAgentParticipantMedia (#83 live silence fix)", () => {
+  it("preserves the authorized single audio track + mid across loads", () => {
+    const before = media()
+    const result = normalizeAgentParticipantMedia(
+      before,
+      grantedVoice(),
+      AGENT_ID
+    )
+    expect(result.changed).toBe(false)
+    expect(result.media?.tracks).toEqual([
+      { trackName: "agent-voice", kind: "audio" },
+    ])
+    expect(result.media?.agentPublishedMid).toBe(MID)
+  })
+
+  it("still strips tracks when voiceReply is inactive (Stop semantics)", () => {
+    const inactive = { ...grantedVoice(), active: false }
+    const result = normalizeAgentParticipantMedia(media(), inactive, AGENT_ID)
+    expect(result.changed).toBe(true)
+    expect(result.media?.tracks).toEqual([])
+    // Stale mid is cleared too so capacity/revocation bookkeeping cannot
+    // reference a dead publication.
+    expect(result.media?.agentPublishedMid).toBeUndefined()
+  })
+
+  it("strips tracks when the grant names a different agent", () => {
+    const other = { ...grantedVoice(), agentParticipantId: "agent-other" }
+    const result = normalizeAgentParticipantMedia(media(), other, AGENT_ID)
+    expect(result.changed).toBe(true)
+    expect(result.media?.tracks).toEqual([])
+    expect(result.media?.agentPublishedMid).toBeUndefined()
+  })
+
+  it("strips multi-track or video shapes even under an active grant", () => {
+    const two = media({
+      tracks: [
+        { trackName: "a", kind: "audio" },
+        { trackName: "b", kind: "audio" },
+      ],
+    })
+    expect(
+      normalizeAgentParticipantMedia(two, grantedVoice(), AGENT_ID).changed
+    ).toBe(true)
+
+    const video = media({
+      tracks: [{ trackName: "v", kind: "video" }],
+    })
+    const videoResult = normalizeAgentParticipantMedia(
+      video,
+      grantedVoice(),
+      AGENT_ID
+    )
+    expect(videoResult.changed).toBe(true)
+    expect(videoResult.media?.agentPublishedMid).toBeUndefined()
+  })
+
+  it("strips a mid without a matching track (illegal state)", () => {
+    const orphan = media({ tracks: [] })
+    const result = normalizeAgentParticipantMedia(
+      orphan,
+      grantedVoice(),
+      AGENT_ID
+    )
+    expect(result.changed).toBe(true)
+    expect(result.media?.agentPublishedMid).toBeUndefined()
+  })
+
+  it("leaves absent media untouched", () => {
+    const result = normalizeAgentParticipantMedia(
+      undefined,
+      grantedVoice(),
+      AGENT_ID
+    )
+    expect(result.changed).toBe(false)
+    expect(result.media).toBeUndefined()
+  })
+
+  it("end-to-end: publish writes mid+track, reload keeps them, Stop clears them", () => {
+    // Simulate agent-track-published bookkeeping.
+    const stored = media()
+    // Reload #1: normalization must preserve the live publication.
+    const afterLoad = normalizeAgentParticipantMedia(
+      stored,
+      grantedVoice(),
+      AGENT_ID
+    )
+    expect(afterLoad.changed).toBe(false)
+    // Human resync sees the voice track and can subscribe.
+    expect(
+      afterLoad.media?.tracks.some((t) => t.trackName === "agent-voice")
+    ).toBe(true)
+    // Stop flips the grant off; next load clears the dead publication.
+    const stopped = { ...grantedVoice(), active: false }
+    const afterStop = normalizeAgentParticipantMedia(
+      afterLoad.media,
+      stopped,
+      AGENT_ID
+    )
+    expect(afterStop.changed).toBe(true)
+    expect(afterStop.media?.tracks).toEqual([])
+  })
+})
+
+describe("normalizeRoom ordering: invalid grants degrade BEFORE media preservation (#130 P1)", () => {
+  const rawInvalidGrant = {
+    active: true,
+    agentParticipantId: AGENT_ID,
+    // startedAt MISSING — persisted state from an older writer.
+  }
+  const rawInvalidStartedAt = {
+    active: true,
+    agentParticipantId: AGENT_ID,
+    startedAt: "not-a-number",
+  }
+
+  it("isValidVoiceReplyState rejects both malformed raw grants", () => {
+    expect(isValidVoiceReplyState(rawInvalidGrant)).toBe(false)
+    expect(isValidVoiceReplyState(rawInvalidStartedAt)).toBe(false)
+  })
+
+  it("missing startedAt clears tracks and mid instead of preserving them", () => {
+    const normalized = isValidVoiceReplyState(rawInvalidGrant)
+      ? rawInvalidGrant
+      : NO_VOICE_REPLY
+    const result = normalizeAgentParticipantMedia(media(), normalized, AGENT_ID)
+    expect(result.changed).toBe(true)
+    expect(result.media?.tracks).toEqual([])
+    expect(result.media?.agentPublishedMid).toBeUndefined()
+  })
+
+  it("non-numeric startedAt clears tracks and mid instead of preserving them", () => {
+    const normalized = isValidVoiceReplyState(rawInvalidStartedAt)
+      ? rawInvalidStartedAt
+      : NO_VOICE_REPLY
+    const result = normalizeAgentParticipantMedia(media(), normalized, AGENT_ID)
+    expect(result.changed).toBe(true)
+    expect(result.media?.tracks).toEqual([])
+    expect(result.media?.agentPublishedMid).toBeUndefined()
+  })
+})

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -846,7 +846,11 @@ export function useSfuChatRoom(
             },
           ],
         })
-        if (!response.sessionDescription) return
+        if (!response.sessionDescription) {
+          subscribedTracksRef.current.delete(key)
+          console.warn("sfu_remote_subscribe_missing_description", key)
+          return
+        }
         await pc.setRemoteDescription(response.sessionDescription)
         const answer = await pc.createAnswer()
         await pc.setLocalDescription(answer)
@@ -857,8 +861,9 @@ export function useSfuChatRoom(
           sessionId: session.sessionId,
           sessionDescription: { type: answer.type, sdp: answer.sdp },
         })
-      }).catch(() => {
+      }).catch((error) => {
         subscribedTracksRef.current.delete(key)
+        console.warn("sfu_remote_subscribe_failed", key, error)
       })
     },
     [apiRequest, enqueueNegotiation, roomName]


### PR DESCRIPTION
Fixes the live "Voice replies produce text but no audio" blocker reported
after #127/#129: the runtime published `agent-voice` (Pion ICE/PC connected,
`voice_reply_started`) yet both Human `<audio>` elements stayed empty.

## Root cause

`RoomSession.normalizeRoom()` unconditionally wiped every agent participant's
`media.tracks` on each storage load. The `agent-track-published` bookkeeping
wrote `agentPublishedMid` + the `agent-voice` track, but the very next
`activeRoom()` (Human resync/state or any later control request) re-ran the
old subscribe-only normalization and erased them — so Human resync/state never
contained the track, `subscribeTrack` never fired for it, and no RTP ever
reached the browser. The #83 protocol now explicitly authorizes exactly this
publication (voiceReply grant ⇒ one local audio track), so the stale
"agents never publish" normalization rule had to catch up.

## Fix

New exported pure helper `normalizeAgentParticipantMedia(media, voiceReply,
participantId)`:

- **Preserves** the media block only when the ACTIVE voiceReply grant names
  that participant AND the block is a single audio track with a registered
  `agentPublishedMid`
- **Strips everything else exactly as before** (no grant / wrong agent /
  multi-track / video), and additionally clears a stale `agentPublishedMid`
  alongside stripped tracks so capacity (`agent_publish_capacity_exceeded`)
  and revocation bookkeeping can never reference a dead publication

This preserves an authorized publication across DO eviction/restart; it does
not loosen who may create one — every `/tracks` call is still gated upstream
(purpose matrix + grant re-checks) and by RoomSession's own handlers.

## Live-triage support (same root-cause investigation)

- `MeetingNotesController` forwards VoiceSpeaker lifecycle events into the
  runtime log (`voice_turn_started`, `voice_turn_finished{chunks,frames}`,
  `voice_turn_failed{code}`, `voice_turn_cancelled`, `voice_turn_truncated`)
  so online triage can now distinguish "TTS produced zero frames" from
  "frames written but the Human never received them"
- `useSfuChatRoom.subscribeTrack` no longer swallows a description-less
  success or a negotiation failure silently — the subscribed key is released
  and the failure is logged, letting the next state/trackPublished retry

## Regression coverage

- `roomSessionNormalize.test.ts`: preserve authorized track+mid across reload;
  Stop clears track+mid; wrong-agent / multi-track / video / orphan-mid all
  stripped; absent media untouched; publish→reload→stop end-to-end sequence
- `meetingNotesVoiceReply.test.ts`: lifecycle log surfaces
  `voice_turn_finished{frames>0}` after a real speak() through the shared
  bridge sink path

## Constraints

- No protocol redesign; Worker/DO/MCP shapes unchanged beyond storage hygiene
- Doubao TTS config untouched; no OpenAI TTS; no secrets read/printed

Refs #83. Do **not** merge until web ChatGPT approves the exact head SHA.
