### PR TITLE
fix(#83): arm the Pion outbound publish track before the voice offer

### DIFF
--- a/agent-runtime/src/media/sfuMediaBridge.ts
+++ b/agent-runtime/src/media/sfuMediaBridge.ts
@@ -223,6 +223,13 @@ export class SfuMediaBridge {
     )
     const run = (async () => {
       if (this.stopped || !this.pc || !this.mySessionId) return
+      // The Pion engine only adds its outbound send m-line when armed, and
+      // #83 live silence traced to this arm step never running in production
+      // (the bootstrap offer is receive-only, so a later fresh offer still
+      // lacked the track and localPublishMid() returned ""). Arming is
+      // idempotent in the engine, so calling it here — immediately before
+      // the publication offer — is always correct.
+      await this.pc.armPublishAudio?.()
       const offer = await this.pc.createOffer()
       await this.pc.setLocalDescription(offer)
       const mid = (await this.pc.localPublishMid?.()) ?? ""

--- a/agent-runtime/test/sfuMediaBridgeVoice.test.ts
+++ b/agent-runtime/test/sfuMediaBridgeVoice.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+
+import { SfuMediaBridge } from "../src/media/sfuMediaBridge.js"
+import type { DecodedParticipantHandle } from "../src/media/participantHandle.js"
+import type {
+  PeerConnectionLike,
+  MediaTrackLike,
+  RtpPacketLike,
+} from "../src/media/peerConnectionLike.js"
+import type { SessionDescriptionLike } from "../src/media/sfuRestClient.js"
+
+const handle: DecodedParticipantHandle = {
+  roomId: "room-1",
+  participantId: "agent-1",
+  participantToken: "tok",
+  sessionId: "sess-agent",
+  apiToken: "api",
+} as never
+
+type Op = string
+
+function scriptedPc(ops: Op[]) {
+  const pc = {
+    createOffer: async () => {
+      ops.push("offer")
+      return {
+        type: "offer",
+        sdp: "offer-sdp",
+      } satisfies SessionDescriptionLike
+    },
+    setRemoteDescription: async (description: SessionDescriptionLike) => {
+      ops.push(`apply:${description.type}`)
+    },
+    createAnswer: async () => {
+      ops.push("answer")
+      return {
+        type: "answer",
+        sdp: "answer-sdp",
+      } satisfies SessionDescriptionLike
+    },
+    setLocalDescription: async () => {
+      ops.push("setLocal")
+    },
+    onTrack: {
+      subscribe: (cb: (track: MediaTrackLike) => void) => {
+        void cb
+      },
+    },
+    close: () => undefined,
+    armPublishAudio: async () => {
+      ops.push("arm")
+    },
+    activatePublish: async () => {
+      ops.push("activate")
+    },
+    deactivatePublish: async () => {
+      ops.push("deactivate")
+    },
+    cancelTurnAudio: async () => {
+      ops.push("cancelTurn")
+    },
+    flushAudio: async () => {
+      ops.push("flush")
+    },
+    localPublishMid: async () => {
+      ops.push("local-mid")
+      return "pub-mid-9"
+    },
+    writePcmChunk: async (chunk: Uint8Array) => {
+      void chunk
+      ops.push("write")
+    },
+  }
+  return pc as unknown as PeerConnectionLike & {
+    armPublishAudio: () => Promise<void>
+    activatePublish: () => Promise<void>
+    localPublishMid: () => Promise<string | undefined>
+    writePcmChunk: (chunk: Uint8Array) => Promise<void>
+  }
+}
+
+const bootstrapRest = {
+  createAgentSessionWithOffer: async () => ({
+    sessionId: "sess-agent",
+    sessionDescription: { type: "answer", sdp: "boot-answer" },
+  }),
+  establishDataChannelTransport: async () => ({
+    dataChannels: [{ id: 1, location: "local" }],
+  }),
+  roomMedia: async () => [],
+  subscribeTrack: async () =>
+    ({
+      type: "answer",
+      sdp: "x",
+    }) satisfies SessionDescriptionLike,
+  renegotiate: async () => undefined,
+}
+
+describe("SfuMediaBridge voiceReply publication (#83 live-silence fix)", () => {
+  it("arms the Pion outbound track BEFORE the publication offer and completes the full signaling sequence", async () => {
+    const ops: Op[] = []
+    const publishCalls: Array<{
+      sessionId: string
+      args: { trackName: string; mid: string; offer: SessionDescriptionLike }
+    }> = []
+
+    const bridge = new SfuMediaBridge({
+      mcpUrl: "https://www.free4.chat/mcp",
+      handle,
+      onEvent: () => undefined,
+      createPeerConnection: () =>
+        scriptedPc(ops) as unknown as PeerConnectionLike,
+      pollIntervalMs: 1_000_000,
+      publish: { trackName: "agent-voice" },
+      restClient: {
+        ...bootstrapRest,
+        // #83: the publication call under test.
+        publishAudioTrack: async (sessionId, args) => {
+          ops.push("publish")
+          publishCalls.push({ sessionId, args })
+          return {
+            sessionDescription: { type: "answer", sdp: "pub-answer" },
+          } satisfies SessionDescriptionLike
+        },
+      },
+    })
+
+    await bridge.start()
+    assert.equal(bridge.voicePublishCapable, true)
+    await bridge.activateVoicePublish()
+
+    // Bootstrap receive-only offer first; publication arms BEFORE its own
+    // offer so the send m-line actually exists.
+    assert.deepEqual(ops, [
+      "offer",
+      "setLocal",
+      "apply:answer",
+      "arm",
+      "offer",
+      "setLocal",
+      "local-mid",
+      "publish",
+      "apply:answer",
+      "activate",
+    ])
+    assert.equal(publishCalls.length, 1)
+    assert.equal(publishCalls[0]!.sessionId, "sess-agent")
+    assert.equal(publishCalls[0]!.args.trackName, "agent-voice")
+    assert.equal(publishCalls[0]!.args.mid, "pub-mid-9")
+    assert.equal(publishCalls[0]!.args.offer.sdp, "offer-sdp")
+
+    await bridge.stop()
+  })
+
+  it("throws media_engine_publish_unsupported when the engine cannot arm/write (werift fallback boundary)", async () => {
+    const ops: Op[] = []
+    const barePc = {
+      createOffer: async () => {
+        ops.push("offer")
+        return { type: "offer", sdp: "sdp" } satisfies SessionDescriptionLike
+      },
+      setRemoteDescription: async () => {
+        ops.push("apply")
+      },
+      createAnswer: async () => ({ type: "answer", sdp: "sdp" }),
+      setLocalDescription: async () => {},
+      onTrack: { subscribe: () => undefined },
+      close: () => undefined,
+    }
+    const bridge = new SfuMediaBridge({
+      mcpUrl: "https://www.free4.chat/mcp",
+      handle,
+      onEvent: () => undefined,
+      createPeerConnection: () => barePc as unknown as PeerConnectionLike,
+      pollIntervalMs: 1_000_000,
+      publish: { trackName: "agent-voice" },
+      restClient: bootstrapRest,
+    })
+
+    await bridge.start()
+    assert.equal(bridge.voicePublishCapable, false)
+    await assert.rejects(
+      bridge.activateVoicePublish(),
+      /media_engine_publish_unsupported/
+    )
+    await bridge.stop()
+  })
+})
+
+// Keep RtpPacketLike/MediaTrackLike imports referenced for strict configs.
+export type { MediaTrackLike, RtpPacketLike }


### PR DESCRIPTION
Fixes the live "Voice replies produce text but no audio" blocker reported
after #127/#129/#130: the runtime now logs `voice_turn_finished
{turn:1,chunks:1,frames:8}` and Pion reaches ICE/PC connected, yet both Human
`<audio>` elements stay empty (`hasSrcObject=false`, `tracks=[]`).

## Root cause (second half of the chain)

`SfuMediaBridge.activateVoicePublish()` never invoked `pc.armPublishAudio()`.
The Go engine creates its outbound Opus TrackLocal **only** inside
`ArmPublish()` — without that JSONL op:

- the bootstrap offer is receive-only,
- every later fresh offer still lacks the send m-line,
- `localPublishMid()` returns "" (`publish_mid_unavailable`) **or** the track
  simply never exists upstream for Humans to subscribe.

So the publication the Human was supposed to subscribe to never existed on
the SFU, even though the runtime believed activation had started.

## Fix

`activateVoicePublish()` now awaits `pc.armPublishAudio?.()` immediately
before its publication offer. The engine op is idempotent (`outbound != nil`
short-circuits) and remains valid even after the bootstrap offer because the
receive-only path never sets `offered`. werift fallback keeps its explicit
boundary: engines without publish ops still reject with
`media_engine_publish_unsupported`.

## Deterministic coverage

New `test/sfuMediaBridgeVoice.test.ts` (node:test, scripted PC ops recorded
in order):

1. Full activation sequence asserted end-to-end:
   bootstrap(`offer`,`setLocal`,`apply:answer`) → **`arm`** → `offer` →
   `setLocal` → `local-mid` → `publish` → `apply:answer` → `activate`,
   plus `publishAudioTrack` args pinned (sessionId, `trackName=agent-voice`,
   `mid`, offer SDP)
2. Capability gate: a `PeerConnectionLike` without publish ops still
   bootstraps, but `activateVoicePublish()` rejects with
   `media_engine_publish_unsupported` — the fallback boundary stays explicit

## Constraints

- Runtime-only diff (bridge + new test); no Worker/DO/MCP protocol changes
- Doubao TTS config untouched; no OpenAI TTS; no secrets read/printed

Refs #83. Follow-up to #127 / #129 / #130. Do **not** merge until web ChatGPT
approves the exact head SHA.
