### PR TITLE
fix(#83): bootstrap missing agent media on Human trackPublished (silent no-op)

### DIFF
--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -998,16 +998,34 @@ export function useSfuChatRoom(
               fileChannelReady: false,
               tracks: [message.participant.track],
             }
+          } else {
+            // Human resync missed the agent-media-attach state broadcast;
+            // bootstrap from the publication so subscribe can proceed.
+            current.media = {
+              sessionId: incomingSessionId,
+              muted: false,
+              fileChannelReady: false,
+              tracks: [message.participant.track],
+            }
           }
         } else if (current) {
-          if (!current.media) return
-          current.media.tracks = [
-            ...current.media.tracks.filter(
-              (track) =>
-                track.trackName !== message.participant!.track!.trackName
-            ),
-            message.participant.track,
-          ]
+          if (!current.media) {
+            if (!incomingSessionId) return
+            current.media = {
+              sessionId: incomingSessionId,
+              muted: false,
+              fileChannelReady: false,
+              tracks: [message.participant.track],
+            }
+          } else {
+            current.media.tracks = [
+              ...current.media.tracks.filter(
+                (track) =>
+                  track.trackName !== message.participant!.track!.trackName
+              ),
+              message.participant.track,
+            ]
+          }
         } else if (message.participant.name && incomingSessionId) {
           participantMapRef.current.set(participantId, {
             id: participantId,


### PR DESCRIPTION
Fixes the remaining live "Voice replies produce text but no audio" hop left
after #130/#131. Round-3 triage evidence: `voice_turn_finished
{turn:1,chunks:1,frames:11}` (TTS/PCM fine), Pion ICE/PC connected, grant
active — and **zero** `sfu_remote_subscribe_*` warnings in the Human
console, which proves the Human's `subscribeTrack` was never even reached
for the agent-voice publication.

## Root cause (the last silent no-op)

In `useSfuChatRoom.ts`'s `trackPublished` handler, when the Human's
participant map already contained the Agent entry but WITHOUT a `media`
block (the resync raced ahead of the `agent-media-attach` state broadcast),
the handler hit:

```ts
} else if (current) {
  if (!current.media) return   // <-- silent permanent drop
```

The publication was discarded forever: no `POST /tracks(remote)`, no
`ontrack`, and the DO never re-emits `trackPublished` for the same mid, so
nothing ever retried.

## Fix

Bootstrap `current.media` from the publication payload itself (`sessionId`
+ track), mirroring the create-new-participant branch directly below.
Fail-closed preserved: without an incoming sessionId the handler still
returns before subscribing.

## Coverage note

The two failure breadcrumbs added in #130 remain (`sfu_remote_subscribe_
missing_description` / `_failed`), so any future break past this point is
visible in the browser console. A hook-level integration harness for this
handler would require the full WS/PC scaffolding; the branch logic here is
pinned by type-checking plus the existing server-side chain tests
(`sfu/server.test.ts` covers registration + broadcast emission upstream).

## Constraints

- No protocol changes; no new media permissions; single shared session
- Runtime untouched this round; Doubao TTS config unchanged; no secrets

Refs #83. Follow-up to #127 / #129 / #130 / #131. Do **not** merge until web
ChatGPT approves the exact head SHA.
