### PR TITLE
[codex] fix(#83): include media kind in remote Agent subscriptions

### DIFF
--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -1,4 +1,4 @@
-import { renderHook, waitFor } from "@testing-library/react"
+import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useSfuChatRoom } from "./useSfuChatRoom"
@@ -422,6 +422,136 @@ describe("useSfuChatRoom room attachments (#123)", () => {
     await expect(
       result.current.uploadRoomAttachment(makeLogFile())
     ).rejects.toThrow("unsupported_attachment_type")
+    unmount()
+  })
+
+  it("includes the authoritative media kind in remote Agent subscriptions", async () => {
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.endsWith("/api/sfu/session"))
+        return jsonResponse({
+          participantId: "participant-1",
+          participantToken: "participant-token",
+          sessionId: "session-1",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      if (url.endsWith("/api/sfu/datachannels/new"))
+        return jsonResponse({ dataChannels: [{ id: 1 }] })
+      if (url.endsWith("/api/sfu/tracks"))
+        return jsonResponse({
+          requiresImmediateRenegotiation: true,
+          sessionDescription: { type: "offer", sdp: "fake-sfu-offer" },
+          tracks: [{ mid: "7", trackName: "agent-voice" }],
+        })
+      return jsonResponse({})
+    })
+
+    const { unmount } = await connect("room-remote-kind")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "trackPublished",
+          participant: {
+            id: "agent-b",
+            name: "Agent B",
+            kind: "agent",
+            sessionId: "agent-session",
+            track: { trackName: "agent-voice", kind: "audio" },
+          },
+        }),
+      })
+    })
+
+    let trackCall: [RequestInfo | URL, RequestInit] | undefined
+    await waitFor(() => {
+      trackCall = fetchMock.mock.calls.find(([input, init]) => {
+        if (!String(input).endsWith("/api/sfu/tracks")) return false
+        const body = JSON.parse(init.body as string) as {
+          tracks?: Array<{ location?: string }>
+        }
+        return body.tracks?.[0]?.location === "remote"
+      }) as [RequestInfo | URL, RequestInit] | undefined
+      expect(trackCall).toBeDefined()
+    })
+    const trackBody = JSON.parse(trackCall![1].body as string)
+    expect(trackBody.tracks).toEqual([
+      {
+        location: "remote",
+        sessionId: "agent-session",
+        trackName: "agent-voice",
+        kind: "audio",
+      },
+    ])
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([input]) =>
+          String(input).endsWith("/api/sfu/renegotiate")
+        )
+      ).toBe(true)
+    )
+    unmount()
+  })
+
+  it("fails closed and leaves an errored remote subscription retryable", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    let trackAttempts = 0
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.endsWith("/api/sfu/session"))
+        return jsonResponse({
+          participantId: "participant-1",
+          participantToken: "participant-token",
+          sessionId: "session-1",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      if (url.endsWith("/api/sfu/datachannels/new"))
+        return jsonResponse({ dataChannels: [{ id: 1 }] })
+      if (url.endsWith("/api/sfu/tracks")) {
+        trackAttempts += 1
+        return jsonResponse({
+          requiresImmediateRenegotiation: false,
+          tracks: [{ errorCode: "track_not_found" }],
+        })
+      }
+      return jsonResponse({})
+    })
+
+    const { unmount } = await connect("room-remote-error")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+    const publish = () =>
+      act(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({
+            type: "trackPublished",
+            participant: {
+              id: "agent-b",
+              name: "Agent B",
+              kind: "agent",
+              sessionId: "agent-session",
+              track: { trackName: "agent-voice", kind: "audio" },
+            },
+          }),
+        })
+      })
+
+    publish()
+    await waitFor(() => expect(trackAttempts).toBe(1))
+    expect(
+      fetchMock.mock.calls.some(([input]) =>
+        String(input).endsWith("/api/sfu/renegotiate")
+      )
+    ).toBe(false)
+    expect(JSON.stringify(warn.mock.calls)).not.toContain("agent-session")
+
+    publish()
+    await waitFor(() => expect(trackAttempts).toBe(2))
     unmount()
   })
 })

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -93,9 +93,41 @@ interface IncomingFileTransfer {
 
 interface SfuApiResponse {
   dataChannels?: Array<{ id?: number }>
+  errorCode?: string
   requiresImmediateRenegotiation?: boolean
   sessionDescription?: RTCSessionDescriptionInit
-  tracks?: Array<{ trackName?: string }>
+  tracks?: Array<{
+    errorCode?: string
+    errorDescription?: string
+    mid?: string
+    trackName?: string
+  }>
+}
+
+function summarizeRemoteTrackResponse(response: SfuApiResponse) {
+  const tracks = Array.isArray(response.tracks) ? response.tracks : []
+  return {
+    requiresImmediateRenegotiation:
+      response.requiresImmediateRenegotiation === true,
+    hasSessionDescription: Boolean(response.sessionDescription),
+    sessionDescriptionType: response.sessionDescription?.type ?? null,
+    trackResultCount: tracks.length,
+    trackHasMid: tracks.some(
+      (track) => typeof track.mid === "string" && track.mid.length > 0
+    ),
+    topLevelErrorCode:
+      typeof response.errorCode === "string"
+        ? response.errorCode.slice(0, 64)
+        : undefined,
+    trackErrorCodes: tracks
+      .map((track) =>
+        typeof track.errorCode === "string"
+          ? track.errorCode.slice(0, 64)
+          : undefined
+      )
+      .filter((code): code is string => Boolean(code))
+      .slice(0, 4),
+  }
 }
 
 function isAgentImage(file: File): boolean {
@@ -843,12 +875,16 @@ export function useSfuChatRoom(
               location: "remote",
               sessionId: media.sessionId,
               trackName: track.trackName,
+              kind: track.kind,
             },
           ],
         })
         if (!response.sessionDescription) {
           subscribedTracksRef.current.delete(key)
-          console.warn("sfu_remote_subscribe_missing_description", key)
+          console.warn(
+            "sfu_remote_subscribe_missing_description",
+            summarizeRemoteTrackResponse(response)
+          )
           return
         }
         await pc.setRemoteDescription(response.sessionDescription)
@@ -863,7 +899,9 @@ export function useSfuChatRoom(
         })
       }).catch((error) => {
         subscribedTracksRef.current.delete(key)
-        console.warn("sfu_remote_subscribe_failed", key, error)
+        console.warn("sfu_remote_subscribe_failed", {
+          errorType: error instanceof Error ? error.name : typeof error,
+        })
       })
     },
     [apiRequest, enqueueNegotiation, roomName]


### PR DESCRIPTION
## Summary

Fix the Human-side remote Agent track subscription so Cloudflare receives the authoritative media kind and make subscription diagnostics safe and actionable.

## Problem

After PR #132, the browser correctly reached `subscribeTrack`, but the remote `/api/sfu/tracks` request contained only the publisher session and track name. The SFU-generated-offer path needs the existing `audio` or `video` kind to create the remote transceiver. The previous warning also logged a composite subscription key and the failure path logged the raw error, which could expose session identifiers or upstream details.

## Fix

- Forward the existing validated `track.kind` with each remote subscription request.
- Extend the local response shape for top-level and per-track error codes.
- Replace remote subscription logging with bounded structural response metadata and an error type; SDP, tokens, handles, session identifiers, raw bodies, and descriptions are not logged.
- Keep failed subscriptions fail-closed and remove their dedup key so a later authoritative event can retry.

## Validation

- `yarn test` — 347 tests passed across 32 files.
- `yarn type-check` — passed.
- `yarn prettier --check src` — passed.
- `yarn eslint src` — passed.
- `yarn cf-build` — passed.
- Added hook coverage for kind forwarding, remote offer renegotiation, fail-closed errors, safe diagnostics, and retryability.

This PR is intentionally limited to `useSfuChatRoom` and its focused hook tests. It does not change ACP, TTS, Pion, Agent runtime, RoomSession grants, tokens, or media authorization.
