### PR TITLE
[codex] diagnose missing remote SFU descriptions

### DIFF
--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -394,6 +394,179 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  it("Human remote response with an offer does not perform publisher diagnostics", async () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined)
+    try {
+      fetchMock = vi.fn(async () =>
+        Response.json({
+          sessionDescription: { type: "offer", sdp: "sdp" },
+          tracks: [{ mid: "0" }],
+        })
+      )
+      vi.stubGlobal("fetch", fetchMock)
+      const env = makeEnv({}, doResponderForKind("human"))
+      const res = await handleSfuRequest(
+        req("tracks", {
+          body: JSON.stringify(
+            humanTracksBody({
+              location: "remote",
+              sessionId: "publisher-sess-1",
+              trackName: "audio-human",
+            })
+          ),
+        }),
+        env
+      )
+      expect(res.status).toBe(200)
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      expect(warnSpy).not.toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it("Human remote missing-description diagnostics preserve the original response and stay redacted", async () => {
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined)
+    fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.endsWith("/tracks/new"))
+        return Response.json({
+          requiresImmediateRenegotiation: true,
+          errorCode: "track_lookup_failed",
+          tracks: [{ errorCode: "track_not_found" }],
+        })
+      if (url.endsWith("/sessions/publisher-sess-1"))
+        return new Response("upstream unavailable", { status: 503 })
+      throw new Error("unexpected diagnostic request")
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    try {
+      const env = makeEnv({}, doResponderForKind("human"))
+      const res = await handleSfuRequest(
+        req("tracks", {
+          body: JSON.stringify(
+            humanTracksBody({
+              location: "remote",
+              sessionId: "publisher-sess-1",
+              trackName: "audio-human",
+            })
+          ),
+        }),
+        env
+      )
+      expect(res.status).toBe(200)
+      await expect(res.json()).resolves.toEqual({
+        requiresImmediateRenegotiation: true,
+        errorCode: "track_lookup_failed",
+        tracks: [{ errorCode: "track_not_found" }],
+      })
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+      expect(String(fetchMock.mock.calls[1]![0])).toContain(
+        "/sessions/publisher-sess-1"
+      )
+      const diagnosticCall = warnSpy.mock.calls.find(
+        (call) => call[0] === "sfu_remote_subscribe_diagnostic"
+      )
+      expect(diagnosticCall?.[1]).toMatchObject({
+        upstreamStatus: 200,
+        requiresImmediateRenegotiation: true,
+        hasSessionDescription: false,
+        trackResultCount: 1,
+        trackHasMid: false,
+        topLevelErrorCode: "track_lookup_failed",
+        trackErrorCodes: ["track_not_found"],
+        publisherSessionLookupOk: false,
+        publisherTrackCount: 0,
+        matchingTrackFound: false,
+        matchingTrackStatus: "unknown",
+        matchingTrackHasMid: false,
+      })
+      expect(JSON.stringify(diagnosticCall)).not.toContain("publisher-sess-1")
+      expect(JSON.stringify(diagnosticCall)).not.toContain("audio-human")
+      expect(JSON.stringify(diagnosticCall)).not.toContain(
+        "upstream unavailable"
+      )
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it.each([
+    [
+      "active",
+      [{ trackName: "audio-human", status: "active", mid: "3" }],
+      "active",
+      true,
+    ],
+    [
+      "inactive",
+      [{ trackName: "audio-human", status: "inactive", mid: "3" }],
+      "inactive",
+      true,
+    ],
+    [
+      "waiting",
+      [{ trackName: "audio-human", status: "waiting", mid: "3" }],
+      "waiting",
+      true,
+    ],
+    [
+      "missing",
+      [{ trackName: "other-track", status: "active", mid: "3" }],
+      "unknown",
+      false,
+    ],
+  ])(
+    "summarizes publisher status when Human remote response lacks an offer (%s)",
+    async (_label, publisherTracks, expectedStatus, expectedFound) => {
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => undefined)
+      fetchMock = vi.fn(async (input: string | URL | Request) => {
+        const url = String(input)
+        if (url.endsWith("/tracks/new"))
+          return Response.json({ tracks: [{ errorCode: "track_not_found" }] })
+        if (url.endsWith("/sessions/publisher-sess-1"))
+          return Response.json({ tracks: publisherTracks })
+        throw new Error("unexpected diagnostic request")
+      })
+      vi.stubGlobal("fetch", fetchMock)
+      try {
+        const env = makeEnv({}, doResponderForKind("human"))
+        const res = await handleSfuRequest(
+          req("tracks", {
+            body: JSON.stringify(
+              humanTracksBody({
+                location: "remote",
+                sessionId: "publisher-sess-1",
+                trackName: "audio-human",
+              })
+            ),
+          }),
+          env
+        )
+        expect(res.status).toBe(200)
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+        const diagnosticCall = warnSpy.mock.calls.find(
+          (call) => call[0] === "sfu_remote_subscribe_diagnostic"
+        )
+        expect(diagnosticCall?.[1]).toMatchObject({
+          publisherSessionLookupOk: true,
+          publisherTrackCount: 1,
+          matchingTrackFound: expectedFound,
+          matchingTrackStatus: expectedStatus,
+          matchingTrackHasMid: expectedFound,
+        })
+      } finally {
+        warnSpy.mockRestore()
+      }
+    }
+  )
+
   it("Agent + remote Human audio track => allowed (subscribing is the whole point of Phase 0)", async () => {
     const env = makeEnv(
       { AGENT_MEDIA_ENABLED: "true" },

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -189,6 +189,164 @@ async function realtimeRequest(
   )
 }
 
+const MAX_DIAGNOSTIC_TRACK_COUNT = 100
+const MAX_DIAGNOSTIC_ERROR_CODE_LENGTH = 64
+const DIAGNOSTIC_LOOKUP_TIMEOUT_MS = 3000
+
+function boundedDiagnosticErrorCode(value: unknown): string | undefined {
+  return typeof value === "string"
+    ? value.slice(0, MAX_DIAGNOSTIC_ERROR_CODE_LENGTH)
+    : undefined
+}
+
+function parsedObject(value: string): Record<string, unknown> | undefined {
+  try {
+    const parsed = JSON.parse(value)
+    return parsed && typeof parsed === "object"
+      ? (parsed as Record<string, unknown>)
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function summarizeRemoteTrackResponse(
+  status: number,
+  responseBody: string
+): {
+  upstreamStatus: number
+  requiresImmediateRenegotiation: boolean
+  hasSessionDescription: boolean
+  sessionDescriptionType: string | null
+  trackResultCount: number
+  trackHasMid: boolean
+  topLevelErrorCode?: string
+  trackErrorCodes: string[]
+} {
+  const response = parsedObject(responseBody)
+  const sessionDescription =
+    response?.sessionDescription &&
+    typeof response.sessionDescription === "object"
+      ? (response.sessionDescription as Record<string, unknown>)
+      : undefined
+  const tracks = Array.isArray(response?.tracks)
+    ? response.tracks.slice(0, MAX_DIAGNOSTIC_TRACK_COUNT)
+    : []
+  const trackErrorCodes = tracks
+    .map((track) =>
+      track && typeof track === "object"
+        ? boundedDiagnosticErrorCode(
+            (track as Record<string, unknown>).errorCode
+          )
+        : undefined
+    )
+    .filter((code): code is string => Boolean(code))
+    .filter((code, index, all) => all.indexOf(code) === index)
+    .slice(0, 4)
+  return {
+    upstreamStatus: status,
+    requiresImmediateRenegotiation:
+      response?.requiresImmediateRenegotiation === true,
+    hasSessionDescription: Boolean(sessionDescription),
+    sessionDescriptionType:
+      sessionDescription?.type === "offer" ||
+      sessionDescription?.type === "answer"
+        ? sessionDescription.type
+        : null,
+    trackResultCount: tracks.length,
+    trackHasMid: tracks.some(
+      (track) =>
+        track &&
+        typeof track === "object" &&
+        typeof (track as Record<string, unknown>).mid === "string" &&
+        ((track as Record<string, unknown>).mid as string).length > 0
+    ),
+    ...(boundedDiagnosticErrorCode(response?.errorCode)
+      ? { topLevelErrorCode: boundedDiagnosticErrorCode(response?.errorCode) }
+      : {}),
+    trackErrorCodes,
+  }
+}
+
+function usableSessionDescription(responseBody: string): boolean {
+  const response = parsedObject(responseBody)
+  const description =
+    response?.sessionDescription &&
+    typeof response.sessionDescription === "object"
+      ? (response.sessionDescription as Record<string, unknown>)
+      : undefined
+  return typeof description?.sdp === "string" && description.sdp.length > 0
+}
+
+type PublisherTrackStatus = "active" | "inactive" | "waiting" | "unknown"
+
+function publisherTrackStatus(value: unknown): PublisherTrackStatus {
+  return value === "active" || value === "inactive" || value === "waiting"
+    ? value
+    : "unknown"
+}
+
+async function diagnosePublisherSession(
+  env: SfuEnv,
+  publisherSessionId: string,
+  requestedTrackName: string
+): Promise<{
+  publisherSessionLookupOk: boolean
+  publisherTrackCount: number
+  matchingTrackFound: boolean
+  matchingTrackStatus: PublisherTrackStatus
+  matchingTrackHasMid: boolean
+}> {
+  const failed = {
+    publisherSessionLookupOk: false,
+    publisherTrackCount: 0,
+    matchingTrackFound: false,
+    matchingTrackStatus: "unknown" as const,
+    matchingTrackHasMid: false,
+  }
+  const controller = new AbortController()
+  const timeout = setTimeout(
+    () => controller.abort(),
+    DIAGNOSTIC_LOOKUP_TIMEOUT_MS
+  )
+  try {
+    const response = await realtimeRequest(
+      env,
+      `/sessions/${encodeURIComponent(publisherSessionId)}`,
+      { method: "GET", signal: controller.signal }
+    )
+    const body = await response.text()
+    if (!response.ok) return failed
+    const parsed = parsedObject(body)
+    const tracks = Array.isArray(parsed?.tracks)
+      ? parsed.tracks.slice(0, MAX_DIAGNOSTIC_TRACK_COUNT)
+      : []
+    const matching = tracks.find(
+      (track) =>
+        track &&
+        typeof track === "object" &&
+        (track as Record<string, unknown>).trackName === requestedTrackName
+    )
+    const matchingRecord =
+      matching && typeof matching === "object"
+        ? (matching as Record<string, unknown>)
+        : undefined
+    return {
+      publisherSessionLookupOk: true,
+      publisherTrackCount: tracks.length,
+      matchingTrackFound: Boolean(matchingRecord),
+      matchingTrackStatus: publisherTrackStatus(matchingRecord?.status),
+      matchingTrackHasMid:
+        typeof matchingRecord?.mid === "string" &&
+        matchingRecord.mid.length > 0,
+    }
+  } catch {
+    return failed
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 async function readBody(
   request: Request
 ): Promise<Record<string, unknown> | null> {
@@ -521,6 +679,36 @@ export async function handleSfuRequest(
     const responseBody = await upstream.text()
     if (!upstream.ok)
       return new Response(responseBody, { status: upstream.status })
+
+    // Production-only diagnostic for the Human remote-subscribe path. A
+    // successful tracks/new response should carry an SFU-generated offer;
+    // when it does not, inspect the publisher session without changing the
+    // response returned to the browser. Never log the publisher session ID,
+    // requested track name, credentials, raw body, SDP, or descriptions.
+    const firstHumanRemoteTrack =
+      route === "tracks" && participantKind === "human"
+        ? requestedTracks.find((track) => track.location === "remote")
+        : undefined
+    if (
+      firstHumanRemoteTrack &&
+      !usableSessionDescription(responseBody) &&
+      typeof firstHumanRemoteTrack.sessionId === "string" &&
+      typeof firstHumanRemoteTrack.trackName === "string"
+    ) {
+      const responseSummary = summarizeRemoteTrackResponse(
+        upstream.status,
+        responseBody
+      )
+      const publisherSummary = await diagnosePublisherSession(
+        env,
+        firstHumanRemoteTrack.sessionId,
+        firstHumanRemoteTrack.trackName
+      )
+      console.warn("sfu_remote_subscribe_diagnostic", {
+        ...responseSummary,
+        ...publisherSummary,
+      })
+    }
 
     if (route === "tracks" && Array.isArray(body.tracks)) {
       for (const track of body.tracks as Array<Record<string, unknown>>) {


### PR DESCRIPTION
## Summary

Diagnostic-only follow-up for #83 after PR #133 was deployed. This does not change remote-subscribe behavior, signaling, authorization, ACP, TTS, Pion, or Agent runtime behavior.

When a Human remote `/tracks` request receives a 2xx response without a usable session description, the Worker now records a bounded structured summary and performs one best-effort publisher-session lookup. The original Cloudflare response is returned unchanged.

Diagnostics intentionally exclude SDP, credentials, participant handles, session IDs, track names, raw bodies, and error descriptions.

## Verification

- `yarn test` — 32 files / 353 tests passed
- `yarn type-check` passed
- `yarn prettier --check src` passed
- `yarn eslint src` passed
- `yarn cf-build` passed

## Commit identity

Head commit author and committer: codex <267193182+codex@users.noreply.github.com>

Please review the exact head. Do not merge until ChatGPT explicitly approves it and CI is green.
