### PR TITLE
fix: announce agent voice after first PCM

### DIFF
--- a/agent-runtime/src/media/sfuMediaBridge.ts
+++ b/agent-runtime/src/media/sfuMediaBridge.ts
@@ -30,6 +30,11 @@ function isHumanMediaDiscoveryDenied(error: unknown): boolean {
 }
 /** Emit a bounded stats event at most this often per track, not per packet. */
 const STATS_FLUSH_INTERVAL_MS = 2000
+// One 20 ms mono S16LE frame at the Pion voice rate. This is a bounded,
+// non-user priming packet: it lets Cloudflare observe the publication before
+// the first audible PCM chunk is sent.
+const VOICE_PRIMING_SILENCE_BYTES = 960
+const MAX_PENDING_VOICE_PCM_BYTES = 8 * 1024 * 1024
 
 export interface SfuMediaBridgeOptions {
   /** Base MCP URL (same env var/default as the rest of the Runtime) or an
@@ -108,6 +113,11 @@ export class SfuMediaBridge {
     }
   >()
   private readonly subscriptions = new Map<string, TrackSubscription>()
+  private voicePublicationAnnounced = false
+  private voiceAnnounceInFlight: Promise<void> | null = null
+  private voicePrimingSent = false
+  private pendingVoicePcm: Uint8Array[] = []
+  private pendingVoicePcmBytes = 0
 
   constructor(options: SfuMediaBridgeOptions) {
     this.onEvent = options.onEvent
@@ -217,6 +227,9 @@ export class SfuMediaBridge {
       throw new Error("media_engine_publish_unsupported")
     if (!this.restClient.publishAudioTrack)
       throw new Error("rest_client_publish_unsupported")
+    this.voicePublicationAnnounced = false
+    this.voiceAnnounceInFlight = null
+    this.voicePrimingSent = false
     await this.negotiationQueue.then(
       () => undefined,
       () => undefined
@@ -266,16 +279,127 @@ export class SfuMediaBridge {
       await this.pc?.deactivatePublish?.()
     } catch {
       // Best effort cooperative stop; server-side close is authoritative.
+    } finally {
+      this.clearPendingVoicePcm()
     }
   }
 
   async writeVoicePcm(chunk: Uint8Array): Promise<void> {
     if (this.stopped) throw new Error("bridge_stopped")
+    await this.primeVoicePublication()
+    await this.confirmVoicePublicationActive()
+    if (
+      this.publish &&
+      this.restClient.confirmPublishedAudioTrackActive &&
+      !this.voicePublicationAnnounced
+    ) {
+      this.enqueuePendingVoicePcm(chunk)
+      return
+    }
+    await this.drainPendingVoicePcm()
     await this.pc?.writePcmChunk?.(chunk)
+    await this.confirmVoicePublicationActive()
   }
 
   async flushVoice(): Promise<void> {
-    await this.pc?.flushAudio?.()
+    await this.primeVoicePublication()
+    await this.confirmVoicePublicationActive()
+    await this.drainPendingVoicePcm()
+    let flushError: unknown
+    try {
+      await this.pc?.flushAudio?.()
+    } catch (error) {
+      flushError = error
+    }
+    await this.confirmVoicePublicationActive()
+    const needsSecondFlush =
+      this.voicePublicationAnnounced && this.pendingVoicePcm.length > 0
+    if (needsSecondFlush) {
+      await this.drainPendingVoicePcm()
+      try {
+        await this.pc?.flushAudio?.()
+      } catch (error) {
+        if (flushError === undefined) flushError = error
+      }
+    }
+    if (flushError !== undefined) throw flushError
+  }
+
+  /** Cloudflare may report a newly booked publication as inactive until its
+   * first RTP packet has arrived. Confirmation is best-effort and single-
+   * flight: a negative/failed check never turns a successful voice write into
+   * a failed speech turn, and the next write/flush is the retry opportunity. */
+  private async confirmVoicePublicationActive(): Promise<void> {
+    if (
+      !this.publish ||
+      this.voicePublicationAnnounced ||
+      !this.mySessionId ||
+      !this.restClient.confirmPublishedAudioTrackActive
+    )
+      return
+    if (!this.voiceAnnounceInFlight) {
+      const sessionId = this.mySessionId
+      const run = (async () => {
+        try {
+          const active = await this.restClient
+            .confirmPublishedAudioTrackActive!(
+            sessionId,
+            this.publish!.trackName
+          )
+          if (active) this.voicePublicationAnnounced = true
+        } catch {
+          // Readiness is advisory; leave the flag false so a later write or
+          // final flush can retry without failing the voice turn.
+        }
+      })()
+      const flight = run.finally(() => {
+        if (this.voiceAnnounceInFlight === flight)
+          this.voiceAnnounceInFlight = null
+      })
+      this.voiceAnnounceInFlight = flight
+    }
+    await this.voiceAnnounceInFlight
+  }
+
+  /** Send at most one synthetic silence frame before user audio for this
+   * publication. If Cloudflare still says inactive, later real writes and
+   * the final flush remain the bounded retry opportunities; the silence is
+   * never user-visible audio. */
+  private async primeVoicePublication(): Promise<void> {
+    if (
+      !this.publish ||
+      this.voicePublicationAnnounced ||
+      this.voicePrimingSent ||
+      !this.pc?.writePcmChunk ||
+      !this.restClient.confirmPublishedAudioTrackActive
+    )
+      return
+    this.voicePrimingSent = true
+    await this.pc.writePcmChunk(new Uint8Array(VOICE_PRIMING_SILENCE_BYTES))
+  }
+
+  private enqueuePendingVoicePcm(chunk: Uint8Array): void {
+    if (chunk.length === 0) return
+    if (this.pendingVoicePcmBytes + chunk.length > MAX_PENDING_VOICE_PCM_BYTES)
+      throw new Error("voice_pcm_buffer_full")
+    const copy = new Uint8Array(chunk)
+    this.pendingVoicePcm.push(copy)
+    this.pendingVoicePcmBytes += copy.length
+  }
+
+  private async drainPendingVoicePcm(): Promise<void> {
+    if (!this.voicePublicationAnnounced || !this.pc?.writePcmChunk) return
+    while (this.pendingVoicePcm.length > 0) {
+      const chunk = this.pendingVoicePcm[0]!
+      await this.pc.writePcmChunk(chunk)
+      this.pendingVoicePcm.shift()
+      this.pendingVoicePcmBytes -= chunk.length
+    }
+  }
+
+  private clearPendingVoicePcm(): void {
+    this.pendingVoicePcm = []
+    this.pendingVoicePcmBytes = 0
   }
 
   /** Cancelled-utterance boundary (#83): discards any buffered partial
@@ -284,6 +408,7 @@ export class SfuMediaBridge {
    * Best-effort cooperative discard; server-side revocation remains
    * authoritative. */
   async cancelVoiceTurn(): Promise<void> {
+    this.clearPendingVoicePcm()
     try {
       await this.pc?.cancelTurnAudio?.()
     } catch {
@@ -309,6 +434,10 @@ export class SfuMediaBridge {
     this.pc?.close()
     this.pc = null
     this.mySessionId = null
+    this.voicePublicationAnnounced = false
+    this.voiceAnnounceInFlight = null
+    this.voicePrimingSent = false
+    this.clearPendingVoicePcm()
     this.stopped = true
   }
 

--- a/agent-runtime/src/media/sfuRestClient.ts
+++ b/agent-runtime/src/media/sfuRestClient.ts
@@ -89,12 +89,18 @@ export interface SfuRestClientLike {
     mySessionId: string,
     args: { trackName: string; mid: string; offer: SessionDescriptionLike }
   ): Promise<{ sessionDescription?: SessionDescriptionLike }>
+  /** Confirms Cloudflare has observed the publication as active after a PCM
+   * write; the Worker exposes it to Humans only on a positive result. */
+  confirmPublishedAudioTrackActive?(
+    mySessionId: string,
+    trackName: string
+  ): Promise<boolean>
 }
 
 /**
  * Thin REST client for the app's /api/sfu/* endpoints — the same ones the
  * browser client (useSfuChatRoom.ts) already uses for tracks/renegotiate,
- * plus the two agent-only endpoints added alongside this PR
+ * plus the Agent-only endpoints added alongside this PR
  * (agent-session, agent-room-media). No SFU/Cloudflare credentials ever
  * live here — only the participant token this Agent already holds from
  * its normal room join.
@@ -267,6 +273,18 @@ export class SfuRestClient implements SfuRestClientLike {
     const description = data.sessionDescription as
       SessionDescriptionLike | undefined
     return description ? { sessionDescription: description } : {}
+  }
+
+  async confirmPublishedAudioTrackActive(
+    mySessionId: string,
+    trackName: string
+  ): Promise<boolean> {
+    const data = await this.request("agent-track-active", "POST", {
+      ...this.base(),
+      sessionId: mySessionId,
+      trackName,
+    })
+    return data.active === true
   }
 
   async renegotiate(

--- a/agent-runtime/test/sfuMediaBridgeVoice.test.ts
+++ b/agent-runtime/test/sfuMediaBridgeVoice.test.ts
@@ -68,8 +68,7 @@ function scriptedPc(ops: Op[]) {
       return "pub-mid-9"
     },
     writePcmChunk: async (chunk: Uint8Array) => {
-      void chunk
-      ops.push("write")
+      ops.push(chunk.length === 960 ? "silence" : "write")
     },
   }
   return pc as unknown as PeerConnectionLike & {
@@ -104,6 +103,7 @@ describe("SfuMediaBridge voiceReply publication (#83 live-silence fix)", () => {
       sessionId: string
       args: { trackName: string; mid: string; offer: SessionDescriptionLike }
     }> = []
+    const confirmCalls: Array<{ sessionId: string; trackName: string }> = []
 
     const bridge = new SfuMediaBridge({
       mcpUrl: "https://www.free4.chat/mcp",
@@ -123,12 +123,18 @@ describe("SfuMediaBridge voiceReply publication (#83 live-silence fix)", () => {
             sessionDescription: { type: "answer", sdp: "pub-answer" },
           } satisfies SessionDescriptionLike
         },
+        confirmPublishedAudioTrackActive: async (sessionId, trackName) => {
+          ops.push("confirm")
+          confirmCalls.push({ sessionId, trackName })
+          return true
+        },
       },
     })
 
     await bridge.start()
     assert.equal(bridge.voicePublishCapable, true)
     await bridge.activateVoicePublish()
+    assert.deepEqual(confirmCalls, [])
 
     // Bootstrap receive-only offer first; publication arms BEFORE its own
     // offer so the send m-line actually exists.
@@ -150,6 +156,95 @@ describe("SfuMediaBridge voiceReply publication (#83 live-silence fix)", () => {
     assert.equal(publishCalls[0]!.args.mid, "pub-mid-9")
     assert.equal(publishCalls[0]!.args.offer.sdp, "offer-sdp")
 
+    await bridge.writeVoicePcm(new Uint8Array([1, 2]))
+    await bridge.writeVoicePcm(new Uint8Array([3, 4]))
+    assert.deepEqual(confirmCalls, [
+      { sessionId: "sess-agent", trackName: "agent-voice" },
+    ])
+    assert.deepEqual(ops.slice(-4), ["silence", "confirm", "write", "write"])
+
+    await bridge.stop()
+  })
+
+  it("retries inactive or failed readiness checks on later writes and final flush without failing audio", async () => {
+    const ops: Op[] = []
+    let confirmations = 0
+    const bridge = new SfuMediaBridge({
+      mcpUrl: "https://www.free4.chat/mcp",
+      handle,
+      onEvent: () => undefined,
+      createPeerConnection: () =>
+        scriptedPc(ops) as unknown as PeerConnectionLike,
+      pollIntervalMs: 1_000_000,
+      publish: { trackName: "agent-voice" },
+      restClient: {
+        ...bootstrapRest,
+        publishAudioTrack: async () => ({}),
+        confirmPublishedAudioTrackActive: async () => {
+          ops.push("confirm")
+          confirmations += 1
+          if (confirmations === 1) return false
+          if (confirmations === 2) throw new Error("temporary_lookup_failure")
+          return true
+        },
+      },
+    })
+
+    await bridge.start()
+    await bridge.activateVoicePublish()
+    await assert.doesNotReject(() => bridge.writeVoicePcm(new Uint8Array([1])))
+    await assert.doesNotReject(() => bridge.writeVoicePcm(new Uint8Array([2])))
+    await bridge.flushVoice()
+    await bridge.writeVoicePcm(new Uint8Array([3]))
+    assert.equal(confirmations, 3)
+    assert.deepEqual(ops.slice(-8), [
+      "silence",
+      "confirm",
+      "confirm",
+      "confirm",
+      "write",
+      "write",
+      "flush",
+      "write",
+    ])
+    await bridge.stop()
+  })
+
+  it("flushes again when its final readiness check activates and drains pending audio", async () => {
+    const ops: Op[] = []
+    let confirmations = 0
+    const bridge = new SfuMediaBridge({
+      mcpUrl: "https://www.free4.chat/mcp",
+      handle,
+      onEvent: () => undefined,
+      createPeerConnection: () =>
+        scriptedPc(ops) as unknown as PeerConnectionLike,
+      pollIntervalMs: 1_000_000,
+      publish: { trackName: "agent-voice" },
+      restClient: {
+        ...bootstrapRest,
+        publishAudioTrack: async () => ({}),
+        confirmPublishedAudioTrackActive: async () => {
+          ops.push("confirm")
+          confirmations += 1
+          return confirmations > 2
+        },
+      },
+    })
+
+    await bridge.start()
+    await bridge.activateVoicePublish()
+    await bridge.writeVoicePcm(new Uint8Array([7]))
+    await bridge.flushVoice()
+    assert.deepEqual(ops.slice(-7), [
+      "silence",
+      "confirm",
+      "confirm",
+      "flush",
+      "confirm",
+      "write",
+      "flush",
+    ])
     await bridge.stop()
   })
 

--- a/agent-runtime/test/sfuRestClient.test.ts
+++ b/agent-runtime/test/sfuRestClient.test.ts
@@ -25,6 +25,7 @@ function captureBody(): {
     // Generic-envelope response that satisfies every signaling method's
     // response parsing (subscribe/publish need an SDP description).
     return Response.json({
+      active: true,
       sessionDescription: { type: "answer", sdp: "v=0\r\n" },
       tracks: [],
     })
@@ -147,6 +148,42 @@ test("every signaling method carries its typed purpose on the wire (#83 review)"
     } finally {
       capture.restore()
     }
+  }
+})
+
+test("confirms the published PCM track through the Agent-only endpoint", async () => {
+  const capture = captureBody()
+  try {
+    const client = new SfuRestClient("https://example.test", handle())
+    await assert.doesNotReject(async () => {
+      assert.equal(
+        await client.confirmPublishedAudioTrackActive!("s", "agent-voice"),
+        true
+      )
+    })
+    assert.deepEqual(capture.body, {
+      room: "room",
+      participantId: "participant",
+      token: "token",
+      sessionId: "s",
+      trackName: "agent-voice",
+    })
+  } finally {
+    capture.restore()
+  }
+})
+
+test("treats an inactive publication confirmation as false", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () => Response.json({ active: false })
+  try {
+    const client = new SfuRestClient("https://example.test", handle())
+    assert.equal(
+      await client.confirmPublishedAudioTrackActive!("s", "agent-voice"),
+      false
+    )
+  } finally {
+    globalThis.fetch = originalFetch
   }
 })
 

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -184,6 +184,13 @@ type ControlRequest =
       trackName: string
     }
   | {
+      action: "agent-track-active"
+      participantId: string
+      token: string
+      sessionId: string
+      trackName: string
+    }
+  | {
       action: "reconnect"
       participantId: string
       token: string
@@ -382,9 +389,11 @@ type ClientMessage =
  * an agent holding the ACTIVE voiceReply grant may keep its single published
  * outbound audio track (and the registered mid Stop needs for revocation)
  * across room loads. Every other shape — no grant, wrong agent, multiple
- * tracks, video, or a mid without a matching track — is stripped exactly as
- * the old subscribe-only rule did. This preserves an authorized publication
- * across DO eviction/restart; it never loosens who may create one. */
+ * tracks, video, or a mid without a matching track or pending track name — is
+ * stripped exactly as the old subscribe-only rule did. A pending publication
+ * is kept private until the Runtime confirms its first PCM write. This
+ * preserves an authorized publication across DO eviction/restart; it never
+ * loosens who may create one. */
 export function normalizeAgentParticipantMedia(
   media: RoomParticipant["media"],
   voiceReply: VoiceReplyState,
@@ -397,19 +406,29 @@ export function normalizeAgentParticipantMedia(
     media.agentPublishedMid.length > 0
       ? media.agentPublishedMid
       : undefined
+  const pendingTrackName =
+    typeof media.agentPublishedTrackName === "string" &&
+    media.agentPublishedTrackName.length > 0
+      ? media.agentPublishedTrackName
+      : undefined
   // Callers pass the ALREADY-NORMALIZED grant (normalizeRoom hoists
   // isValidVoiceReplyState above this decision); authorization reuses the
   // exact production predicate so no second rule can drift.
   const authorized =
     isAgentAuthorizedForVoiceReply(voiceReply, participantId) &&
-    tracks.length === 1 &&
-    tracks[0]!.kind === "audio" &&
-    publishedMid !== undefined
+    publishedMid !== undefined &&
+    ((tracks.length === 1 && tracks[0]!.kind === "audio") ||
+      (tracks.length === 0 && pendingTrackName !== undefined))
   if (authorized) return { media, changed: false }
-  if (tracks.length === 0 && publishedMid === undefined)
+  if (
+    tracks.length === 0 &&
+    publishedMid === undefined &&
+    pendingTrackName === undefined
+  )
     return { media, changed: false }
   const next: RoomParticipant["media"] = { ...media, tracks: [] }
   if (publishedMid !== undefined) delete next.agentPublishedMid
+  if (pendingTrackName !== undefined) delete next.agentPublishedTrackName
   return { media: next, changed: true }
 }
 
@@ -772,12 +791,14 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           // participant-visible state.
           if (
             !participant.media?.agentSubscribedMids &&
-            !participant.media?.agentPublishedMid
+            !participant.media?.agentPublishedMid &&
+            !participant.media?.agentPublishedTrackName
           )
             return participant
           const {
             agentSubscribedMids: _mids,
             agentPublishedMid: _publishedMid,
+            agentPublishedTrackName: _publishedTrackName,
             ...media
           } = participant.media
           return { ...participant, media }
@@ -2155,13 +2176,50 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       participant.media = {
         ...participant.media,
         agentPublishedMid: request.mid,
-        tracks: [
-          ...participant.media.tracks.filter(
-            (track) => track.trackName !== request.trackName
-          ),
-          { trackName: request.trackName, kind: "audio" },
-        ],
+        // Registration is durable revocation bookkeeping only. Do not expose
+        // the track to Humans until the Runtime has successfully written its
+        // first PCM packet; Cloudflare can report a booked track as inactive
+        // before that happens.
+        agentPublishedTrackName: request.trackName,
+        tracks: [],
       }
+      participant.lastSeenAt = Date.now()
+      await this.saveRoom(room)
+      return this.json({ ok: true })
+    }
+
+    if (request.action === "agent-track-active") {
+      // The Worker calls this only after Cloudflare reports this publication
+      // as active. It is intentionally idempotent because confirmation may
+      // be retried after an inactive result or a transient lookup failure.
+      const participant = this.findParticipant(
+        room,
+        request.participantId,
+        request.token,
+        request.sessionId
+      )
+      if (!participant || participant.kind !== "agent")
+        return this.json({ error: "unauthorized" }, 401)
+      if (!isAgentAuthorizedForVoiceReply(room.voiceReply, participant.id))
+        return this.json({ error: "voice_reply_not_authorized" }, 403)
+      if (!participant.media)
+        return this.json({ error: "media_unavailable" }, 400)
+      if (
+        participant.media.tracks.length === 1 &&
+        participant.media.tracks[0]!.trackName === request.trackName &&
+        participant.media.tracks[0]!.kind === "audio"
+      )
+        return this.json({ ok: true })
+      if (
+        !participant.media.agentPublishedMid ||
+        participant.media.agentPublishedTrackName !== request.trackName
+      )
+        return this.json({ error: "agent_publication_not_ready" }, 409)
+      participant.media = {
+        ...participant.media,
+        tracks: [{ trackName: request.trackName, kind: "audio" }],
+      }
+      delete participant.media.agentPublishedTrackName
       participant.lastSeenAt = Date.now()
       await this.saveRoom(room)
       await this.broadcast({
@@ -2183,6 +2241,13 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       participant.media.tracks = participant.media.tracks.filter(
         (track) => track.trackName !== request.trackName
       )
+      if (
+        participant.kind === "agent" &&
+        participant.media.agentPublishedTrackName === request.trackName
+      ) {
+        delete participant.media.agentPublishedTrackName
+        delete participant.media.agentPublishedMid
+      }
       await this.saveRoom(room)
       await this.broadcastState(room)
       return this.json({ ok: true })

--- a/app/src/do/realtimeMedia.ts
+++ b/app/src/do/realtimeMedia.ts
@@ -240,6 +240,7 @@ export function stageAgentMediaRevocation(
   // Notes subscriptions must survive it.
   if (direction !== "subscribed") {
     nextMedia.agentPublishedMid = undefined
+    nextMedia.agentPublishedTrackName = undefined
     nextMedia.tracks = nextMedia.tracks.filter(
       (track) => track.kind !== "audio"
     )

--- a/app/src/do/roomSessionNormalize.test.ts
+++ b/app/src/do/roomSessionNormalize.test.ts
@@ -50,6 +50,22 @@ describe("normalizeAgentParticipantMedia (#83 live silence fix)", () => {
     expect(result.media?.agentPublishedMid).toBeUndefined()
   })
 
+  it("preserves a booked publication privately until its first PCM write", () => {
+    const pending = media({
+      tracks: [],
+      agentPublishedTrackName: "agent-voice",
+    })
+    const result = normalizeAgentParticipantMedia(
+      pending,
+      grantedVoice(),
+      AGENT_ID
+    )
+    expect(result.changed).toBe(false)
+    expect(result.media?.tracks).toEqual([])
+    expect(result.media?.agentPublishedMid).toBe(MID)
+    expect(result.media?.agentPublishedTrackName).toBe("agent-voice")
+  })
+
   it("strips tracks when the grant names a different agent", () => {
     const other = { ...grantedVoice(), agentParticipantId: "agent-other" }
     const result = normalizeAgentParticipantMedia(media(), other, AGENT_ID)

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -26,6 +26,9 @@ export interface RoomMediaState {
   // track (#83) — the revocation handle for server-side close; never
   // broadcast to clients.
   agentPublishedMid?: string
+  // Kept private until the Runtime confirms that the publication has
+  // accepted its first PCM packet. At that point it is moved into `tracks`.
+  agentPublishedTrackName?: string
 }
 
 export interface AgentCapabilities {

--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -775,6 +775,74 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
     })
   })
 
+  it("confirms an already-booked Agent publication only after Cloudflare reports it active", async () => {
+    const roomActions: Array<Record<string, unknown>> = []
+    fetchMock.mockResolvedValueOnce(
+      Response.json({
+        tracks: [{ trackName: "agent-voice", mid: "0", status: "active" }],
+      })
+    )
+    const env = makeEnv({ AGENT_MEDIA_ENABLED: "true" }, (body) => {
+      roomActions.push(body)
+      return { status: 200, body: { ok: true } }
+    })
+    const res = await handleSfuRequest(
+      req("agent-track-active", {
+        body: JSON.stringify({
+          ...agentBody,
+          sessionId: "sess-1",
+          trackName: "agent-voice",
+        }),
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(roomActions).toEqual([
+      {
+        action: "authorize",
+        participantId: "agent-1",
+        token: "tok-1",
+        sessionId: "sess-1",
+        purpose: "voice-reply",
+        wantsVoicePublish: true,
+      },
+      {
+        action: "agent-track-active",
+        participantId: "agent-1",
+        token: "tok-1",
+        sessionId: "sess-1",
+        trackName: "agent-voice",
+      },
+    ])
+  })
+
+  it("does not announce an Agent publication while Cloudflare still reports it inactive", async () => {
+    fetchMock.mockResolvedValueOnce(
+      Response.json({
+        tracks: [{ trackName: "agent-voice", mid: "0", status: "inactive" }],
+      })
+    )
+    const roomActions: Array<Record<string, unknown>> = []
+    const env = makeEnv({ AGENT_MEDIA_ENABLED: "true" }, (body) => {
+      roomActions.push(body)
+      return { status: 200, body: { ok: true } }
+    })
+    const res = await handleSfuRequest(
+      req("agent-track-active", {
+        body: JSON.stringify({
+          ...agentBody,
+          sessionId: "sess-1",
+          trackName: "agent-voice",
+        }),
+      }),
+      env
+    )
+    expect(res.status).toBe(200)
+    expect((await json(res)).active).toBe(false)
+    expect(roomActions.map((action) => action.action)).toEqual(["authorize"])
+  })
+
   it("does not affect renegotiate (no tracks array, route-scoped check)", async () => {
     const env = makeEnv(
       { AGENT_MEDIA_ENABLED: "true" },

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -43,6 +43,7 @@ function badRequest(message: string): Response {
 const MISSING_ORIGIN_ALLOWED_ROUTES = new Set([
   "agent-session",
   "agent-room-media",
+  "agent-track-active",
   "tracks",
   "renegotiate",
   // The resident, subscribe-only Meeting Notes Runtime has no browser Origin
@@ -552,6 +553,52 @@ export async function handleSfuRequest(
       participantId,
       token,
     })
+  }
+
+  if (route === "agent-track-active") {
+    if (request.method !== "POST")
+      return json({ error: "method_not_allowed" }, 405)
+    if (!agentMediaEnabled(env))
+      return json({ error: "agent_media_disabled" }, 403)
+    const body = await readBody(request)
+    if (!body) return badRequest("invalid_json")
+    const room = typeof body.room === "string" ? body.room : ""
+    const participantId =
+      typeof body.participantId === "string" ? body.participantId : ""
+    const token = typeof body.token === "string" ? body.token : ""
+    const sessionId = typeof body.sessionId === "string" ? body.sessionId : ""
+    const trackName = typeof body.trackName === "string" ? body.trackName : ""
+    if (!room || !participantId || !token || !sessionId || !trackName)
+      return badRequest("missing_track")
+    const authResponse = await authorize(
+      env,
+      room,
+      participantId,
+      token,
+      sessionId,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      "voice-reply",
+      true
+    )
+    if (!authResponse.ok) return authResponse
+    const publisher = await diagnosePublisherSession(env, sessionId, trackName)
+    const active =
+      publisher.matchingTrackFound &&
+      publisher.matchingTrackStatus === "active" &&
+      publisher.matchingTrackHasMid
+    if (!active) return json({ active: false })
+    const activation = await roomControl(env, room, {
+      action: "agent-track-active",
+      participantId,
+      token,
+      sessionId,
+      trackName,
+    })
+    if (!activation.ok) return activation
+    return json({ active: true })
   }
 
   if (route === "tracks" || route === "renegotiate") {


### PR DESCRIPTION
## Summary

- keep Agent voice publication bookkeeping private until the first PCM write
- announce the track through an authenticated, idempotent Agent route once media is ready
- preserve the publication mid for server-side revocation and add regression coverage

## Evidence

- Cloudflare production diagnostics showed `tracks/new` returning 200 while the publication was still `inactive`, with no usable Human-side SDP.
- The Runtime now registers the mid before media starts, then exposes `trackPublished` only after the media engine accepts its first PCM packet.
- App tests: 32 files, 355 tests passed.
- Runtime targeted voice/SFU tests passed; the full Runtime suite has 215 passed and 2 pre-existing failures in `create.test.ts` and `readiness.test.ts` unrelated to this change.
- App type-check, lint, and formatting checks passed.

## Review request

Please review the exact head for the publication-registration versus first-RTP timing, current-grant authorization, idempotent announce behavior, DO restart normalization, and revocation cleanup. This PR is intentionally focused on the live voice-subscription race.
