### PR TITLE
ci: couple runtime releases to pion binaries

### DIFF
--- a/.github/workflows/agent-runtime.yml
+++ b/.github/workflows/agent-runtime.yml
@@ -18,6 +18,9 @@ jobs:
   agent-runtime:
     name: Agent Runtime
     runs-on: ubuntu-latest
+    outputs:
+      runtime_version: ${{ steps.release_metadata.outputs.runtime_version }}
+      source_sha: ${{ steps.release_metadata.outputs.source_sha }}
     steps:
       - uses: actions/checkout@v4
 
@@ -26,6 +29,26 @@ jobs:
           node-version: 22
           cache: npm
           cache-dependency-path: agent-runtime/package-lock.json
+
+      - name: Resolve release metadata
+        id: release_metadata
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          package_version="$(node -p "require('./agent-runtime/package.json').version")"
+          if [[ "$GITHUB_REF" == refs/tags/agent-runtime-v* ]]; then
+            tag_version="${TAG_NAME#agent-runtime-v}"
+            if [ "$tag_version" != "$package_version" ]; then
+              echo "Tag $TAG_NAME does not match package.json version $package_version" >&2
+              exit 1
+            fi
+            echo "runtime_version=$package_version" >> "$GITHUB_OUTPUT"
+            echo "source_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          else
+            echo "runtime_version=$package_version" >> "$GITHUB_OUTPUT"
+            echo "source_sha=$GITHUB_SHA" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Install dependencies
         run: npm ci
@@ -55,10 +78,21 @@ jobs:
         run: npm run pack:check
         working-directory: agent-runtime
 
+  pion-release:
+    name: Build and verify matching Pion release
+    if: startsWith(github.ref, 'refs/tags/agent-runtime-v')
+    needs: agent-runtime
+    uses: ./.github/workflows/pion-binaries.yml
+    with:
+      version: ${{ needs.agent-runtime.outputs.runtime_version }}
+      source_sha: ${{ needs.agent-runtime.outputs.source_sha }}
+    permissions:
+      contents: write
+
   publish:
     name: Publish Agent Runtime
     if: startsWith(github.ref, 'refs/tags/agent-runtime-v')
-    needs: agent-runtime
+    needs: [agent-runtime, pion-release]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/pion-binaries.yml
+++ b/.github/workflows/pion-binaries.yml
@@ -1,21 +1,84 @@
 name: Pion Binaries
 
-# Builds and publishes the version-matched Pion media-engine binaries used
-# by @i365dev/free4chat-agent's lazy provisioning (#105). Push a tag
-# `pion-v<runtime version>` (e.g. pion-v0.2.0) to build and attach:
-#   pion-<version>-<os>-<arch>  (raw executable, one per supported platform)
-#   SHA256SUMS                  (sha256sum-format manifest)
-
+# Version-matched Pion media engine release. Runtime releases call this
+# workflow with the exact tagged source SHA; the tag trigger remains a repair
+# path for an already tagged version.
 on:
   push:
     tags:
       - "pion-v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Runtime/Pion version
+        required: true
+        type: string
+      source_sha:
+        description: Exact source commit to build
+        required: true
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: Runtime/Pion version
+        required: true
+        type: string
+      source_sha:
+        description: Exact source commit to build
+        required: true
+        type: string
 
 permissions:
   contents: write
 
+env:
+  REQUESTED_VERSION: ${{ inputs.version || '' }}
+  REQUESTED_SOURCE_SHA: ${{ inputs.source_sha || '' }}
+
 jobs:
+  metadata:
+    name: Validate release metadata
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.metadata.outputs.version }}
+      source_sha: ${{ steps.metadata.outputs.source_sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Validate version and source
+        id: metadata
+        env:
+          TAG_NAME: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          version="$REQUESTED_VERSION"
+          if [ -z "$version" ]; then version="${TAG_NAME#pion-v}"; fi
+          source_sha="$REQUESTED_SOURCE_SHA"
+          if [ -z "$source_sha" ]; then source_sha="$GITHUB_SHA"; fi
+          package_version="$(node -p "require('./agent-runtime/package.json').version")"
+          if [ "$version" != "$package_version" ]; then
+            echo "Pion version $version does not match agent-runtime/package.json $package_version" >&2
+            exit 1
+          fi
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [ "$checked_out_sha" != "$source_sha" ]; then
+            echo "Checked out $checked_out_sha, expected source SHA $source_sha" >&2
+            exit 1
+          fi
+          case "$version" in
+            *[!0-9A-Za-z.+-]*|"") echo "Invalid release version: $version" >&2; exit 1 ;;
+          esac
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$source_sha" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: metadata
     strategy:
       fail-fast: false
       matrix:
@@ -27,25 +90,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-
+        with:
+          ref: ${{ needs.metadata.outputs.source_sha }}
+          fetch-depth: 1
       - uses: actions/setup-go@v5
         with:
           go-version: stable
-
       - name: Build
         working-directory: experiments/pion-cloudflare
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
           CGO_ENABLED: "0"
-        # GOARCH uses Go's amd64 naming; the asset filename uses Node's x64
-        # so the runtime resolver (process.arch) matches exactly.
+          VERSION: ${{ needs.metadata.outputs.version }}
         run: |
+          set -euo pipefail
           mkdir -p ../../dist
-          VERSION="${GITHUB_REF_NAME#pion-v}"
           go build -trimpath -ldflags "-s -w" \
             -o "../../dist/pion-${VERSION}-${{ matrix.goos }}-${{ matrix.nodearch }}" .
-
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -54,21 +116,84 @@ jobs:
           if-no-files-found: error
 
   release:
-    needs: build
+    needs: [metadata, build]
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.metadata.outputs.source_sha }}
+          fetch-depth: 1
+      - name: Check existing tag does not point elsewhere
+        env:
+          VERSION: ${{ needs.metadata.outputs.version }}
+          SOURCE_SHA: ${{ needs.metadata.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          tag="pion-v${VERSION}"
+          direct_sha="$(git ls-remote --refs origin "refs/tags/${tag}" | awk 'NR==1 {print $1}')"
+          peeled_sha="$(git ls-remote origin "refs/tags/${tag}^{}" | awk 'NR==1 {print $1}')"
+          if [ -n "$direct_sha" ]; then
+            existing_sha="${peeled_sha:-$direct_sha}"
+            if [ "$existing_sha" != "$SOURCE_SHA" ]; then
+              echo "$tag already points to $existing_sha, expected $SOURCE_SHA" >&2
+              exit 1
+            fi
+          fi
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
           path: release-assets
-
-      - name: Generate SHA256SUMS
+      - name: Verify all assets and generate SHA256SUMS
         working-directory: release-assets
-        run: sha256sum pion-* > SHA256SUMS
-
+        env:
+          VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          for asset in "pion-${VERSION}-darwin-arm64" "pion-${VERSION}-darwin-x64" "pion-${VERSION}-linux-arm64" "pion-${VERSION}-linux-x64"; do
+            test -s "$asset"
+          done
+          sha256sum pion-* > SHA256SUMS
+          test "$(wc -l < SHA256SUMS)" -eq 4
       - name: Attach to release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: pion-v${{ needs.metadata.outputs.version }}
+          target_commitish: ${{ needs.metadata.outputs.source_sha }}
+          fail_on_unmatched_files: true
           files: |
             release-assets/pion-*
             release-assets/SHA256SUMS
+
+  smoke:
+    needs: [metadata, release]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: macos-14, goos: darwin, goarch: arm64 }
+          - { os: macos-15-intel, goos: darwin, goarch: x64 }
+          - { os: ubuntu-22.04, goos: linux, goarch: x64 }
+          - { os: ubuntu-22.04-arm, goos: linux, goarch: arm64 }
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.metadata.outputs.source_sha }}
+          fetch-depth: 1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: agent-runtime/package-lock.json
+      - name: Install Runtime dependencies
+        run: npm ci
+        working-directory: agent-runtime
+      - name: Build Runtime
+        run: npm run build
+        working-directory: agent-runtime
+      - name: Smoke-test public release download and cache reuse
+        env:
+          PION_SMOKE_VERSION: ${{ needs.metadata.outputs.version }}
+          PION_SMOKE_OS: ${{ matrix.goos }}
+          PION_SMOKE_ARCH: ${{ matrix.goarch }}
+        run: node agent-runtime/scripts/smoke-pion-release.mjs

--- a/agent-runtime/scripts/smoke-pion-release.mjs
+++ b/agent-runtime/scripts/smoke-pion-release.mjs
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict"
+import { mkdtemp, rm, stat } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { spawn } from "node:child_process"
+
+import { ensurePionBinary } from "../dist/media/pionProvision.js"
+
+const version = process.env.PION_SMOKE_VERSION
+const platform = process.env.PION_SMOKE_OS
+const arch = process.env.PION_SMOKE_ARCH
+if (!version || !platform || !arch)
+  throw new Error(
+    "PION_SMOKE_VERSION, PION_SMOKE_OS and PION_SMOKE_ARCH are required"
+  )
+
+const cacheRoot = await mkdtemp(join(tmpdir(), "free4chat-pion-smoke-"))
+try {
+  const resolved = await ensurePionBinary({
+    version,
+    platform,
+    arch,
+    cacheRoot,
+  })
+  assert.equal(resolved.source, "download")
+  assert.equal(resolved.version, version)
+  assert.match(
+    resolved.binPath,
+    new RegExp(`pion-${version}-${platform}-${arch}$`)
+  )
+  assert.equal((await stat(resolved.binPath)).isFile(), true)
+
+  await pingChild(resolved.binPath)
+
+  const rejectedFetch = async () => {
+    throw new Error("unexpected redownload")
+  }
+  const cached = await ensurePionBinary({
+    version,
+    platform,
+    arch,
+    cacheRoot,
+    fetchImpl: rejectedFetch,
+  })
+  assert.equal(cached.source, "cache")
+  assert.equal(cached.binPath, resolved.binPath)
+  console.log(
+    `Pion ${version} ${platform}-${arch}: download, checksum, ping and cache reuse passed`
+  )
+} finally {
+  await rm(cacheRoot, { recursive: true, force: true })
+}
+
+function pingChild(binPath) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(binPath, [], { stdio: ["pipe", "pipe", "ignore"] })
+    let buffer = ""
+    let settled = false
+    const timeout = setTimeout(
+      () => finish(new Error("Pion ping timed out")),
+      5000
+    )
+    const finish = (error) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+      child.kill()
+      if (error) reject(error)
+      else resolve()
+    }
+    child.once("error", finish)
+    child.once("exit", (code) => {
+      if (!settled)
+        finish(new Error(`Pion exited before ping response (${code})`))
+    })
+    child.stdout.on("data", (chunk) => {
+      buffer += chunk.toString()
+      const newline = buffer.indexOf("\n")
+      if (newline < 0) return
+      try {
+        const response = JSON.parse(buffer.slice(0, newline))
+        assert.equal(response.id, 1)
+        assert.equal(response.ok, true)
+        child.stdin.write('{"id":2,"op":"close"}\n')
+        finish()
+      } catch (error) {
+        finish(error)
+      }
+    })
+    child.stdin.write('{"id":1,"op":"ping"}\n')
+  })
+}


### PR DESCRIPTION
## Summary\n\n- make Pion Binaries reusable from Agent Runtime releases with exact source SHA and version validation\n- gate npm publish on four-platform Pion release plus public download/cache smoke tests\n- preserve exact-version provisioning, checksum verification, override precedence, and no fallback\n\n## Root cause\n\nRuntime 0.4.0 requested pion-v0.4.0/pion-0.4.0-darwin-arm64, but that release asset was absent. This PR prevents future Runtime/Pion version drift.\n\n## Verification\n\n- Agent Runtime format, lint, type-check, build, full test suite: 216/216, package check\n- commit author/committer: codex <267193182+codex@users.noreply.github.com>\n- no Worker/DO, TTS, PCM, SDP, or RTP behavior changes\n\nDo not merge until GitHub CI and ChatGPT exact-head review approve.