### PR TITLE
fix(agent-runtime): Pion SFU server-offer bootstrap for the media bridge

### DIFF
--- a/agent-runtime/src/media/sfuMediaBridge.ts
+++ b/agent-runtime/src/media/sfuMediaBridge.ts
@@ -168,9 +168,15 @@ export class SfuMediaBridge {
         this.mySessionId = await this.restClient.createAgentSession()
       }
       if (!description) {
+        // Pion-engine SFU bootstrap: session creation carries no answer and
+        // the server initiates the SDP exchange through
+        // datachannels/establish. The gathered local offer must be omitted
+        // there — the server answers the DataChannel request with its own
+        // offer, and forwarding our already-set offer makes it reject with
+        // 400 decoding_error.
         const transport = await this.restClient.establishDataChannelTransport(
           this.mySessionId,
-          offer,
+          undefined,
           "agent-transport"
         )
         description = transport.sessionDescription

--- a/agent-runtime/src/media/sfuRestClient.ts
+++ b/agent-runtime/src/media/sfuRestClient.ts
@@ -124,10 +124,16 @@ export class SfuRestClient implements SfuRestClientLike {
     const raw = await response.text()
     const data = raw ? (JSON.parse(raw) as Record<string, unknown>) : {}
     if (!response.ok) {
+      // Bounded diagnostics only: Cloudflare's stable machine code (or the
+      // HTTP status) — never the response body, SDP or errorDescription.
+      const errorCode =
+        typeof data.errorCode === "string" ? data.errorCode : undefined
       const error =
         typeof data.error === "string"
           ? data.error
-          : `SFU request failed (${response.status})`
+          : errorCode
+            ? `sfu_${path.replaceAll("/", "_")}_${errorCode}`
+            : `SFU request failed (${response.status})`
       throw new Error(error)
     }
     return data

--- a/agent-runtime/test/media.test.ts
+++ b/agent-runtime/test/media.test.ts
@@ -49,6 +49,20 @@ class FakeRestClient implements SfuRestClientLike {
     if (this.createAgentSessionError) throw this.createAgentSessionError
     return "agent-session-1"
   }
+  /** Optional native initial-offer contract. Absent by default so existing
+   * tests keep the createAgentSession() + establish fallback path. */
+  createAgentSessionWithOffer?: (
+    offer: SessionDescriptionLike
+  ) => Promise<{
+    sessionId: string
+    sessionDescription?: SessionDescriptionLike
+  }>
+  /** What establishDataChannelTransport returns; set to a server offer to
+   * exercise the server-offer answer/renegotiate bootstrap. */
+  establishSessionDescription: SessionDescriptionLike = {
+    type: "answer",
+    sdp: "fake-transport-answer",
+  }
   async establishDataChannelTransport(
     mySessionId: string,
     offer: SessionDescriptionLike | undefined,
@@ -60,9 +74,7 @@ class FakeRestClient implements SfuRestClientLike {
       purpose,
     })
     if (this.establishTransportError) throw this.establishTransportError
-    return {
-      sessionDescription: { type: "answer", sdp: "fake-transport-answer" },
-    }
+    return { sessionDescription: this.establishSessionDescription }
   }
   async roomMedia(): Promise<RoomMediaParticipant[]> {
     if (this.roomMediaError) throw this.roomMediaError
@@ -122,6 +134,8 @@ class FakePeerConnection implements PeerConnectionLike {
   lastRtpCallback: RtpCallback | undefined
   localPublishMidResult: string | undefined
   activatePublishCalls = 0
+  /** Call order for the server-offer bootstrap assertions. */
+  calls: string[] = []
   private trackHandlers: Array<(track: MediaTrackLike) => void> = []
   onTrack = {
     subscribe: (callback: (track: MediaTrackLike) => void) => {
@@ -138,12 +152,16 @@ class FakePeerConnection implements PeerConnectionLike {
   writePcmChunk = async () => undefined
 
   async createOffer(): Promise<SessionDescriptionLike> {
+    this.calls.push("createOffer")
     return { type: "offer", sdp: "fake-initial-offer" }
   }
 
   async setRemoteDescription(
     description: SessionDescriptionLike
   ): Promise<void> {
+    this.calls.push(
+      `setRemoteDescription:${description.type}:${description.sdp ?? ""}`
+    )
     // The initial server-offer DataChannel transport does not add a media
     // track. Only a later /tracks subscription offer should fire onTrack.
     if (description.sdp !== "fake-sdp") return
@@ -159,11 +177,13 @@ class FakePeerConnection implements PeerConnectionLike {
     for (const handler of this.trackHandlers) handler(track)
   }
   async createAnswer(): Promise<SessionDescriptionLike> {
+    this.calls.push("createAnswer")
     return { type: "answer", sdp: "fake-answer" }
   }
   async setLocalDescription(
     description: SessionDescriptionLike
   ): Promise<void> {
+    this.calls.push(`setLocalDescription:${description.sdp}`)
     this.localDescriptions.push(description)
   }
   close(): void {
@@ -808,4 +828,86 @@ test("start() is a no-op while already running (does not create a second session
   await bridge.start()
   assert.equal(restClient.createAgentSessionCalls, 1)
   bridge.stop()
+})
+
+test("server-offer bootstrap: a session without a description establishes the transport with the offer omitted, answers the server offer, then renegotiates, in order", async () => {
+  const restClient = new FakeRestClient()
+  restClient.createAgentSessionWithOffer = async () => ({
+    sessionId: "agent-session-1",
+  })
+  restClient.establishSessionDescription = {
+    type: "offer",
+    sdp: "fake-server-offer",
+  }
+  const pc = new FakePeerConnection()
+  const { bridge } = makeBridge(restClient, pc)
+
+  await bridge.start()
+
+  assert.deepEqual(restClient.establishTransportCalls, [
+    { sessionId: "agent-session-1", purpose: "agent-transport" },
+  ])
+  assert.equal(restClient.renegotiateCalls, 1)
+  assert.deepEqual(restClient.renegotiatePurposes, ["agent-transport"])
+  assert.deepEqual(pc.localDescriptions, [
+    { type: "offer", sdp: "fake-initial-offer" },
+    { type: "answer", sdp: "fake-answer" },
+  ])
+  assert.deepEqual(pc.calls, [
+    "createOffer",
+    "setLocalDescription:fake-initial-offer",
+    "setRemoteDescription:offer:fake-server-offer",
+    "createAnswer",
+    "setLocalDescription:fake-answer",
+  ])
+  bridge.stop()
+})
+
+test("native-answer bootstrap is unchanged: a returned answer is applied directly with no establish or renegotiate", async () => {
+  const restClient = new FakeRestClient()
+  restClient.createAgentSessionWithOffer = async () => ({
+    sessionId: "agent-session-1",
+    sessionDescription: { type: "answer", sdp: "fake-transport-answer" },
+  })
+  const pc = new FakePeerConnection()
+  const { bridge } = makeBridge(restClient, pc)
+
+  await bridge.start()
+
+  assert.equal(restClient.establishTransportCalls.length, 0)
+  assert.equal(restClient.renegotiateCalls, 0)
+  assert.deepEqual(pc.localDescriptions, [
+    { type: "offer", sdp: "fake-initial-offer" },
+  ])
+  bridge.stop()
+})
+
+test("server-offer bootstrap failure surfaces only the bounded error classification and is retryable", async () => {
+  const restClient = new FakeRestClient()
+  restClient.createAgentSessionWithOffer = async () => ({
+    sessionId: "agent-session-1",
+  })
+  restClient.establishTransportError = new Error(
+    "sfu_datachannels_establish_decoding_error"
+  )
+  const pc = new FakePeerConnection()
+  const { bridge } = makeBridge(restClient, pc)
+
+  await assert.rejects(
+    () => bridge.start(),
+    /sfu_datachannels_establish_decoding_error/
+  )
+  assert.equal(pc.closed, true)
+
+  restClient.establishTransportError = undefined
+  restClient.establishSessionDescription = {
+    type: "offer",
+    sdp: "fake-server-offer",
+  }
+  const pc2 = new FakePeerConnection()
+  const { bridge: bridge2 } = makeBridge(restClient, pc2)
+  await bridge2.start()
+  assert.equal(restClient.establishTransportCalls.length, 2)
+  assert.equal(bridge2.voicePublishCapable, false)
+  bridge2.stop()
 })

--- a/agent-runtime/test/media.test.ts
+++ b/agent-runtime/test/media.test.ts
@@ -51,9 +51,7 @@ class FakeRestClient implements SfuRestClientLike {
   }
   /** Optional native initial-offer contract. Absent by default so existing
    * tests keep the createAgentSession() + establish fallback path. */
-  createAgentSessionWithOffer?: (
-    offer: SessionDescriptionLike
-  ) => Promise<{
+  createAgentSessionWithOffer?: (offer: SessionDescriptionLike) => Promise<{
     sessionId: string
     sessionDescription?: SessionDescriptionLike
   }>
@@ -397,7 +395,6 @@ test("subscribes to a newly discovered Human audio track and reports it started"
   assert.deepEqual(restClient.establishTransportCalls, [
     {
       sessionId: "agent-session-1",
-      offer: { type: "offer", sdp: "fake-initial-offer" },
       purpose: "agent-transport",
     },
   ])

--- a/agent-runtime/test/sfuRestClient.test.ts
+++ b/agent-runtime/test/sfuRestClient.test.ts
@@ -216,3 +216,27 @@ test("subscribeTrack keeps the remote-track payload shape and carries the mid ba
     globalThis.fetch = originalFetch
   }
 })
+
+test("reports an SFU route and error code without echoing the response body", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () =>
+    Response.json(
+      {
+        errorCode: "decoding_error",
+        errorDescription: "untrusted upstream detail",
+      },
+      { status: 400 }
+    )
+
+  try {
+    const client = new SfuRestClient("https://example.test", handle())
+    await assert.rejects(
+      client.establishDataChannelTransport("s", undefined, "agent-transport"),
+      (error: unknown) =>
+        error instanceof Error &&
+        error.message === "sfu_datachannels_establish_decoding_error"
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})


### PR DESCRIPTION
## Summary

Fixes the production Pion SFU bootstrap: with a Pion-engine SFU, the local
offer and ICE succeed, but forwarding the gathered local offer to
`datachannels/establish` makes the server reject with **400 decoding_error**.

When `createAgentSession` returns a sessionId **without** a
sessionDescription (Pion contract), `SfuMediaBridge.start()` now:

1. calls `establishDataChannelTransport(sessionId, undefined)` — the
   `sessionDescription` field is omitted from the request;
2. accepts the server offer returned by the establish call;
3. `setRemoteDescription` → `createAnswer` → `setLocalDescription`;
4. commits the answer via `renegotiate`.

The **native answer path is unchanged**: when `agent-session` returns
Cloudflare's answer directly, it is still applied via `setRemoteDescription`
with no establish/renegotiate call. The dataChannel request keeps exactly
`{ location: "remote", dataChannelName: "server-events" }`.

## Scope

Only `agent-runtime/` (bridge, REST client, tests). No Worker/DO, TTS, RTP,
or browser playback changes. No retries added. The `AgentSessionBootstrapLike`
type now allows an omitted `sessionDescription` (validation stays strict when
present).

## Tests (all runtime checks run)

- ordering: session-without-description → establish (offer omitted) → apply
  server offer → answer → renegotiate
- unchanged native-answer path: no establish, no renegotiate, answer applied
  directly
- omitted field: establish receives `undefined` offer
- bounded safe diagnostics: `failure` exposes only `sfu_datachannels_establish_decoding_error`
  or `failed_at_establishing_transport`, never SDP/response text

`npm run type-check`, `npm run build`, `npm run lint`, `npm run format:check`
all pass. Test suite: 87 pass / 3 fail — the 3 failures are pre-existing on
this branch (verified against a pristine `HEAD` archive: stale
`createWeriftPeerConnection` reference, agent.md doctor text, and the
session-creation close assertion from the earlier wip commits); none touch
the files in this PR.

Note: this branch also carries the prior investigation commits
(`0142b52` wait-for-connection, `6fa367c` wip probe preserve) that predate
this change.