### PR TITLE
[codex] fix(voice): align capability truth and diagnostics

### DIFF
--- a/agent-runtime/README.md
+++ b/agent-runtime/README.md
@@ -174,6 +174,10 @@ free4chat-agent speech speak-tts --text "你好，世界。" --out /tmp/probe.pc
 # add --wav for a RIFF header wrapper
 ```
 
-Room-audible Agent voice over the Cloudflare SFU (outbound publish) is not
-wired yet — see #83. Synthesized audio currently reaches only local sinks;
-no audio, transcript, or credential material is persisted by the Runtime.
+When a human enables the room's voiceReply grant for this Agent, the resident
+Runtime can publish Harness replies as room-audible voice over the shared
+Cloudflare SFU. It uses the locally configured Doubao Speech Synthesis 2.0
+provider (V3 X-Api-Key, PCM s16le / 24 kHz / mono); the MCP tools themselves
+remain text-only, and no audio, transcript, or credential material is
+persisted by the Runtime. Voice output is unavailable until both the current
+voiceReply grant and local TTS configuration are ready.

--- a/agent-runtime/src/core/runtime.ts
+++ b/agent-runtime/src/core/runtime.ts
@@ -473,6 +473,15 @@ export class ResidentRoomRuntime {
                     : this.options.speech!.store!,
                 environment: this.options.speech?.environment ?? process.env,
               })
+              this.log("voice_reply_tts_provider", {
+                tts_provider_selected:
+                  state.providerId === "doubao"
+                    ? "doubao"
+                    : state.providerId
+                      ? "other"
+                      : "none",
+                tts_provider_resolved: state.tts ? 1 : 0,
+              })
               return state.tts ?? null
             },
           },

--- a/agent-runtime/src/media/meetingNotesController.ts
+++ b/agent-runtime/src/media/meetingNotesController.ts
@@ -182,13 +182,16 @@ export class MeetingNotesController {
     let epoch: number | null = null
     let vrAuthorized = false
     let vrEpoch: number | null = null
+    let vrTargetsSelf = false
     try {
       const info = await this.options.client.roomInfo(this.options.roomId)
       if (this.options.voiceReply) {
+        vrTargetsSelf =
+          info.voiceReply.agentParticipantId === this.options.participantId
         vrAuthorized =
           info.voiceReplyMediaAvailable === true &&
           info.voiceReply.active === true &&
-          info.voiceReply.agentParticipantId === this.options.participantId
+          vrTargetsSelf
         vrEpoch = info.voiceReply.startedAt ?? null
         const epochChanged =
           this.observedVoiceEpochInitialized &&
@@ -196,7 +199,7 @@ export class MeetingNotesController {
         this.log("voice_reply_state", {
           voice_reply_media_available: info.voiceReplyMediaAvailable ? 1 : 0,
           voice_reply_active: info.voiceReply.active ? 1 : 0,
-          voice_reply_targets_self: vrAuthorized ? 1 : 0,
+          voice_reply_targets_self: vrTargetsSelf ? 1 : 0,
           voice_reply_grant_epoch_present: vrEpoch === null ? 0 : 1,
           voice_reply_grant_epoch_changed: epochChanged ? 1 : 0,
         })

--- a/agent-runtime/src/media/meetingNotesController.ts
+++ b/agent-runtime/src/media/meetingNotesController.ts
@@ -34,6 +34,16 @@ export function resolveDefaultCreatePeerConnection(): PeerConnectionFactory {
 }
 
 const DEFAULT_POLL_INTERVAL_MS = 5000
+function safeDiagnosticCode(error: unknown): string {
+  const message = error instanceof Error ? error.message : "unknown"
+  const normalized = message.toLowerCase()
+  if (normalized.includes("timeout")) return "timeout"
+  if (normalized.includes("unsupported_chunk")) return "unsupported_chunk"
+  if (normalized.includes("not authorized")) return "not_authorized"
+  if (normalized.includes("decoding")) return "decoding_error"
+  if (normalized.includes("network")) return "network_error"
+  return "operation_failed"
+}
 
 type BridgeState = "idle" | "starting" | "running"
 
@@ -105,6 +115,8 @@ export class MeetingNotesController {
   private stopped = true
   // #83 voiceReply state (same shared bridge; never a second session).
   private voiceEpoch: number | null = null
+  private observedVoiceEpoch: number | null = null
+  private observedVoiceEpochInitialized = false
   private voiceSpeaker: VoiceSpeaker | null = null
   private voiceStarting = false
   // Outbound track name for the shared bridge's publish config; null when
@@ -178,6 +190,18 @@ export class MeetingNotesController {
           info.voiceReply.active === true &&
           info.voiceReply.agentParticipantId === this.options.participantId
         vrEpoch = info.voiceReply.startedAt ?? null
+        const epochChanged =
+          this.observedVoiceEpochInitialized &&
+          this.observedVoiceEpoch !== vrEpoch
+        this.log("voice_reply_state", {
+          voice_reply_media_available: info.voiceReplyMediaAvailable ? 1 : 0,
+          voice_reply_active: info.voiceReply.active ? 1 : 0,
+          voice_reply_targets_self: vrAuthorized ? 1 : 0,
+          voice_reply_grant_epoch_present: vrEpoch === null ? 0 : 1,
+          voice_reply_grant_epoch_changed: epochChanged ? 1 : 0,
+        })
+        this.observedVoiceEpoch = vrEpoch
+        this.observedVoiceEpochInitialized = true
       }
       // The master switch is checked on every poll, not just at grant
       // start: if it flips off while a session is already active, this
@@ -192,12 +216,16 @@ export class MeetingNotesController {
         info.meetingNotes.active &&
         info.meetingNotes.agentParticipantId === this.options.participantId
       epoch = info.meetingNotes.startedAt ?? null
-    } catch {
+    } catch (error) {
       // A transient room_info failure fails closed for BOTH grants: do not
       // keep an already-running bridge alive on stale authorization, and do
       // not start a new one on a guess. The next poll tries again.
       authorized = false
       vrAuthorized = false
+      if (this.options.voiceReply)
+        this.log("voice_reply_room_info_failed", {
+          code: safeDiagnosticCode(error),
+        })
     }
     if (this.stopped) return
 
@@ -262,7 +290,14 @@ export class MeetingNotesController {
     this.voiceStarting = true
     try {
       const provider = await options.createTtsProvider()
-      if (!provider || this.bridgeState !== "running") return
+      if (!provider) {
+        this.log("voice_reply_tts_unresolved", {
+          voice_reply_tts_resolved: 0,
+        })
+        return
+      }
+      this.log("voice_reply_tts_resolved", { voice_reply_tts_resolved: 1 })
+      if (this.bridgeState !== "running") return
       await bridge.activateVoicePublish()
       if (this.bridgeState !== "running") return
       this.voiceSpeaker = new VoiceSpeaker({
@@ -307,7 +342,7 @@ export class MeetingNotesController {
       this.log("voice_reply_started")
     } catch (error) {
       this.log("voice_reply_start_failed", {
-        error: error instanceof Error ? error.message : "unknown",
+        code: safeDiagnosticCode(error),
       })
     } finally {
       this.voiceStarting = false
@@ -363,7 +398,7 @@ export class MeetingNotesController {
         this.bridgeState = "idle"
       }
       this.log("meeting_notes_media_start_failed", {
-        error: error instanceof Error ? error.message : "unknown error",
+        code: safeDiagnosticCode(error),
       })
       return
     }

--- a/agent-runtime/test/docsConsistency.test.ts
+++ b/agent-runtime/test/docsConsistency.test.ts
@@ -73,6 +73,31 @@ test("the source package.json version never appears as a bootstrap pin in agent.
   )
 })
 
+test("speech docs agree that granted Runtime voice is SFU-backed", () => {
+  for (const doc of [
+    "app/public/agent.md",
+    "app/public/speech.md",
+    "agent-runtime/README.md",
+  ]) {
+    const content = read(doc)
+    assert.match(
+      content,
+      /voiceReply|voice reply/i,
+      `${doc} must describe voice reply`
+    )
+    assert.match(
+      content,
+      /Cloudflare\s+SFU/,
+      `${doc} must describe the SFU path`
+    )
+    assert.doesNotMatch(
+      content,
+      /voice over (the )?(Cloudflare )?SFU (is )?not wired yet/i,
+      `${doc} must not claim that room voice is unavailable`
+    )
+  }
+})
+
 test("DEVELOPMENT.md matches the actual tag-triggered publishing model", () => {
   const development = read("DEVELOPMENT.md")
   assert.ok(

--- a/agent-runtime/test/meetingNotesVoiceReply.test.ts
+++ b/agent-runtime/test/meetingNotesVoiceReply.test.ts
@@ -100,7 +100,9 @@ function providerFor(chunks: Array<{ text: string }>) {
 
 function controller(
   bridge: FakeBridge,
-  tts: () => Promise<StreamingTtsProvider | null>
+  tts: () => Promise<StreamingTtsProvider | null>,
+  log: (message: string, data?: Record<string, string | number>) => void = () =>
+    undefined
 ) {
   return new MeetingNotesController({
     client: fakeClient(makeRoomInfo({ mnActive: false, vrActive: false })),
@@ -112,10 +114,44 @@ function controller(
     createBridge: () => bridge as never,
     createPeerConnection: (() => ({ close() {} })) as never,
     restClient: {} as never,
-    log: () => undefined,
+    log,
     voiceReply: { createTtsProvider: tts },
   })
 }
+
+test("voice diagnostics expose grant state and unresolved TTS without secrets", async () => {
+  const bridge = new FakeBridge()
+  const logs: Array<{
+    message: string
+    data?: Record<string, string | number>
+  }> = []
+  const c = controller(
+    bridge,
+    () => Promise.resolve(null),
+    (message, data) => logs.push({ message, data })
+  )
+  await drive(
+    c,
+    makeRoomInfo({ mnActive: true, vrActive: true, vrStartedAt: 100 }),
+    () => Promise.resolve(null)
+  )
+
+  const state = logs.find((entry) => entry.message === "voice_reply_state")
+  assert.deepEqual(state?.data, {
+    voice_reply_media_available: 1,
+    voice_reply_active: 1,
+    voice_reply_targets_self: 1,
+    voice_reply_grant_epoch_present: 1,
+    voice_reply_grant_epoch_changed: 0,
+  })
+  assert.ok(
+    logs.some((entry) => entry.message === "voice_reply_tts_unresolved")
+  )
+  assert.ok(
+    logs.every((entry) => !JSON.stringify(entry).includes("agent-1")),
+    "voice diagnostics must not include participant identifiers"
+  )
+})
 
 async function waitFor(predicate: () => boolean) {
   for (let i = 0; i < 200; i++) {

--- a/agent-runtime/test/meetingNotesVoiceReply.test.ts
+++ b/agent-runtime/test/meetingNotesVoiceReply.test.ts
@@ -48,6 +48,8 @@ function makeRoomInfo(opts: {
   mnActive: boolean
   vrActive: boolean
   vrStartedAt?: number
+  vrMediaAvailable?: boolean
+  vrTarget?: string
 }) {
   return {
     exists: true,
@@ -58,9 +60,12 @@ function makeRoomInfo(opts: {
     voiceReplyMediaAvailable: true,
     voiceReply: {
       active: opts.vrActive,
-      agentParticipantId: opts.vrActive ? "agent-1" : undefined,
+      agentParticipantId: opts.vrActive
+        ? (opts.vrTarget ?? "agent-1")
+        : undefined,
       startedAt: opts.vrStartedAt,
     },
+    voiceReplyMediaAvailable: opts.vrMediaAvailable ?? true,
   }
 }
 
@@ -150,6 +155,63 @@ test("voice diagnostics expose grant state and unresolved TTS without secrets", 
   assert.ok(
     logs.every((entry) => !JSON.stringify(entry).includes("agent-1")),
     "voice diagnostics must not include participant identifiers"
+  )
+})
+
+test("voice diagnostics keep media availability separate from target matching", async () => {
+  const bridge = new FakeBridge()
+  const logs: Array<{
+    message: string
+    data?: Record<string, string | number>
+  }> = []
+  const c = controller(
+    bridge,
+    () => Promise.resolve(null),
+    (message, data) => logs.push({ message, data })
+  )
+
+  await drive(
+    c,
+    makeRoomInfo({
+      mnActive: false,
+      vrActive: true,
+      vrMediaAvailable: false,
+      vrTarget: "agent-1",
+      vrStartedAt: 100,
+    }),
+    () => Promise.resolve(null)
+  )
+  await drive(
+    c,
+    makeRoomInfo({
+      mnActive: false,
+      vrActive: true,
+      vrMediaAvailable: true,
+      vrTarget: "other-agent",
+      vrStartedAt: 100,
+    }),
+    () => Promise.resolve(null)
+  )
+
+  const states = logs.filter((entry) => entry.message === "voice_reply_state")
+  assert.deepEqual(
+    states.map((entry) => entry.data),
+    [
+      {
+        voice_reply_media_available: 0,
+        voice_reply_active: 1,
+        voice_reply_targets_self: 1,
+        voice_reply_grant_epoch_present: 1,
+        voice_reply_grant_epoch_changed: 0,
+      },
+      {
+        voice_reply_media_available: 1,
+        voice_reply_active: 1,
+        voice_reply_targets_self: 0,
+        voice_reply_grant_epoch_present: 1,
+        voice_reply_grant_epoch_changed: 0,
+      },
+    ]
   )
 })
 

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -227,11 +227,13 @@ Image events contain metadata only. When an image is relevant, call
 Attachments are private, ephemeral room data and have no public URL.
 The local Runtime supports Doubao Speech 2.0 with one local console
 credential: Streaming ASR 2.0 for authorized Meeting Notes media, and
-Speech Synthesis 2.0 (TTS) for outbound voice audio generated locally via
-the V3 X-Api-Key interface (`seed-tts-2.0`, PCM 24 kHz mono; voice
-overridable with `DOUBAO_TTS_VOICE`). Room-audible Agent voice over the
-SFU is not wired yet (#83); TTS output currently lands in a local file via
-`free4chat-agent speech speak-tts`.
+Speech Synthesis 2.0 (TTS) for outbound voice audio via the V3 X-Api-Key
+interface (`seed-tts-2.0`, PCM 24 kHz mono; voice overridable with
+`DOUBAO_TTS_VOICE`). When a human grants this Agent voiceReply permission,
+the resident Runtime publishes Harness replies through the shared Cloudflare
+SFU so they are audible in the room. Voice reply still requires that current
+room grant and local TTS configuration; the MCP tools themselves remain
+text-only.
 If the human asks for Meeting Notes or voice capabilities, fetch
 `https://www.free4.chat/speech.md` and follow it. Never ask the human to paste
 a speech-provider credential into the room, model conversation, or an

--- a/app/public/speech.md
+++ b/app/public/speech.md
@@ -36,7 +36,11 @@ TTS selections live in separate config slots
 (`speech.stt.provider` / `speech.tts.provider`; override with
 `FREE4CHAT_TTS_PROVIDER`) and never displace each other.
 
-Room-audible Agent voice over the Cloudflare SFU is not wired yet (#83):
-synthesized audio currently reaches only the local test entry point
-(`free4chat-agent speech speak-tts --text "..." --out out.pcm [--wav]`),
-which writes real provider audio to a file without ever printing the key.
+When a human enables the room's voiceReply grant for an Agent, the resident
+Runtime publishes synthesized replies over the shared Cloudflare SFU, making
+them audible to room participants. This uses the configured Doubao Speech
+Synthesis 2.0 provider and remains separate from the text-only MCP tools.
+Without both the current room grant and local TTS configuration, voice output
+is not activated. The local test entry point
+(`free4chat-agent speech speak-tts --text "..." --out out.pcm [--wav]`)
+remains available for checking provider audio without printing the key.


### PR DESCRIPTION
## Summary

The merged runtime already contains the Doubao Speech Synthesis 2.0 to Pion/SFU voice path. This focused PR fixes the capability truth exposed to Agents and makes the first failed runtime stage observable without changing media behavior.

Previously, the public Agent and speech handoff documents still said that room-audible voice was not wired. That directly encouraged a Harness to answer a voice request with “I am a text AI”. Separately, a missing voice grant or local TTS selection could silently leave the Runtime text-only, making the browser's missing remote audio track impossible to localize.

## Changes

- Updated `app/public/agent.md`, `app/public/speech.md`, and `agent-runtime/README.md` to describe the existing granted Runtime voice path accurately while preserving the text-only MCP boundary.
- Added safe Runtime diagnostics for voiceReply state/targeting/epoch, TTS resolution, media startup failures, and bounded voice lifecycle codes.
- Added regression coverage for unresolved TTS diagnostics, grant state diagnostics, participant-id redaction, and documentation consistency.

Diagnostics never include participant IDs, handles, tokens, session IDs, track IDs, mids, SDP, ICE, credentials, URLs, response bodies, raw text, or audio.

No Worker/DO authorization, signaling, TTS protocol/provider, Pion engine, or browser media behavior was changed.

## Verification

- `npm test` — 227 tests passed
- `npm run type-check` — passed
- `npm run lint` — passed
- `npm run format:check` — passed
- `git diff --check` — passed

Base: `cf-sfu` at merged PR #139 (`cc0dac781050acc39d52afc411889194b57f8290`)
Head: `ba7d8125b2370e15c752cb7799b970a6b4dca879`

Commit author and committer: codex <267193182+codex@users.noreply.github.com>

Please review the exact head. Do not merge until the exact-head review and CI are green.
