### PR TITLE
fix(media): restore Meeting Notes Pion bootstrap

### DIFF
--- a/agent-runtime/package-lock.json
+++ b/agent-runtime/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@i365dev/free4chat-agent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@i365dev/free4chat-agent",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@agentclientprotocol/sdk": "^1.4.0",

--- a/agent-runtime/package.json
+++ b/agent-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@i365dev/free4chat-agent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Zero-setup local lifecycle runtime for resident Free4Chat Agents",
   "author": "i365dev",
   "license": "MIT",

--- a/agent-runtime/src/bootstrap.ts
+++ b/agent-runtime/src/bootstrap.ts
@@ -1,5 +1,5 @@
 export const RUNTIME_PACKAGE_NAME = "@i365dev/free4chat-agent"
-export const RUNTIME_PACKAGE_VERSION = "0.4.0"
+export const RUNTIME_PACKAGE_VERSION = "0.4.1"
 
 export const BUILT_IN_AGENT_IDS = [
   "hermes",

--- a/agent-runtime/src/media/sfuMediaBridge.ts
+++ b/agent-runtime/src/media/sfuMediaBridge.ts
@@ -168,15 +168,15 @@ export class SfuMediaBridge {
         this.mySessionId = await this.restClient.createAgentSession()
       }
       if (!description) {
-        // Pion-engine SFU bootstrap: session creation carries no answer and
-        // the server initiates the SDP exchange through
-        // datachannels/establish. The gathered local offer must be omitted
-        // there — the server answers the DataChannel request with its own
-        // offer, and forwarding our already-set offer makes it reject with
-        // 400 decoding_error.
+        // Pion-engine SFU bootstrap: session creation carries no answer, so
+        // the transport is established by submitting OUR gathered local
+        // offer (client-offer establish, exactly like the Free4Chat browser)
+        // and applying the returned answer. Omitting the offer mixed
+        // client-offer and server-offer signaling and made the server reject
+        // with decoding_error.
         const transport = await this.restClient.establishDataChannelTransport(
           this.mySessionId,
-          undefined,
+          offer,
           "agent-transport"
         )
         description = transport.sessionDescription

--- a/agent-runtime/test/media.test.ts
+++ b/agent-runtime/test/media.test.ts
@@ -55,8 +55,8 @@ class FakeRestClient implements SfuRestClientLike {
     sessionId: string
     sessionDescription?: SessionDescriptionLike
   }>
-  /** What establishDataChannelTransport returns; set to a server offer to
-   * exercise the server-offer answer/renegotiate bootstrap. */
+  /** What establishDataChannelTransport returns; a returned answer is
+   * applied directly (client-offer bootstrap). */
   establishSessionDescription: SessionDescriptionLike = {
     type: "answer",
     sdp: "fake-transport-answer",
@@ -132,7 +132,7 @@ class FakePeerConnection implements PeerConnectionLike {
   lastRtpCallback: RtpCallback | undefined
   localPublishMidResult: string | undefined
   activatePublishCalls = 0
-  /** Call order for the server-offer bootstrap assertions. */
+  /** Call order for the client-offer bootstrap assertions. */
   calls: string[] = []
   private trackHandlers: Array<(track: MediaTrackLike) => void> = []
   onTrack = {
@@ -160,8 +160,8 @@ class FakePeerConnection implements PeerConnectionLike {
     this.calls.push(
       `setRemoteDescription:${description.type}:${description.sdp ?? ""}`
     )
-    // The initial server-offer DataChannel transport does not add a media
-    // track. Only a later /tracks subscription offer should fire onTrack.
+    // The initial DataChannel transport is not a subscribed media track.
+    // Only a later /tracks subscription offer should fire onTrack.
     if (description.sdp !== "fake-sdp") return
     const track: MediaTrackLike = {
       kind: "audio",
@@ -395,6 +395,7 @@ test("subscribes to a newly discovered Human audio track and reports it started"
   assert.deepEqual(restClient.establishTransportCalls, [
     {
       sessionId: "agent-session-1",
+      offer: { type: "offer", sdp: "fake-initial-offer" },
       purpose: "agent-transport",
     },
   ])
@@ -827,35 +828,31 @@ test("start() is a no-op while already running (does not create a second session
   bridge.stop()
 })
 
-test("server-offer bootstrap: a session without a description establishes the transport with the offer omitted, answers the server offer, then renegotiates, in order", async () => {
+test("client-offer bootstrap: a session without a description establishes the transport with the initial offer, then applies the returned answer, in order", async () => {
   const restClient = new FakeRestClient()
   restClient.createAgentSessionWithOffer = async () => ({
     sessionId: "agent-session-1",
   })
-  restClient.establishSessionDescription = {
-    type: "offer",
-    sdp: "fake-server-offer",
-  }
   const pc = new FakePeerConnection()
   const { bridge } = makeBridge(restClient, pc)
 
   await bridge.start()
 
   assert.deepEqual(restClient.establishTransportCalls, [
-    { sessionId: "agent-session-1", purpose: "agent-transport" },
+    {
+      sessionId: "agent-session-1",
+      offer: { type: "offer", sdp: "fake-initial-offer" },
+      purpose: "agent-transport",
+    },
   ])
-  assert.equal(restClient.renegotiateCalls, 1)
-  assert.deepEqual(restClient.renegotiatePurposes, ["agent-transport"])
+  assert.equal(restClient.renegotiateCalls, 0)
   assert.deepEqual(pc.localDescriptions, [
     { type: "offer", sdp: "fake-initial-offer" },
-    { type: "answer", sdp: "fake-answer" },
   ])
   assert.deepEqual(pc.calls, [
     "createOffer",
     "setLocalDescription:fake-initial-offer",
-    "setRemoteDescription:offer:fake-server-offer",
-    "createAnswer",
-    "setLocalDescription:fake-answer",
+    "setRemoteDescription:answer:fake-transport-answer",
   ])
   bridge.stop()
 })
@@ -879,7 +876,7 @@ test("native-answer bootstrap is unchanged: a returned answer is applied directl
   bridge.stop()
 })
 
-test("server-offer bootstrap failure surfaces only the bounded error classification and is retryable", async () => {
+test("establish bootstrap failure surfaces only the bounded error classification and is retryable", async () => {
   const restClient = new FakeRestClient()
   restClient.createAgentSessionWithOffer = async () => ({
     sessionId: "agent-session-1",
@@ -897,14 +894,15 @@ test("server-offer bootstrap failure surfaces only the bounded error classificat
   assert.equal(pc.closed, true)
 
   restClient.establishTransportError = undefined
-  restClient.establishSessionDescription = {
-    type: "offer",
-    sdp: "fake-server-offer",
-  }
   const pc2 = new FakePeerConnection()
   const { bridge: bridge2 } = makeBridge(restClient, pc2)
   await bridge2.start()
   assert.equal(restClient.establishTransportCalls.length, 2)
+  assert.deepEqual(restClient.establishTransportCalls[1], {
+    sessionId: "agent-session-1",
+    offer: { type: "offer", sdp: "fake-initial-offer" },
+    purpose: "agent-transport",
+  })
   assert.equal(bridge2.voicePublishCapable, false)
   bridge2.stop()
 })

--- a/agent-runtime/test/productization.test.ts
+++ b/agent-runtime/test/productization.test.ts
@@ -41,7 +41,7 @@ test("bootstrap command uses the official pinned package and argv boundaries", (
   assert.equal(invocation.command, "npx")
   assert.deepEqual(invocation.args, [
     "-y",
-    "@i365dev/free4chat-agent@0.4.0",
+    "@i365dev/free4chat-agent@0.4.1",
     "join",
     "--room",
     "room\nwith `quotes`",

--- a/experiments/pion-cloudflare/main_test.go
+++ b/experiments/pion-cloudflare/main_test.go
@@ -50,7 +50,8 @@ func TestHandleCmdPublishOpsRoundTripAndFailClosed(t *testing.T) {
 		t.Fatal("write-pcm before activate-publish must fail closed")
 	}
 
-	// Create() already armed the outbound track pre-offer; arming again is
+	// arm-publish arms the outbound track explicitly (Create() leaves it
+	// unarmed so the bootstrap offer is Meeting-Notes-only); re-arming is
 	// idempotent.
 	if r := handleCmd(spike, testTracer(t), cmd{Op: "arm-publish"}); !r.OK {
 		t.Fatalf("arm-publish: %+v", r)

--- a/experiments/pion-cloudflare/media.go
+++ b/experiments/pion-cloudflare/media.go
@@ -117,12 +117,11 @@ func (s *MediaSpike) Create() error {
 		return err
 	}
 	s.pc = pc
-	// #83: ONE shared agent session serves Meeting Notes ingress AND
-	// voiceReply publication, so the single outbound Opus track is armed
-	// before any offer. No RTP flows until an authorised activation.
-	if err := s.ArmPublish(); err != nil {
-		return err
-	}
+	// Meeting Notes bootstrap is receive-only: the initial offer must NOT
+	// carry an outbound voice m-line, so Create() leaves the publish track
+	// unarmed. ArmPublish() is called explicitly (arm-publish op) right
+	// before the voice offer (#83 shared session); no RTP flows until an
+	// authorised activation.
 
 	pc.OnICECandidate(func(c *webrtc.ICECandidate) {
 		if c == nil {

--- a/experiments/pion-cloudflare/pcm_test.go
+++ b/experiments/pion-cloudflare/pcm_test.go
@@ -16,8 +16,56 @@ func newPublishSpike(t *testing.T) *MediaSpike {
 	if err := spike.Create(); err != nil {
 		t.Skipf("pc unavailable: %v", err)
 	}
+	// Create() leaves the outbound track unarmed (Meeting-Notes-only
+	// bootstrap); a publish spike arms it explicitly.
+	if err := spike.ArmPublish(); err != nil {
+		t.Skipf("arm publish: %v", err)
+	}
 	t.Cleanup(spike.Close)
 	return spike
+}
+
+func TestCreateLeavesPublishUnarmedUntilExplicitArmPublish(t *testing.T) {
+	spike, err := NewMediaSpike(testTracer(t), func(map[string]any) {})
+	if err != nil {
+		t.Skipf("engine unavailable: %v", err)
+	}
+	if err := spike.Create(); err != nil {
+		t.Skipf("pc unavailable: %v", err)
+	}
+	t.Cleanup(spike.Close)
+	spike.mu.Lock()
+	unarmed := spike.outbound == nil
+	spike.mu.Unlock()
+	if !unarmed {
+		t.Fatal("Create() must not arm the outbound publish track")
+	}
+	for _, tr := range spike.pc.GetTransceivers() {
+		if tr.Sender() != nil && tr.Sender().Track() != nil {
+			t.Fatal("Create() must leave no send track before ArmPublish")
+		}
+	}
+	if err := spike.ArmPublish(); err != nil {
+		t.Fatalf("ArmPublish: %v", err)
+	}
+	spike.mu.Lock()
+	armed := spike.outbound != nil
+	spike.mu.Unlock()
+	if !armed {
+		t.Fatal("ArmPublish must arm the outbound publish track")
+	}
+	found := false
+	for _, tr := range spike.pc.GetTransceivers() {
+		if tr.Sender() != nil && tr.Sender().Track() != nil {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("ArmPublish must register a send track on a transceiver")
+	}
+	if err := spike.ArmPublish(); err != nil {
+		t.Fatalf("idempotent re-arm: %v", err)
+	}
 }
 
 func TestWritePCMRequiresActivation(t *testing.T) {


### PR DESCRIPTION
## Summary

Recovery for the Meeting Notes media path that regressed before STT/TTS. Two regressions are reverted together to restore the live-proven bootstrap:

1. **Pion engine eager arming** — `MediaSpike.Create()` eagerly called `ArmPublish()`, so the initial bootstrap offer carried an outbound voice send m-line. The live-proven Meeting Notes implementation did not arm the outbound `TrackLocal` during `Create()`; the bootstrap offer must be Meeting-Notes-only (receive-only). Explicit voice activation (`arm-publish` op) is retained unchanged and arms the track right before a voice offer.
2. **`datachannels/establish` offer omission** (#139) — `sfuMediaBridge.ts` passed `undefined` to `establishDataChannelTransport` after already doing `createOffer` + `setLocalDescription`, mixing client-offer and server-offer signaling; the server rejected with `400 decoding_error`. Cloudflare supports client-offer establish and the Free4Chat browser uses it. Restored: `establishDataChannelTransport(this.mySessionId, offer, "agent-transport")` with the exact gathered local offer, and the returned answer is applied directly.

Scope is strictly Agent Runtime + Pion: no Worker/DO, browser, TTS, Doubao, or docs changes.

## Changes

| File | Change |
| --- | --- |
| `experiments/pion-cloudflare/media.go` | Remove eager `ArmPublish()` from `Create()`; bootstrap offer stays receive-only |
| `experiments/pion-cloudflare/pcm_test.go` | Add `TestCreateLeavesPublishUnarmedUntilExplicitArmPublish` (Create unarmed, explicit `ArmPublish` arms, idempotent re-arm); publish spike helper arms explicitly |
| `experiments/pion-cloudflare/main_test.go` | Update stale arming comment |
| `agent-runtime/src/media/sfuMediaBridge.ts` | Restore exact local offer in `establishDataChannelTransport` |
| `agent-runtime/test/media.test.ts` | Bootstrap tests: exact initial offer through establish, sequence `createOffer -> setLocalDescription -> establish(initial offer) -> setRemoteDescription(answer)`, no renegotiate; failure test updated |
| `agent-runtime/package.json` | `0.4.0` -> `0.4.1` (pion-v0.4.0 is immutable) |
| `agent-runtime/package-lock.json` | `0.4.0` -> `0.4.1` |
| `agent-runtime/src/bootstrap.ts` | Sync pinned bootstrap version `0.4.1` (required by productization test, precedent f2f5356) |
| `agent-runtime/test/productization.test.ts` | Sync expected pinned package version `0.4.1` |

## Verification

- Runtime: `format:check` PASS, `lint` PASS, `type-check` PASS, `build` PASS, `test` 227/227 PASS, `pack:check` PASS
- Pion: `gofmt -l` clean, `go vet ./...` PASS, `CGO_ENABLED=0 go test ./...` PASS, `CGO_ENABLED=0 go build ./...` PASS
- `git diff --check` PASS

## Manual gate (not run)

The real production Meeting Notes smoke (room=test, voiceReply OFF, Human browser + mic, Doubao STT segment) requires the user's real browser (Turnstile blocks headless automation) and is a post-PR/CI gate, to be run after CI deploys.

## Commit identity

Head commit author and committer: `codex <267193182+codex@users.noreply.github.com>`

- Base: `origin/cf-sfu` @ `160292f7d9f96e6c86033f62bbde24ac34e1e2eb`
- Head: `1f13e71c971cde1d4fe2e4c1a8ff96dd6b2533ef`

Please review the exact head. Do not merge until ChatGPT explicitly approves it and CI is green.