### PR TITLE
chore(dev): make media experiments reproducible

### DIFF
--- a/.agent/skills/free4chat-media-experiment/SKILL.md
+++ b/.agent/skills/free4chat-media-experiment/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: free4chat-media-experiment
+description: Strict provenance-first SOP for real deployed Free4Chat Meeting Notes, Voice Reply, Pion, Cloudflare SFU, and browser-media experiments.
+---
+
+# Free4Chat media experiment SOP
+
+Use this skill for real browser/media experiments against a deployed Free4Chat
+environment. It is deliberately separate from `free4chat-local-e2e`, which
+covers generic local Worker/DO full-stack tests.
+
+## Hard rule
+
+If experiment provenance cannot be proved, abort the experiment and mark its
+result **INVALID**. Do not interpret the logs or use them to choose a fix.
+
+Every experiment changes one variable and answers one question. Do not debug
+bootstrap, STT, TTS, Pion, Worker behavior, and browser playback in one run.
+
+## Preflight and provenance
+
+1. State one hypothesis, such as “does current Voice Reply publish outbound
+   RTP?”
+2. Use the canonical repository only. Do not create a worktree. Fetch and
+   resolve `origin/cf-sfu`; use branch `cf-sfu` with a clean tree and record
+   the exact `HEAD` SHA. Historical bisects are an explicit separate mode.
+3. Build `agent-runtime` freshly from that SHA and record its package version.
+   Never reuse an old `dist` directory without rebuilding.
+4. Build Pion from the intended source tree when practical. Set
+   `FREE4CHAT_PION_BIN` to that exact executable. Record its path and intended
+   source SHA; if exact identity cannot be proven, record
+   `pion_source_identity=unverified` and require a binary built in this run.
+5. Run the read-only gate before starting anything:
+
+   ```bash
+   ./scripts/media-e2e-preflight.sh --pion-bin /absolute/path/to/pion
+   ```
+
+   It must pass branch, clean-tree, origin, Runtime build, Pion executable,
+   and process checks. It never starts or kills processes. It only reports
+   counts for Free4Chat Runtime and Pion processes; never terminate unrelated
+   OpenCode, Codex, Claude, editor, browser, or user processes.
+
+6. Start exactly one fresh Free4Chat daemon and one resident Agent after the
+   process count is zero. Record only process counts and safe executable
+   identity. Do not record handles, tokens, session IDs, or credentials.
+
+## Fresh disposable room
+
+Use a new room for every media experiment. Never reuse `test`, `test2`, `test3`,
+or another long-lived debugging room. Use labels such as
+`e2e-mn-YYYYMMDD-HHMMSS` and `e2e-vr-YYYYMMDD-HHMMSS`. A room contains
+participants, leases, grants, and media history, so reuse invalidates a clean
+experiment.
+
+## Golden control: Meeting Notes
+
+Before diagnosing Voice after any media or transport change, run the control
+with Voice Reply **OFF**. The required gates are:
+
+```text
+Agent joined
+Pion PeerConnection created
+server-events DataChannel created
+offer generated
+remote answer applied
+ICE connected
+PeerConnection connected
+remote Human audio/opus track received
+Meeting Notes UI = Listening
+RTP/audio frames observed
+real speech reaches STT
+at least one committed transcript segment
+```
+
+If any control gate fails, stop. The Voice experiment is INVALID; do not
+inspect or modify TTS/Voice based on it. The known-good control is current
+`cf-sfu` `62b0c54ef0f454a7d00ce264d8520d2935d9bfb3` until a newer verified
+baseline replaces it.
+
+## Voice treatment
+
+Use the same repository SHA, freshly built Runtime, Pion binary, deployed
+Worker, browser, credentials, and provider configuration as the control, but
+use a second fresh room. Keep Meeting Notes OFF and enable Voice Reply for
+exactly one Agent. Send one minimal deterministic request.
+
+Walk the existing implementation in order:
+
+1. Grant: `voiceReplyMediaAvailable`, `active`, and `targetsSelf`.
+2. Provider: provider resolved and `voice_reply_started`.
+3. Turn: `voice_turn_started`, TTS chunks, PCM frames, and finished/failed.
+4. Publication: publish arm, local MID present as a boolean/count only,
+   `/tracks` 2xx, remote description applied, publication active.
+5. Outbound Pion RTP packet/frame count, if observable.
+6. Human/browser: announcement, subscription, `ontrack`, audio `srcObject`,
+   and audible playback.
+
+Never infer a later-layer cause when an earlier gate has not passed.
+
+## Safe evidence
+
+Allowed: booleans, HTTP status, safe error codes, counts, media kind/codec,
+connection/signaling state, versions, repository SHA, binary path/source SHA,
+and disposable room labels.
+
+Never put in output, chat, issues, or PRs: participant IDs, handles/tokens,
+API keys, session IDs, identity-bearing track names, MID values, full SDP, ICE
+contents or credentials, fingerprints, IPs/addresses, Doubao credentials, raw
+audio, transcript text, or upstream response bodies.
+
+## Failure report before any code change
+
+If a real experiment fails, do not edit code, create a PR, or delegate a fix.
+First report:
+
+```text
+hypothesis
+exact repo SHA
+Runtime version and fresh-build provenance
+Pion path and provenance
+fresh room confirmed
+Free4Chat process counts
+golden-control result
+stage reached
+first failed gate
+safe evidence
+what was ruled out
+what remains unknown
+```
+
+Then request architecture/root-cause review. A failure without proven
+provenance is not evidence.
+
+## Turnstile development switch
+
+The development deployment may temporarily set:
+
+```text
+frontend: NEXT_PUBLIC_TURNSTILE_DISABLED=1
+Worker:   TURNSTILE_DISABLED=true
+```
+
+This is a reversible E2E convenience switch only. It does not remove Origin,
+rate-limit, Agent authorization, or media authorization checks. To restore
+Turnstile, remove both environment settings; do not delete the existing
+site-key or secret configuration.

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -72,6 +72,9 @@ jobs:
         working-directory: app
         env:
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
+          # Temporary development/E2E switch. Remove this line to restore the
+          # client Turnstile widget after media experiments are complete.
+          NEXT_PUBLIC_TURNSTILE_DISABLED: "1"
 
       - name: Validate deployment variables
         run: test -n "$SFU_APP_ID"
@@ -108,9 +111,13 @@ jobs:
       - name: Deploy
         if: steps.freshness.outputs.stale != 'true'
         run: |
+          # Temporary development/E2E switch. The Worker secret remains
+          # configured; remove this --var and the client build flag above to
+          # restore Turnstile verification without changing code.
           npx wrangler deploy \
             --var "SFU_APP_ID:${SFU_APP_ID}" \
-            --var "AGENT_MEDIA_ENABLED:true"
+            --var "AGENT_MEDIA_ENABLED:true" \
+            --var "TURNSTILE_DISABLED:true"
         working-directory: app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -84,6 +84,90 @@ const agentBody = {
   token: "tok-1",
 }
 
+describe("TURNSTILE_DISABLED", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("bypasses Turnstile when explicitly enabled, even with a secret", async () => {
+    const requestedUrls: string[] = []
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      requestedUrls.push(String(input))
+      return Response.json({ sessionId: "cf-session-1" })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await handleSfuRequest(
+      req("session", {
+        origin: "https://www.free4.chat",
+        body: JSON.stringify({
+          room: "room-1",
+          name: "Human",
+          turnstileToken: "invalid",
+        }),
+      }),
+      makeEnv({
+        TURNSTILE_SECRET_KEY: "configured-secret",
+        TURNSTILE_DISABLED: "true",
+      })
+    )
+
+    expect(res.status).toBe(200)
+    expect(requestedUrls).toEqual([
+      "https://rtc.live.cloudflare.com/v1/apps/app-id/sessions/new",
+    ])
+  })
+
+  it("preserves verification when the explicit bypass is absent", async () => {
+    const requestedUrls: string[] = []
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      requestedUrls.push(String(input))
+      return Response.json({ success: false })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const res = await handleSfuRequest(
+      req("session", {
+        origin: "https://www.free4.chat",
+        body: JSON.stringify({
+          room: "room-1",
+          name: "Human",
+          turnstileToken: "invalid",
+        }),
+      }),
+      makeEnv({ TURNSTILE_SECRET_KEY: "configured-secret" })
+    )
+
+    expect(res.status).toBe(403)
+    expect((await json(res)).error).toBe("verification_failed")
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(requestedUrls).toEqual([
+      "https://challenges.cloudflare.com/turnstile/v0/siteverify",
+    ])
+  })
+
+  it("does not bypass origin or Agent media authorization", async () => {
+    const invalidOrigin = await handleSfuRequest(
+      req("session", {
+        origin: "https://evil.example.com",
+        body: JSON.stringify({ room: "room-1", name: "Human" }),
+      }),
+      makeEnv({ TURNSTILE_DISABLED: "true" })
+    )
+    expect(invalidOrigin.status).toBe(403)
+    expect((await json(invalidOrigin)).error).toBe("forbidden_origin")
+
+    const agentWithoutMediaGate = await handleSfuRequest(
+      req("agent-session", { body: JSON.stringify(agentBody) }),
+      makeEnv({ TURNSTILE_DISABLED: "true" })
+    )
+    expect(agentWithoutMediaGate.status).toBe(403)
+    expect((await json(agentWithoutMediaGate)).error).toBe(
+      "agent_media_disabled"
+    )
+  })
+})
+
 describe("AGENT_MEDIA_ENABLED gate", () => {
   it("agent-session rejects when the gate is unset (production default)", async () => {
     const env = makeEnv()

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -15,6 +15,9 @@ export interface SfuEnv {
   SFU_APP_ID?: string
   SFU_APP_SECRET?: string
   TURNSTILE_SECRET_KEY?: string
+  // Explicit, reversible development/E2E bypass. Any value other than the
+  // literal string "true" preserves the normal Turnstile behavior below.
+  TURNSTILE_DISABLED?: string
   // Coarse, environment-wide master switch for Agent SFU media (#82).
   // Absent/anything other than "true" => agent-session/agent-room-media
   // reject unconditionally, and RoomSession also refuses to ever start a
@@ -98,6 +101,7 @@ async function checkRateLimit(
 }
 
 async function verifyTurnstile(token: unknown, env: SfuEnv): Promise<boolean> {
+  if (env.TURNSTILE_DISABLED === "true") return true
   if (!env.TURNSTILE_SECRET_KEY) return true
   if (typeof token !== "string" || !token) return false
   const form = new URLSearchParams({

--- a/scripts/media-e2e-preflight.sh
+++ b/scripts/media-e2e-preflight.sh
@@ -46,12 +46,18 @@ fi
 
 head_sha="$(git rev-parse HEAD)"
 echo "repo_sha=$head_sha"
-if origin_sha="$(git rev-parse --verify refs/remotes/origin/cf-sfu 2>/dev/null)"; then
-  echo "origin_cf_sfu_sha=$origin_sha"
-  [[ "$head_sha" == "$origin_sha" ]] || fail "head_differs_from_origin-cf-sfu"
+if origin_sha_line="$(git ls-remote --exit-code origin refs/heads/cf-sfu 2>/dev/null)"; then
+  origin_sha="${origin_sha_line%%$'\t'*}"
+  if [[ -z "$origin_sha" ]]; then
+    echo "origin_cf_sfu_resolvable=false"
+    fail "origin-cf-sfu_sha_missing"
+  else
+    echo "origin_cf_sfu_sha=$origin_sha"
+    [[ "$head_sha" == "$origin_sha" ]] || fail "head_differs_from_origin-cf-sfu"
+  fi
 else
   echo "origin_cf_sfu_resolvable=false"
-  fail "origin-cf-sfu_not_fetched"
+  fail "origin-cf-sfu_remote_query_failed"
 fi
 
 runtime_version="$(node -p "require('./agent-runtime/package.json').version")"

--- a/scripts/media-e2e-preflight.sh
+++ b/scripts/media-e2e-preflight.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Read-only provenance gate for real deployed-media experiments. It never
+# starts or stops anything; an experiment runner must handle lifecycle after
+# this command succeeds.
+
+usage() {
+  echo "usage: $0 --pion-bin /absolute/path/to/pion" >&2
+  exit 2
+}
+
+PION_BIN="${FREE4CHAT_PION_BIN:-}"
+while (($# > 0)); do
+  case "$1" in
+    --pion-bin)
+      (($# >= 2)) || usage
+      PION_BIN="$2"
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+failures=0
+fail() {
+  echo "preflight_error=$1" >&2
+  failures=$((failures + 1))
+}
+
+branch="$(git branch --show-current)"
+echo "repo_branch=$branch"
+[[ "$branch" == "cf-sfu" ]] || fail "branch_must_be_cf-sfu"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "git_status_clean=false"
+  fail "working_tree_not_clean"
+else
+  echo "git_status_clean=true"
+fi
+
+head_sha="$(git rev-parse HEAD)"
+echo "repo_sha=$head_sha"
+if origin_sha="$(git rev-parse --verify refs/remotes/origin/cf-sfu 2>/dev/null)"; then
+  echo "origin_cf_sfu_sha=$origin_sha"
+  [[ "$head_sha" == "$origin_sha" ]] || fail "head_differs_from_origin-cf-sfu"
+else
+  echo "origin_cf_sfu_resolvable=false"
+  fail "origin-cf-sfu_not_fetched"
+fi
+
+runtime_version="$(node -p "require('./agent-runtime/package.json').version")"
+echo "runtime_version=$runtime_version"
+if [[ -f agent-runtime/dist/cli.js ]]; then
+  echo "runtime_build=present"
+else
+  echo "runtime_build=required"
+  fail "runtime_build_missing"
+fi
+
+if [[ -z "$PION_BIN" ]]; then
+  fail "pion_binary_not_supplied"
+else
+  echo "pion_binary=$PION_BIN"
+  [[ "$PION_BIN" == /* ]] || fail "pion_binary_path_must_be_absolute"
+  [[ -f "$PION_BIN" ]] || fail "pion_binary_missing"
+  [[ -x "$PION_BIN" ]] || fail "pion_binary_not_executable"
+fi
+echo "pion_source_identity=unverified"
+
+if ! process_snapshot="$(ps -axo pid=,command= 2>/dev/null)"; then
+  fail "cannot_inspect_processes"
+  process_snapshot=""
+fi
+runtime_count="$(printf '%s\n' "$process_snapshot" | awk '$0 ~ /free4chat-agent|agent-runtime\/dist\/cli\.js/ {count++} END {print count+0}')"
+pion_count="$(printf '%s\n' "$process_snapshot" | awk '$0 ~ /pion-cloudflare|experiments\/pion-cloudflare/ {count++} END {print count+0}')"
+echo "free4chat_runtime_processes=$runtime_count"
+echo "free4chat_pion_processes=$pion_count"
+((runtime_count == 0)) || fail "free4chat_runtime_processes_running"
+((pion_count == 0)) || fail "free4chat_pion_processes_running"
+
+if ((failures > 0)); then
+  echo "preflight=FAIL"
+  exit 1
+fi
+echo "preflight=PASS"


### PR DESCRIPTION
## Summary

- add an explicit, reversible TURNSTILE_DISABLED=true Worker development switch while preserving Origin, rate-limit, Agent, and media authorization
- set the temporary client/Worker Turnstile bypass in the cf-sfu deployment workflow with restoration comments
- add free4chat-media-experiment provenance-first SOP and a read-only fail-closed preflight helper
- add focused tests for bypass, preserved verification, Origin, and Agent media authorization

## Validation

- app/yarn test — 359 passed
- app/yarn type-check — passed
- app/npx prettier --check . — passed
- app/yarn lint --max-warnings 0 — passed
- app/yarn cf-build — passed
- bash -n scripts/media-e2e-preflight.sh — passed
- preflight fixture: clean/pass, dirty/fail, wrong branch/fail, missing Pion/fail

## Scope

No Voice, TTS, Meeting Notes transport, Pion behavior, Worker media semantics, or issue #128 implementation changes. Do not merge this PR until reviewed.