### PR TITLE
Add safe Voice publication diagnostics

### DIFF
--- a/agent-runtime/src/core/runtime.ts
+++ b/agent-runtime/src/core/runtime.ts
@@ -584,6 +584,9 @@ export class ResidentRoomRuntime {
         // A newly addressed turn wins the speaker (#83): stale audio from
         // the previous response must never keep playing over the new one.
         const voiceOutput = this.resolveVoiceOutput()
+        this.log("voice_dispatch_start", {
+          captured_voice_output_available: voiceOutput ? 1 : 0,
+        })
         voiceOutput?.cancel()
         const result = await this.options.adapter.runTurn(input)
         this.harnessFailed = false
@@ -594,6 +597,13 @@ export class ResidentRoomRuntime {
             text
           )
           this.log("message_persisted", { sequence: sent.sequence })
+          this.log("voice_dispatch_before_speak", {
+            captured_voice_output_available: voiceOutput ? 1 : 0,
+            current_voice_output_available: this.currentVoiceOutputAvailable()
+              ? 1
+              : 0,
+            speak_invoked: voiceOutput ? 1 : 0,
+          })
           voiceOutput?.speak(text)
         }
       }
@@ -778,6 +788,12 @@ export class ResidentRoomRuntime {
   private resolveVoiceOutput(): VoiceOutput | null {
     if (this.options.createVoiceOutput) return this.options.createVoiceOutput()
     return this.meetingNotes?.currentVoiceOutput() ?? null
+  }
+
+  /** Side-effect-free readiness snapshot for Voice dispatch diagnostics. */
+  private currentVoiceOutputAvailable(): boolean {
+    if (this.options.createVoiceOutput) return this.voiceOutput !== null
+    return this.meetingNotes?.hasCurrentVoiceOutput() ?? false
   }
 
   private async cleanupResources(): Promise<void> {

--- a/agent-runtime/src/media/meetingNotesController.ts
+++ b/agent-runtime/src/media/meetingNotesController.ts
@@ -279,6 +279,26 @@ export class MeetingNotesController {
     return this.voiceSpeaker
   }
 
+  /** Side-effect-free readiness check for Runtime diagnostics. */
+  hasCurrentVoiceOutput(): boolean {
+    return this.voiceSpeaker !== null
+  }
+
+  private logVoiceTurnStats(
+    event: "voice_turn_finished" | "voice_turn_failed",
+    details: Record<string, string | number>
+  ): void {
+    const bridge = this.bridge
+    if (!bridge || typeof bridge.voicePublishStats !== "function") {
+      this.log(event, details)
+      return
+    }
+    void bridge
+      .voicePublishStats()
+      .then((stats) => this.log(event, { ...details, ...stats }))
+      .catch(() => this.log(event, details))
+  }
+
   private async ensureVoice(): Promise<void> {
     const options = this.options.voiceReply
     const bridge = this.bridge
@@ -323,13 +343,13 @@ export class MeetingNotesController {
           if (event.type === "turnStarted")
             this.log("voice_turn_started", { turn: event.turn })
           else if (event.type === "turnFinished")
-            this.log("voice_turn_finished", {
+            this.logVoiceTurnStats("voice_turn_finished", {
               turn: event.turn,
               chunks: event.chunks,
               frames: event.frames,
             })
           else if (event.type === "turnFailed")
-            this.log("voice_turn_failed", {
+            this.logVoiceTurnStats("voice_turn_failed", {
               turn: event.turn,
               code: event.code,
             })
@@ -386,6 +406,7 @@ export class MeetingNotesController {
         ...(this.voiceTrackName
           ? { publish: { trackName: this.voiceTrackName } }
           : {}),
+        log: this.log,
       })
     this.bridge = bridge
     try {

--- a/agent-runtime/src/media/peerConnectionLike.ts
+++ b/agent-runtime/src/media/peerConnectionLike.ts
@@ -47,6 +47,14 @@ export interface PeerConnectionLike {
   localPublishMid?(): Promise<string | undefined>
   /** Feeds arbitrary S16LE 24 kHz mono PCM bytes into the outbound path. */
   writePcmChunk?(chunk: Uint8Array): Promise<void>
+  /** Read-only counters from the Pion outbound voice path. */
+  publishStats?(): Promise<{
+    pcm_write_calls: number
+    pcm_input_bytes: number
+    opus_frames_written: number
+    outbound_rtp_packets?: number
+    outbound_rtp_bytes?: number
+  }>
 }
 
 export type PeerConnectionFactory = () =>

--- a/agent-runtime/src/media/pionPeerConnectionLike.ts
+++ b/agent-runtime/src/media/pionPeerConnectionLike.ts
@@ -32,6 +32,7 @@ interface GoResponse {
   answer?: SessionDescriptionLike
   mid?: string
   appliedType?: string
+  counts?: Record<string, number>
 }
 
 interface GoEvent {
@@ -295,6 +296,23 @@ export async function createPionPeerConnection(
         { op: "write-pcm", payload: Buffer.from(chunk).toString("base64") },
         30_000
       )
+    },
+    publishStats: async () => {
+      const reply = await send({ op: "publish-stats" })
+      const counts = reply.counts ?? {}
+      const number = (key: string): number =>
+        typeof counts[key] === "number" ? Number(counts[key]) : 0
+      return {
+        pcm_write_calls: number("pcm_write_calls"),
+        pcm_input_bytes: number("pcm_input_bytes"),
+        opus_frames_written: number("opus_frames_written"),
+        ...(typeof counts.outbound_rtp_packets === "number"
+          ? { outbound_rtp_packets: number("outbound_rtp_packets") }
+          : {}),
+        ...(typeof counts.outbound_rtp_bytes === "number"
+          ? { outbound_rtp_bytes: number("outbound_rtp_bytes") }
+          : {}),
+      }
     },
     close: () => {
       try {

--- a/agent-runtime/src/media/sfuMediaBridge.ts
+++ b/agent-runtime/src/media/sfuMediaBridge.ts
@@ -28,6 +28,17 @@ function isHumanMediaDiscoveryDenied(error: unknown): boolean {
     error instanceof Error && error.message === HUMAN_MEDIA_DISCOVERY_DENIED
   )
 }
+
+function safeDiagnosticCode(error: unknown): string {
+  const message = error instanceof Error ? error.message : "unknown"
+  const normalized = message.toLowerCase()
+  if (normalized.includes("timeout")) return "timeout"
+  if (normalized.includes("unsupported_chunk")) return "unsupported_chunk"
+  if (normalized.includes("not authorized")) return "not_authorized"
+  if (normalized.includes("decoding")) return "decoding_error"
+  if (normalized.includes("network")) return "network_error"
+  return "operation_failed"
+}
 /** Emit a bounded stats event at most this often per track, not per packet. */
 const STATS_FLUSH_INTERVAL_MS = 2000
 // One 20 ms mono S16LE frame at the Pion voice rate. This is a bounded,
@@ -50,6 +61,8 @@ export interface SfuMediaBridgeOptions {
    * that implements the optional outbound surface (Pion engine only). */
   publish?: { trackName: string }
   createPeerConnection?: PeerConnectionFactory
+  /** Bounded diagnostic logger; never receives media, credentials or IDs. */
+  log?: (event: string, details?: Record<string, string | number>) => void
   /** Injectable for tests; defaults to Date.now. */
   now?: () => number
 }
@@ -91,6 +104,10 @@ export class SfuMediaBridge {
   private readonly pollIntervalMs: number
   private readonly publish?: { trackName: string }
   private readonly now: () => number
+  private readonly log: (
+    event: string,
+    details?: Record<string, string | number>
+  ) => void
 
   private pc: PeerConnectionLike | null = null
   private mySessionId: string | null = null
@@ -118,11 +135,14 @@ export class SfuMediaBridge {
   private voicePrimingSent = false
   private pendingVoicePcm: Uint8Array[] = []
   private pendingVoicePcmBytes = 0
+  private pcmWriteCalls = 0
+  private pcmInputBytes = 0
 
   constructor(options: SfuMediaBridgeOptions) {
     this.onEvent = options.onEvent
     this.onAudioFrame = options.onAudioFrame
     this.now = options.now ?? Date.now
+    this.log = options.log ?? (() => undefined)
     this.publish = options.publish
     this.pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
     this.restClient =
@@ -241,37 +261,82 @@ export class SfuMediaBridge {
       () => undefined
     )
     const run = (async () => {
-      if (this.stopped || !this.pc || !this.mySessionId) return
-      // The Pion engine only adds its outbound send m-line when armed, and
-      // #83 live silence traced to this arm step never running in production
-      // (the bootstrap offer is receive-only, so a later fresh offer still
-      // lacked the track and localPublishMid() returned ""). Arming is
-      // idempotent in the engine, so calling it here — immediately before
-      // the publication offer — is always correct.
-      await this.pc.armPublishAudio?.()
-      const offer = await this.pc.createOffer()
-      await this.pc.setLocalDescription(offer)
-      const mid = (await this.pc.localPublishMid?.()) ?? ""
-      if (!mid) throw new Error("publish_mid_unavailable")
-      const result = await this.restClient.publishAudioTrack!(
-        this.mySessionId,
-        { trackName: this.publish!.trackName, mid, offer }
-      )
-      if (result.sessionDescription) {
-        if (result.sessionDescription.type === "offer") {
-          await this.pc.setRemoteDescription(result.sessionDescription)
-          const answer = await this.pc.createAnswer()
-          await this.pc.setLocalDescription(answer)
-          await this.restClient.renegotiate(
-            this.mySessionId,
-            answer,
-            "voice-reply"
-          )
-        } else {
-          await this.pc.setRemoteDescription(result.sessionDescription)
-        }
+      const diagnostic: Record<string, string | number> = {
+        arm_publish_ok: 0,
+        voice_offer_created: 0,
+        local_mid_present: 0,
+        tracks_new_ok: 0,
+        publish_response_description_present: 0,
+        publish_response_description_type: "none",
+        remote_description_applied: 0,
+        activate_publish_ok: 0,
       }
-      await this.pc.activatePublish?.()
+      let stage = "arm-publish"
+      const fail = (error: unknown): never => {
+        this.log("voice_publish_failed", {
+          ...diagnostic,
+          stage,
+          code: safeDiagnosticCode(error),
+        })
+        throw error
+      }
+      try {
+        if (this.stopped || !this.pc || !this.mySessionId) return
+        // The Pion engine only adds its outbound send m-line when armed, and
+        // #83 live silence traced to this arm step never running in production
+        // (the bootstrap offer is receive-only, so a later fresh offer still
+        // lacked the track and localPublishMid() returned ""). Arming is
+        // idempotent in the engine, so calling it here — immediately before
+        // the publication offer — is always correct.
+        await this.pc.armPublishAudio?.()
+        diagnostic.arm_publish_ok = 1
+        stage = "offer"
+        const offer = await this.pc.createOffer()
+        diagnostic.voice_offer_created = 1
+        await this.pc.setLocalDescription(offer)
+        stage = "local-mid"
+        const mid = (await this.pc.localPublishMid?.()) ?? ""
+        if (!mid) throw new Error("publish_mid_unavailable")
+        diagnostic.local_mid_present = 1
+        stage = "tracks-new"
+        const result = await this.restClient.publishAudioTrack!(
+          this.mySessionId,
+          { trackName: this.publish!.trackName, mid, offer }
+        )
+        diagnostic.tracks_new_ok = 1
+        diagnostic.publish_response_description_present =
+          result.sessionDescription ? 1 : 0
+        diagnostic.publish_response_description_type =
+          result.sessionDescription?.type === "offer" ||
+          result.sessionDescription?.type === "answer"
+            ? result.sessionDescription.type
+            : "none"
+        if (result.sessionDescription) {
+          stage = "remote-description"
+          if (result.sessionDescription.type === "offer") {
+            await this.pc.setRemoteDescription(result.sessionDescription)
+            diagnostic.remote_description_applied = 1
+            const answer = await this.pc.createAnswer()
+            await this.pc.setLocalDescription(answer)
+            stage = "renegotiate"
+            await this.restClient.renegotiate(
+              this.mySessionId,
+              answer,
+              "voice-reply"
+            )
+            diagnostic.renegotiate_ok = 1
+          } else {
+            await this.pc.setRemoteDescription(result.sessionDescription)
+            diagnostic.remote_description_applied = 1
+          }
+        }
+        stage = "activate-publish"
+        await this.pc.activatePublish?.()
+        diagnostic.activate_publish_ok = 1
+        this.log("voice_publish_succeeded", diagnostic)
+      } catch (error) {
+        fail(error)
+      }
     })()
     this.negotiationQueue = run.then(
       () => undefined,
@@ -292,6 +357,8 @@ export class SfuMediaBridge {
 
   async writeVoicePcm(chunk: Uint8Array): Promise<void> {
     if (this.stopped) throw new Error("bridge_stopped")
+    this.pcmWriteCalls += 1
+    this.pcmInputBytes += chunk.byteLength
     await this.primeVoicePublication()
     await this.confirmVoicePublicationActive()
     if (
@@ -305,6 +372,34 @@ export class SfuMediaBridge {
     await this.drainPendingVoicePcm()
     await this.pc?.writePcmChunk?.(chunk)
     await this.confirmVoicePublicationActive()
+  }
+
+  async voicePublishStats(): Promise<{
+    pcm_write_calls: number
+    pcm_input_bytes: number
+    opus_frames_written: number
+    outbound_rtp_packets?: number
+    outbound_rtp_bytes?: number
+  }> {
+    const bridgeStats = {
+      pcm_write_calls: this.pcmWriteCalls,
+      pcm_input_bytes: this.pcmInputBytes,
+    }
+    const engineStats = (await this.pc?.publishStats?.()) ?? {
+      opus_frames_written: 0,
+      outbound_rtp_packets: undefined,
+      outbound_rtp_bytes: undefined,
+    }
+    return {
+      ...bridgeStats,
+      opus_frames_written: engineStats.opus_frames_written,
+      ...(engineStats.outbound_rtp_packets === undefined
+        ? {}
+        : { outbound_rtp_packets: engineStats.outbound_rtp_packets }),
+      ...(engineStats.outbound_rtp_bytes === undefined
+        ? {}
+        : { outbound_rtp_bytes: engineStats.outbound_rtp_bytes }),
+    }
   }
 
   async flushVoice(): Promise<void> {
@@ -353,6 +448,18 @@ export class SfuMediaBridge {
             this.publish!.trackName
           )
           if (active) this.voicePublicationAnnounced = true
+          const diagnostic =
+            this.restClient.lastPublishedAudioTrackDiagnostic?.()
+          if (diagnostic) {
+            this.log("voice_publish_cloudflare_check", {
+              publisher_session_lookup_ok:
+                diagnostic.publisher_session_lookup_ok,
+              matching_track_found: diagnostic.matching_track_found,
+              matching_track_status: diagnostic.matching_track_status,
+              matching_track_has_mid: diagnostic.matching_track_has_mid,
+              active: diagnostic.active,
+            })
+          }
         } catch {
           // Readiness is advisory; leave the flag false so a later write or
           // final flush can retry without failing the voice turn.

--- a/agent-runtime/src/media/sfuRestClient.ts
+++ b/agent-runtime/src/media/sfuRestClient.ts
@@ -27,6 +27,16 @@ export interface DataChannelTransportLike {
   requiresImmediateRenegotiation?: boolean
 }
 
+export type PublisherTrackStatus = "active" | "inactive" | "waiting" | "unknown"
+
+export interface PublishedAudioTrackDiagnostic {
+  publisher_session_lookup_ok: 0 | 1
+  matching_track_found: 0 | 1
+  matching_track_status: PublisherTrackStatus
+  matching_track_has_mid: 0 | 1
+  active: 0 | 1
+}
+
 /** #83 review: the narrow, typed purpose every Agent signaling request must
  * carry. The Worker/DO re-checks the matching room grant per purpose and
  * fails closed when it is missing or unknown — never Agent token alone:
@@ -95,6 +105,7 @@ export interface SfuRestClientLike {
     mySessionId: string,
     trackName: string
   ): Promise<boolean>
+  lastPublishedAudioTrackDiagnostic?(): PublishedAudioTrackDiagnostic | null
 }
 
 /**
@@ -106,6 +117,8 @@ export interface SfuRestClientLike {
  * its normal room join.
  */
 export class SfuRestClient implements SfuRestClientLike {
+  private lastPublisherDiagnostic: PublishedAudioTrackDiagnostic | null = null
+
   constructor(
     private readonly siteOrigin: string,
     private readonly handle: DecodedParticipantHandle
@@ -290,7 +303,25 @@ export class SfuRestClient implements SfuRestClientLike {
       sessionId: mySessionId,
       trackName,
     })
+    const status =
+      data.matchingTrackStatus === "active" ||
+      data.matchingTrackStatus === "inactive" ||
+      data.matchingTrackStatus === "waiting"
+        ? data.matchingTrackStatus
+        : "unknown"
+    this.lastPublisherDiagnostic = {
+      publisher_session_lookup_ok:
+        data.publisherSessionLookupOk === true ? 1 : 0,
+      matching_track_found: data.matchingTrackFound === true ? 1 : 0,
+      matching_track_status: status,
+      matching_track_has_mid: data.matchingTrackHasMid === true ? 1 : 0,
+      active: data.active === true ? 1 : 0,
+    }
     return data.active === true
+  }
+
+  lastPublishedAudioTrackDiagnostic(): PublishedAudioTrackDiagnostic | null {
+    return this.lastPublisherDiagnostic
   }
 
   async renegotiate(

--- a/agent-runtime/test/meetingNotesVoiceReply.test.ts
+++ b/agent-runtime/test/meetingNotesVoiceReply.test.ts
@@ -42,6 +42,16 @@ class FakeBridge {
   async cancelVoiceTurn() {
     this.discarded += 1
   }
+  async voicePublishStats() {
+    return {
+      pcm_write_calls: this.written.length,
+      pcm_input_bytes: this.written.reduce(
+        (total, chunk) => total + chunk.length,
+        0
+      ),
+      opus_frames_written: this.written.length,
+    }
+  }
 }
 
 function makeRoomInfo(opts: {
@@ -560,4 +570,7 @@ test("voice speaker lifecycle surfaces through the runtime log for live triage",
   const messages = logs.map((entry) => entry.message)
   assert.ok(messages.includes("voice_reply_started"))
   assert.ok(messages.includes("voice_turn_started"))
+  const finished = logs.find((entry) => entry.message === "voice_turn_finished")
+  assert.equal(finished?.pcm_write_calls, 1)
+  assert.ok(Number(finished?.pcm_input_bytes) > 0)
 })

--- a/agent-runtime/test/sfuMediaBridgeVoice.test.ts
+++ b/agent-runtime/test/sfuMediaBridgeVoice.test.ts
@@ -70,6 +70,13 @@ function scriptedPc(ops: Op[]) {
     writePcmChunk: async (chunk: Uint8Array) => {
       ops.push(chunk.length === 960 ? "silence" : "write")
     },
+    publishStats: async () => ({
+      pcm_write_calls: 2,
+      pcm_input_bytes: 4,
+      opus_frames_written: 2,
+      outbound_rtp_packets: 2,
+      outbound_rtp_bytes: 200,
+    }),
   }
   return pc as unknown as PeerConnectionLike & {
     armPublishAudio: () => Promise<void>
@@ -162,6 +169,13 @@ describe("SfuMediaBridge voiceReply publication (#83 live-silence fix)", () => {
       { sessionId: "sess-agent", trackName: "agent-voice" },
     ])
     assert.deepEqual(ops.slice(-4), ["silence", "confirm", "write", "write"])
+    assert.deepEqual(await bridge.voicePublishStats(), {
+      pcm_write_calls: 2,
+      pcm_input_bytes: 4,
+      opus_frames_written: 2,
+      outbound_rtp_packets: 2,
+      outbound_rtp_bytes: 200,
+    })
 
     await bridge.stop()
   })

--- a/agent-runtime/test/sfuRestClient.test.ts
+++ b/agent-runtime/test/sfuRestClient.test.ts
@@ -187,6 +187,41 @@ test("treats an inactive publication confirmation as false", async () => {
   }
 })
 
+test("retains only the bounded publication diagnostic fields", async () => {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = async () =>
+    Response.json({
+      active: true,
+      publisherSessionLookupOk: true,
+      matchingTrackFound: true,
+      matchingTrackStatus: "active",
+      matchingTrackHasMid: true,
+      secret: "must-not-be-retained",
+    })
+  try {
+    const client = new SfuRestClient("https://example.test", handle())
+    assert.equal(
+      await client.confirmPublishedAudioTrackActive!("s", "agent-voice"),
+      true
+    )
+    assert.deepEqual(client.lastPublishedAudioTrackDiagnostic?.(), {
+      publisher_session_lookup_ok: 1,
+      matching_track_found: 1,
+      matching_track_status: "active",
+      matching_track_has_mid: 1,
+      active: 1,
+    })
+    assert.equal(
+      JSON.stringify(client.lastPublishedAudioTrackDiagnostic?.()).includes(
+        "must-not-be-retained"
+      ),
+      false
+    )
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+})
+
 test("subscribeTrack keeps the remote-track payload shape and carries the mid back", async () => {
   const originalFetch = globalThis.fetch
   let receivedBody: Record<string, unknown> | undefined

--- a/app/src/sfu/server.ts
+++ b/app/src/sfu/server.ts
@@ -593,7 +593,14 @@ export async function handleSfuRequest(
       publisher.matchingTrackFound &&
       publisher.matchingTrackStatus === "active" &&
       publisher.matchingTrackHasMid
-    if (!active) return json({ active: false })
+    const diagnostic = {
+      publisherSessionLookupOk: publisher.publisherSessionLookupOk,
+      matchingTrackFound: publisher.matchingTrackFound,
+      matchingTrackStatus: publisher.matchingTrackStatus,
+      matchingTrackHasMid: publisher.matchingTrackHasMid,
+      active,
+    }
+    if (!active) return json(diagnostic)
     const activation = await roomControl(env, room, {
       action: "agent-track-active",
       participantId,
@@ -602,7 +609,7 @@ export async function handleSfuRequest(
       trackName,
     })
     if (!activation.ok) return activation
-    return json({ active: true })
+    return json(diagnostic)
   }
 
   if (route === "tracks" || route === "renegotiate") {

--- a/experiments/pion-cloudflare/main.go
+++ b/experiments/pion-cloudflare/main.go
@@ -208,6 +208,9 @@ func handleCmd(spike *MediaSpike, tracer *Tracer, c cmd) resp {
 		counts := spike.RtpCounts()
 		return resp{OK: true, Counts: counts}
 
+	case "publish-stats":
+		return resp{OK: true, Counts: spike.PublishCounts()}
+
 	case "close":
 		spike.Close()
 		return resp{OK: true}

--- a/experiments/pion-cloudflare/media.go
+++ b/experiments/pion-cloudflare/media.go
@@ -38,14 +38,17 @@ type MediaSpike struct {
 	dcState     string
 	expectedMid string
 
-	mu          sync.Mutex
-	onTrackInfo map[string]any
-	rtpCounts   map[string]uint64
-	offered     bool
-	outbound    *webrtc.TrackLocalStaticSample
-	publishOn   bool
-	encoder     *opus.Encoder
-	pcmCarry    []byte
+	mu                sync.Mutex
+	onTrackInfo       map[string]any
+	rtpCounts         map[string]uint64
+	offered           bool
+	outbound          *webrtc.TrackLocalStaticSample
+	publishOn         bool
+	encoder           *opus.Encoder
+	pcmCarry          []byte
+	pcmWriteCalls     uint64
+	pcmInputBytes     uint64
+	opusFramesWritten uint64
 	// Outbound wall-clock pacing (#83 review): injectable for deterministic
 	// tests; production uses time.Now/time.Sleep.
 	nowFn   func() time.Time
@@ -467,6 +470,41 @@ func (s *MediaSpike) RtpCounts() map[string]uint64 {
 	return out
 }
 
+// PublishCounts returns application-level PCM/Opus counters and, when Pion
+// exposes an audio outbound RTP stats object, its authoritative network
+// counters. The application counters are deliberately named as such: a
+// successful TrackLocal.WriteSample is not itself proof that a packet left
+// the process.
+func (s *MediaSpike) PublishCounts() map[string]uint64 {
+	s.mu.Lock()
+	counts := map[string]uint64{
+		"pcm_write_calls":     s.pcmWriteCalls,
+		"pcm_input_bytes":     s.pcmInputBytes,
+		"opus_frames_written": s.opusFramesWritten,
+	}
+	pc := s.pc
+	s.mu.Unlock()
+	if pc == nil {
+		return counts
+	}
+	var packets, bytes uint64
+	var found bool
+	for _, stat := range pc.GetStats() {
+		outbound, ok := stat.(webrtc.OutboundRTPStreamStats)
+		if !ok || outbound.Kind != "audio" {
+			continue
+		}
+		found = true
+		packets += uint64(outbound.PacketsSent)
+		bytes += outbound.BytesSent
+	}
+	if found {
+		counts["outbound_rtp_packets"] = packets
+		counts["outbound_rtp_bytes"] = bytes
+	}
+	return counts
+}
+
 // TrackInfo returns captured OnTrack metadata (nil if none matched yet).
 func (s *MediaSpike) TrackInfo() map[string]any {
 	s.mu.Lock()
@@ -593,6 +631,10 @@ func (s *MediaSpike) WritePCM(chunk []byte) error {
 	if !active || track == nil || enc == nil {
 		return errPublishNotActive
 	}
+	s.mu.Lock()
+	s.pcmWriteCalls++
+	s.pcmInputBytes += uint64(len(chunk))
+	s.mu.Unlock()
 	data := append(s.takeCarry(), chunk...)
 	const frame24kBytes = 960
 	frames := len(data) / frame24kBytes
@@ -614,6 +656,9 @@ func (s *MediaSpike) WritePCM(chunk []byte) error {
 		if err := track.WriteSample(media.Sample{Data: out[:n], Duration: frameDuration}); err != nil {
 			return err
 		}
+		s.mu.Lock()
+		s.opusFramesWritten++
+		s.mu.Unlock()
 	}
 	return nil
 }
@@ -678,5 +723,11 @@ func (s *MediaSpike) writeSample(b []byte) error {
 	if !active || t == nil {
 		return errPublishNotActive
 	}
-	return t.WriteSample(media.Sample{Data: b, Duration: 20 * time.Millisecond})
+	if err := t.WriteSample(media.Sample{Data: b, Duration: 20 * time.Millisecond}); err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.opusFramesWritten++
+	s.mu.Unlock()
+	return nil
 }


### PR DESCRIPTION
## Summary
- add bounded Runtime voice dispatch and TTS/PCM lifecycle diagnostics
- expose safe Cloudflare publication-state fields without IDs, SDP, tokens, or audio
- add Pion publish-stats counters and regression coverage

## Scope
This PR is observability-only. It does not change Voice behavior, Meeting Notes behavior, TTS protocol, publication signaling sequence, or the Go-Agent architecture.

## Validation
- agent-runtime: isolated full suite 228/228
- app: full Vitest suite 359/359 (also passed serially)
- experiments/pion-cloudflare: go test ./...
- agent-runtime: type-check, build, format check
- app: type-check, lint, OpenNext Cloudflare build

Baseline: 1fced2af59000e383986a09760d7aebfec5fc0bd
Exact head: e12b78ca64e738ba5ddf189863cc1600194ff70f

All commit author and committer metadata is codex <267193182+codex@users.noreply.github.com>.