### PR TITLE
Add browser voice downstream diagnostics

### DIFF
--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { useSfuChatRoom } from "./useSfuChatRoom"
 
 class FakeTrack {
+  kind: "audio" | "video" = "audio"
   enabled = true
   readyState = "live"
   stop = vi.fn()
@@ -27,11 +28,16 @@ class FakeDataChannel {
 }
 
 class FakePeerConnection {
+  static instances: FakePeerConnection[] = []
   connectionState = "new"
   ontrack: ((event: unknown) => void) | null = null
   onconnectionstatechange: (() => void) | null = null
   private mids = 0
   private transceivers: { sender: { track: FakeTrack }; mid: string }[] = []
+
+  constructor() {
+    FakePeerConnection.instances.push(this)
+  }
 
   addTrack(track: FakeTrack) {
     const mid = String(this.mids++)
@@ -74,6 +80,7 @@ describe("useSfuChatRoom — Turnstile boundary", () => {
   let getUserMedia: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    FakePeerConnection.instances.length = 0
     ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
       FakePeerConnection
     class FakeMediaStream {
@@ -266,6 +273,7 @@ describe("useSfuChatRoom room attachments (#123)", () => {
   let fetchMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    FakePeerConnection.instances.length = 0
     ;(global as unknown as { RTCPeerConnection: unknown }).RTCPeerConnection =
       FakePeerConnection
     class FakeMediaStream {
@@ -498,27 +506,38 @@ describe("useSfuChatRoom room attachments (#123)", () => {
 
   it("fails closed and leaves an errored remote subscription retryable", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined)
     let trackAttempts = 0
-    fetchMock.mockImplementation((input: RequestInfo | URL) => {
-      const url = typeof input === "string" ? input : input.toString()
-      if (url.endsWith("/api/sfu/session"))
-        return jsonResponse({
-          participantId: "participant-1",
-          participantToken: "participant-token",
-          sessionId: "session-1",
-          expiresAt: Date.now() + 60 * 60 * 1000,
-        })
-      if (url.endsWith("/api/sfu/datachannels/new"))
-        return jsonResponse({ dataChannels: [{ id: 1 }] })
-      if (url.endsWith("/api/sfu/tracks")) {
-        trackAttempts += 1
-        return jsonResponse({
-          requiresImmediateRenegotiation: false,
-          tracks: [{ errorCode: "track_not_found" }],
-        })
+    fetchMock.mockImplementation(
+      (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString()
+        if (url.endsWith("/api/sfu/session"))
+          return jsonResponse({
+            participantId: "participant-1",
+            participantToken: "participant-token",
+            sessionId: "session-1",
+            expiresAt: Date.now() + 60 * 60 * 1000,
+          })
+        if (url.endsWith("/api/sfu/datachannels/new"))
+          return jsonResponse({ dataChannels: [{ id: 1 }] })
+        if (url.endsWith("/api/sfu/tracks")) {
+          const body = JSON.parse(
+            (init?.body as string | undefined) ?? "{}"
+          ) as {
+            tracks?: Array<{ location?: string }>
+          }
+          if (body.tracks?.[0]?.location !== "remote") return jsonResponse({})
+          trackAttempts += 1
+          if (trackAttempts === 1)
+            return Promise.reject(new Error("secret-sdp-fetch-failure"))
+          return jsonResponse({
+            requiresImmediateRenegotiation: false,
+            tracks: [{ errorCode: "track_not_found" }],
+          })
+        }
+        return jsonResponse({})
       }
-      return jsonResponse({})
-    })
+    )
 
     const { unmount } = await connect("room-remote-error")
     await waitFor(() =>
@@ -552,6 +571,168 @@ describe("useSfuChatRoom room attachments (#123)", () => {
 
     publish()
     await waitFor(() => expect(trackAttempts).toBe(2))
+    const diagnostics = info.mock.calls
+      .filter(([prefix]) => prefix === "free4chat_voice_downstream")
+      .map(([, payload]) => payload as Record<string, unknown>)
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "tracks_new_result",
+          tracks_new_ok: 0,
+          stage: "tracks-new",
+          error_type: "Error",
+        }),
+      ])
+    )
+    expect(JSON.stringify(diagnostics)).not.toContain(
+      "secret-sdp-fetch-failure"
+    )
+    unmount()
+  })
+
+  it("observes the complete Agent audio downstream path without exposing secrets", async () => {
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined)
+    fetchMock.mockImplementation((input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString()
+      if (url.endsWith("/api/sfu/session"))
+        return jsonResponse({
+          participantId: "participant-1",
+          participantToken: "participant-token",
+          sessionId: "session-1",
+          expiresAt: Date.now() + 60 * 60 * 1000,
+        })
+      if (url.endsWith("/api/sfu/datachannels/new"))
+        return jsonResponse({ dataChannels: [{ id: 1 }] })
+      if (url.endsWith("/api/sfu/tracks"))
+        return jsonResponse({
+          sessionDescription: { type: "offer", sdp: "secret-sdp" },
+          tracks: [{ mid: "7", trackName: "secret-track" }],
+        })
+      return jsonResponse({})
+    })
+
+    const { unmount } = await connect("room-remote-observability")
+    await waitFor(() =>
+      expect(RecordingWebSocket.instances.length).toBeGreaterThan(0)
+    )
+    const ws = RecordingWebSocket.instances.at(-1)!
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "state",
+          state: {
+            createdAt: 0,
+            expiresAt: Date.now() + 60 * 60 * 1000,
+            participants: [
+              {
+                id: "agent-b",
+                name: "Agent B",
+                kind: "agent",
+                connected: true,
+                joinedAt: 0,
+                lastSeenAt: 0,
+                media: {
+                  sessionId: "agent-session",
+                  muted: false,
+                  fileChannelReady: false,
+                  tracks: [{ trackName: "agent-voice", kind: "audio" }],
+                },
+              },
+            ],
+            messages: [],
+            meetingNotes: { active: false },
+            meetingNotesMediaAvailable: true,
+            voiceReply: { active: true },
+            voiceReplyMediaAvailable: true,
+          },
+        }),
+      })
+    })
+
+    await waitFor(() =>
+      expect(
+        fetchMock.mock.calls.some(([input]) =>
+          String(input).endsWith("/api/sfu/renegotiate")
+        )
+      ).toBe(true)
+    )
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "trackPublished",
+          participant: {
+            id: "agent-b",
+            name: "Agent B",
+            kind: "agent",
+            sessionId: "agent-session",
+            track: { trackName: "agent-voice", kind: "audio" },
+          },
+        }),
+      })
+    })
+    const pc = FakePeerConnection.instances.at(-1)!
+    const track = new FakeTrack()
+    act(() => {
+      pc.ontrack?.({
+        track,
+        streams: [],
+      })
+    })
+
+    const diagnostics = info.mock.calls
+      .filter(([prefix]) => prefix === "free4chat_voice_downstream")
+      .map(([, payload]) => payload as Record<string, unknown>)
+    expect(diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          event: "room_state_observed",
+          agent_audio_track_visible_in_state: 1,
+          agent_audio_track_count: 1,
+        }),
+        expect.objectContaining({
+          event: "track_published_received",
+          participant_kind: "agent",
+          track_kind: "audio",
+          participant_found: 1,
+          publisher_session_present: 1,
+        }),
+        expect.objectContaining({
+          event: "subscribe_track_entered",
+          participant_kind: "agent",
+          track_kind: "audio",
+          media_present: 1,
+        }),
+        expect.objectContaining({
+          event: "tracks_new_result",
+          tracks_new_ok: 1,
+          has_session_description: 1,
+          session_description_type: "offer",
+          track_result_count: 1,
+          track_has_mid: 1,
+        }),
+        expect.objectContaining({ event: "remote_description_applied" }),
+        expect.objectContaining({ event: "answer_created" }),
+        expect.objectContaining({ event: "local_description_applied" }),
+        expect.objectContaining({ event: "renegotiate_ok" }),
+        expect.objectContaining({
+          event: "ontrack_fired",
+          received_track_kind: "audio",
+          pending_remote_track_present: 1,
+        }),
+        expect.objectContaining({
+          event: "pending_session_match",
+          pending_session_match: 1,
+        }),
+        expect.objectContaining({
+          event: "stream_attached",
+          stream_attached: 1,
+          attached_kind: "audio",
+        }),
+      ])
+    )
+    expect(JSON.stringify(diagnostics)).not.toContain("secret-sdp")
+    expect(JSON.stringify(diagnostics)).not.toContain("secret-track")
+    expect(JSON.stringify(diagnostics)).not.toContain("agent-session")
     unmount()
   })
 })

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -130,6 +130,31 @@ function summarizeRemoteTrackResponse(response: SfuApiResponse) {
   }
 }
 
+type VoiceDownstreamDiagnosticValue = string | number | boolean | string[]
+
+function voiceDownstreamDiagnostic(
+  event: string,
+  details: Record<string, VoiceDownstreamDiagnosticValue> = {}
+) {
+  // These bounded fields are intentionally emitted for production diagnosis.
+  // eslint-disable-next-line no-console
+  console.info("free4chat_voice_downstream", { event, ...details })
+}
+
+function diagnosticParticipantKind(
+  kind: unknown
+): "agent" | "human" | "unknown" {
+  return kind === "agent" || kind === "human" ? kind : "unknown"
+}
+
+function diagnosticTrackKind(kind: unknown): "audio" | "video" | "unknown" {
+  return kind === "audio" || kind === "video" ? kind : "unknown"
+}
+
+function diagnosticErrorType(error: unknown): string {
+  return error instanceof Error && error.name ? error.name : typeof error
+}
+
 function isAgentImage(file: File): boolean {
   return AGENT_IMAGE_TYPES.has(file.type)
 }
@@ -845,9 +870,17 @@ export function useSfuChatRoom(
       const session = sessionRef.current
       const pc = peerConnectionRef.current
       const media = participant.media
+      voiceDownstreamDiagnostic("subscribe_track_entered", {
+        participant_kind: diagnosticParticipantKind(participant.kind),
+        track_kind: diagnosticTrackKind(track.kind),
+        media_present: media ? 1 : 0,
+      })
       if (!session || !pc || !media) return
       const key = `${participant.id}:${media.sessionId}:${track.trackName}`
-      if (subscribedTracksRef.current.has(key)) return
+      if (subscribedTracksRef.current.has(key)) {
+        voiceDownstreamDiagnostic("subscribe_dedup_skipped", {})
+        return
+      }
       if (
         participantMapRef.current.get(participant.id)?.media?.sessionId !==
         media.sessionId
@@ -865,19 +898,50 @@ export function useSfuChatRoom(
           kind: track.kind,
           sessionId: media.sessionId,
         }
-        const response = await apiRequest("tracks", {
-          room: roomName,
-          participantId: session.participantId,
-          token: session.participantToken,
-          sessionId: session.sessionId,
-          tracks: [
-            {
-              location: "remote",
-              sessionId: media.sessionId,
-              trackName: track.trackName,
-              kind: track.kind,
-            },
-          ],
+        let response: SfuApiResponse
+        try {
+          response = await apiRequest("tracks", {
+            room: roomName,
+            participantId: session.participantId,
+            token: session.participantToken,
+            sessionId: session.sessionId,
+            tracks: [
+              {
+                location: "remote",
+                sessionId: media.sessionId,
+                trackName: track.trackName,
+                kind: track.kind,
+              },
+            ],
+          })
+        } catch (error) {
+          voiceDownstreamDiagnostic("tracks_new_result", {
+            tracks_new_ok: 0,
+            stage: "tracks-new",
+            error_type: diagnosticErrorType(error),
+          })
+          voiceDownstreamDiagnostic("negotiation_failed", {
+            stage: "tracks-new",
+            error_type: diagnosticErrorType(error),
+          })
+          throw error
+        }
+        const responseSummary = summarizeRemoteTrackResponse(response)
+        voiceDownstreamDiagnostic("tracks_new_result", {
+          tracks_new_ok: 1,
+          has_session_description: responseSummary.hasSessionDescription
+            ? 1
+            : 0,
+          session_description_type:
+            responseSummary.sessionDescriptionType ?? "none",
+          track_result_count: responseSummary.trackResultCount,
+          track_has_mid: responseSummary.trackHasMid ? 1 : 0,
+          ...(responseSummary.topLevelErrorCode
+            ? { top_level_error_code: responseSummary.topLevelErrorCode }
+            : {}),
+          ...(responseSummary.trackErrorCodes.length > 0
+            ? { track_error_codes: responseSummary.trackErrorCodes }
+            : {}),
         })
         if (!response.sessionDescription) {
           subscribedTracksRef.current.delete(key)
@@ -887,16 +951,57 @@ export function useSfuChatRoom(
           )
           return
         }
-        await pc.setRemoteDescription(response.sessionDescription)
-        const answer = await pc.createAnswer()
-        await pc.setLocalDescription(answer)
-        await apiRequest("renegotiate", {
-          room: roomName,
-          participantId: session.participantId,
-          token: session.participantToken,
-          sessionId: session.sessionId,
-          sessionDescription: { type: answer.type, sdp: answer.sdp },
-        })
+        try {
+          await pc.setRemoteDescription(response.sessionDescription)
+          voiceDownstreamDiagnostic("remote_description_applied", {
+            remote_description_applied: 1,
+          })
+        } catch (error) {
+          voiceDownstreamDiagnostic("negotiation_failed", {
+            stage: "remote-description",
+            error_type: diagnosticErrorType(error),
+          })
+          throw error
+        }
+        let answer: RTCSessionDescriptionInit
+        try {
+          answer = await pc.createAnswer()
+          voiceDownstreamDiagnostic("answer_created", { answer_created: 1 })
+        } catch (error) {
+          voiceDownstreamDiagnostic("negotiation_failed", {
+            stage: "create-answer",
+            error_type: diagnosticErrorType(error),
+          })
+          throw error
+        }
+        try {
+          await pc.setLocalDescription(answer)
+          voiceDownstreamDiagnostic("local_description_applied", {
+            local_description_applied: 1,
+          })
+        } catch (error) {
+          voiceDownstreamDiagnostic("negotiation_failed", {
+            stage: "local-description",
+            error_type: diagnosticErrorType(error),
+          })
+          throw error
+        }
+        try {
+          await apiRequest("renegotiate", {
+            room: roomName,
+            participantId: session.participantId,
+            token: session.participantToken,
+            sessionId: session.sessionId,
+            sessionDescription: { type: answer.type, sdp: answer.sdp },
+          })
+          voiceDownstreamDiagnostic("renegotiate_ok", { renegotiate_ok: 1 })
+        } catch (error) {
+          voiceDownstreamDiagnostic("negotiation_failed", {
+            stage: "renegotiate",
+            error_type: diagnosticErrorType(error),
+          })
+          throw error
+        }
       }).catch((error) => {
         subscribedTracksRef.current.delete(key)
         console.warn("sfu_remote_subscribe_failed", {
@@ -910,6 +1015,20 @@ export function useSfuChatRoom(
   const applyRoomState = useCallback(
     (state: SfuRoomState) => {
       roomStateRef.current = state
+      const agentAudioTrackCount = state.participants.reduce(
+        (count, participant) =>
+          count +
+          (participant.kind === "agent"
+            ? (participant.media?.tracks ?? []).filter(
+                (track) => track.kind === "audio"
+              ).length
+            : 0),
+        0
+      )
+      voiceDownstreamDiagnostic("room_state_observed", {
+        agent_audio_track_visible_in_state: agentAudioTrackCount > 0 ? 1 : 0,
+        agent_audio_track_count: agentAudioTrackCount,
+      })
       setMeetingNotes(state.meetingNotes)
       setMeetingNotesMediaAvailable(state.meetingNotesMediaAvailable)
       setVoiceReply(state.voiceReply)
@@ -964,11 +1083,24 @@ export function useSfuChatRoom(
     peerConnectionRef.current = pc
     pc.ontrack = (event) => {
       const pending = pendingRemoteTrackRef.current
-      if (!pending) return
-      if (
-        participantMapRef.current.get(pending.peerId)?.media?.sessionId !==
+      voiceDownstreamDiagnostic("ontrack_fired", {
+        ontrack_fired: 1,
+        received_track_kind: diagnosticTrackKind(event.track.kind),
+        pending_remote_track_present: pending ? 1 : 0,
+      })
+      if (!pending) {
+        voiceDownstreamDiagnostic("pending_session_match", {
+          pending_session_match: 0,
+        })
+        return
+      }
+      const pendingSessionMatches =
+        participantMapRef.current.get(pending.peerId)?.media?.sessionId ===
         pending.sessionId
-      ) {
+      voiceDownstreamDiagnostic("pending_session_match", {
+        pending_session_match: pendingSessionMatches ? 1 : 0,
+      })
+      if (!pendingSessionMatches) {
         pendingRemoteTrackRef.current = null
         return
       }
@@ -976,6 +1108,11 @@ export function useSfuChatRoom(
       if (pending.kind === "video")
         remoteScreenStreamsRef.current.set(pending.peerId, stream)
       else remoteAudioStreamsRef.current.set(pending.peerId, stream)
+      voiceDownstreamDiagnostic("stream_attached", {
+        stream_attached: 1,
+        attached_kind: pending.kind,
+        remote_audio_stream_count: remoteAudioStreamsRef.current.size,
+      })
       pendingRemoteTrackRef.current = null
       rebuildParticipants()
     }
@@ -1021,8 +1158,17 @@ export function useSfuChatRoom(
       ) {
         const participantId = message.participant.id
         const incomingSessionId = message.participant.sessionId
+        const current = participantId
+          ? participantMapRef.current.get(participantId)
+          : undefined
+        voiceDownstreamDiagnostic("track_published_received", {
+          track_published_received: 1,
+          participant_kind: diagnosticParticipantKind(message.participant.kind),
+          track_kind: diagnosticTrackKind(message.participant.track.kind),
+          participant_found: current ? 1 : 0,
+          publisher_session_present: incomingSessionId ? 1 : 0,
+        })
         if (!participantId) return
-        const current = participantMapRef.current.get(participantId)
         if (
           current &&
           incomingSessionId &&


### PR DESCRIPTION
## Summary
- add bounded production diagnostics for the Agent audio downstream path
- observe room state, track publication, remote subscription, negotiation, and ontrack attachment without IDs, SDP, or raw errors
- add regression coverage for success, retryable failure, deduplication, and secret-free diagnostics

## Validation
- yarn vitest run --no-file-parallelism --maxWorkers=1 --minWorkers=1 (360 tests)
- yarn type-check
- yarn eslint src
- yarn prettier --check src/hooks/useSfuChatRoom.ts src/hooks/useSfuChatRoom.test.tsx
- yarn cf-build

Behavior and signaling order are unchanged; this PR is intended to identify the first failing browser downstream stage after the merged upstream Voice path.