### PR TITLE
Make voice diagnostics collector-readable

### DIFF
--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -571,9 +571,18 @@ describe("useSfuChatRoom room attachments (#123)", () => {
 
     publish()
     await waitFor(() => expect(trackAttempts).toBe(2))
-    const diagnostics = info.mock.calls
-      .filter(([prefix]) => prefix === "free4chat_voice_downstream")
-      .map(([, payload]) => payload as Record<string, unknown>)
+    const diagnostics = info.mock.calls.flatMap(([message]) => {
+      if (
+        typeof message !== "string" ||
+        !message.startsWith("free4chat_voice_downstream ")
+      )
+        return []
+      return [
+        JSON.parse(
+          message.slice("free4chat_voice_downstream ".length)
+        ) as Record<string, unknown>,
+      ]
+    })
     expect(diagnostics).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -679,9 +688,18 @@ describe("useSfuChatRoom room attachments (#123)", () => {
       })
     })
 
-    const diagnostics = info.mock.calls
-      .filter(([prefix]) => prefix === "free4chat_voice_downstream")
-      .map(([, payload]) => payload as Record<string, unknown>)
+    const diagnostics = info.mock.calls.flatMap(([message]) => {
+      if (
+        typeof message !== "string" ||
+        !message.startsWith("free4chat_voice_downstream ")
+      )
+        return []
+      return [
+        JSON.parse(
+          message.slice("free4chat_voice_downstream ".length)
+        ) as Record<string, unknown>,
+      ]
+    })
     expect(diagnostics).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -138,7 +138,9 @@ function voiceDownstreamDiagnostic(
 ) {
   // These bounded fields are intentionally emitted for production diagnosis.
   // eslint-disable-next-line no-console
-  console.info("free4chat_voice_downstream", { event, ...details })
+  console.info(
+    `free4chat_voice_downstream ${JSON.stringify({ event, ...details })}`
+  )
 }
 
 function diagnosticParticipantKind(


### PR DESCRIPTION
## Summary
- serialize the existing free4chat_voice_downstream payload as one console string
- keep every diagnostic field and all browser/WebRTC control flow unchanged
- update focused tests to parse the collector-readable output

## Validation
- app Vitest serial: 32 files, 360 tests passed
- app type-check passed
- app eslint src passed
- Prettier check passed
- OpenNext Cloudflare build passed

This is the minimal follow-up recommended after PR #144. It does not fix Voice behavior or modify Meeting Notes, TTS, Runtime, Pion, Worker, RoomSession, or signaling.