### PR TITLE
fix(agent): correct release artifact assembly for the first native release

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -129,8 +129,12 @@ jobs:
             free4chat-agent-linux-amd64; do
             test -s "$name/$name" || {
               echo "expected artifact missing or empty: $name" >&2; exit 1; }
-            mv "$name/$name" "./$name"
+            # download-artifact unpacks each artifact as a directory named
+            # after the artifact; move the file out via an intermediate name
+            # first (moving into ./$name would collide with the directory).
+            mv "$name/$name" "./$name.artifact"
             rmdir "$name"
+            mv "./$name.artifact" "./$name"
           done
           sha256sum \
             free4chat-agent-darwin-arm64 \

--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.0"
+var Version = "0.5.1"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"

--- a/agent/internal/free4chat/client.go
+++ b/agent/internal/free4chat/client.go
@@ -29,7 +29,7 @@ const (
 	// protection rejects Go's default "Go-http-client/1.1" UA with a 403
 	// challenge page, so an explicit product UA is mandatory (the Node
 	// reference sent "node" for the same reason).
-	defaultUserAgent = "free4chat-agent/0.5.0"
+	defaultUserAgent = "free4chat-agent/0.5.1"
 
 	headerContentType = "application/json"
 	headerAccept      = "application/json, text/event-stream"

--- a/agent/internal/media/rest.go
+++ b/agent/internal/media/rest.go
@@ -146,7 +146,7 @@ func (c *SfuRestClient) request(path, method string, body map[string]any) (map[s
 	// client does not add Origin automatically the way browser/Node fetch
 	// does for cross-origin POSTs.
 	request.Header.Set("Origin", c.siteOrigin)
-	request.Header.Set("User-Agent", "free4chat-agent/0.5.0")
+	request.Header.Set("User-Agent", "free4chat-agent/0.5.1")
 	response, err := c.http.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("network_error")

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -158,7 +158,7 @@ from the repository, configure MCP/ACP, or start a daemon manually.
    `free4chat-agent-linux-amd64`), verifies it against the published
    `SHA256SUMS` before installing, and places it at
    `~/.local/bin/free4chat-agent` (`FREE4CHAT_AGENT_INSTALL_DIR` overrides the
-   install directory; `FREE4CHAT_AGENT_VERSION=0.5.0` pins a release). Then
+   install directory; `FREE4CHAT_AGENT_VERSION=0.5.1` pins a release). Then
    run:
 
    ```text


### PR DESCRIPTION
## Summary

Focused release-blocker fix, found by the first real `agent-v*` tag run of PR #150's distribution workflow.

**Defect:** the tag-triggered Agent Release job (`Publish GitHub Release`) failed after all four build jobs passed. `actions/download-artifact` unpacks each uploaded artifact as a *directory* named after the artifact, so `mv "$name/$name" "./$name"` moved the file onto itself ("same file" error). No release was published.

**Fix:** move the file out via an intermediate name (`./$name.artifact`), remove the now-empty artifact directory, then rename to the exact release asset name. Verified locally by replaying the exact download-artifact layout and the fixed assemble sequence (all four assets + SHA256SUMS + `sha256sum -c`).

**Version:** the immutable `agent-v0.5.0` tag (pointing at the merged PR3 commit) is never moved; the workflow requires a tag version to match the source version, so the corrected first release ships as `agent-v0.5.1`: `doctor.Version`, the two HTTP User-Agent literals, and the installer pin example in `app/public/agent.md` all move to 0.5.1.

## Exact base

`c870d0dc21a51a69289b911dd44506455efae4c2` (origin/cf-sfu, merged PR #150)

## Changed files

- `.github/workflows/agent-release.yml` — two-step artifact move in the release job
- `agent/internal/doctor/doctor.go` — `Version = "0.5.1"`
- `agent/internal/free4chat/client.go` — User-Agent literal 0.5.1
- `agent/internal/media/rest.go` — User-Agent literal 0.5.1
- `app/public/agent.md` — pin example `FREE4CHAT_AGENT_VERSION=0.5.1`

## Tests

- `actionlint` clean on the workflow
- full release-job assemble sequence replayed locally with the download-artifact layout: 4 assets asserted non-empty, SHA256SUMS generated over exactly the four, checksums verified
- Go: `gofmt` clean, `go vet`, `go build`, `go test ./... -count=1 -timeout 300s` (10/10 packages)
- built binary reports `version: 0.5.1` via `doctor --json`
- `git diff --check` clean; `agent/scripts/check-cleanup.sh` OK
- protected surfaces unchanged vs base (`experiments/pion-cloudflare`, `docs/agent-runtime/voice-relay-diagnostics.md`)

## Scope

No #149/media/browser/Worker/RoomSession/RTP changes. Release-validation follow-up only.
