### PR TITLE
fix(agent): restore executable bit on assembled release artifacts

### DIFF
--- a/.github/workflows/agent-release.yml
+++ b/.github/workflows/agent-release.yml
@@ -136,6 +136,14 @@ jobs:
             rmdir "$name"
             mv "./$name.artifact" "./$name"
           done
+          # upload/download-artifact v4 does not preserve the executable
+          # bit: the assembled binaries must be made executable again before
+          # the version-verification step runs them.
+          chmod +x \
+            free4chat-agent-darwin-arm64 \
+            free4chat-agent-darwin-amd64 \
+            free4chat-agent-linux-arm64 \
+            free4chat-agent-linux-amd64
           sha256sum \
             free4chat-agent-darwin-arm64 \
             free4chat-agent-darwin-amd64 \

--- a/agent/internal/doctor/doctor.go
+++ b/agent/internal/doctor/doctor.go
@@ -16,7 +16,7 @@ import (
 // Version identifies the Go Agent Runtime build line (post-freeze rewrite).
 // It is a build-overridable var: release builds inject the agent-vX.Y.Z tag
 // version via -ldflags "-X github.com/i365dev/free4chat/agent/internal/doctor.Version=X.Y.Z".
-var Version = "0.5.1"
+var Version = "0.5.2"
 
 // PackageName mirrors the Node product identity in doctor output.
 const PackageName = "free4chat-agent"

--- a/agent/internal/free4chat/client.go
+++ b/agent/internal/free4chat/client.go
@@ -29,7 +29,7 @@ const (
 	// protection rejects Go's default "Go-http-client/1.1" UA with a 403
 	// challenge page, so an explicit product UA is mandatory (the Node
 	// reference sent "node" for the same reason).
-	defaultUserAgent = "free4chat-agent/0.5.1"
+	defaultUserAgent = "free4chat-agent/0.5.2"
 
 	headerContentType = "application/json"
 	headerAccept      = "application/json, text/event-stream"

--- a/agent/internal/media/rest.go
+++ b/agent/internal/media/rest.go
@@ -146,7 +146,7 @@ func (c *SfuRestClient) request(path, method string, body map[string]any) (map[s
 	// client does not add Origin automatically the way browser/Node fetch
 	// does for cross-origin POSTs.
 	request.Header.Set("Origin", c.siteOrigin)
-	request.Header.Set("User-Agent", "free4chat-agent/0.5.1")
+	request.Header.Set("User-Agent", "free4chat-agent/0.5.2")
 	response, err := c.http.Do(request)
 	if err != nil {
 		return nil, fmt.Errorf("network_error")

--- a/app/public/agent.md
+++ b/app/public/agent.md
@@ -158,7 +158,7 @@ from the repository, configure MCP/ACP, or start a daemon manually.
    `free4chat-agent-linux-amd64`), verifies it against the published
    `SHA256SUMS` before installing, and places it at
    `~/.local/bin/free4chat-agent` (`FREE4CHAT_AGENT_INSTALL_DIR` overrides the
-   install directory; `FREE4CHAT_AGENT_VERSION=0.5.1` pins a release). Then
+   install directory; `FREE4CHAT_AGENT_VERSION=0.5.2` pins a release). Then
    run:
 
    ```text


### PR DESCRIPTION
## Summary

Second focused release-blocker fix from the real tag-run validation of the Agent Release workflow.

**Defect:** after the artifact-assembly fix (#151), the `agent-v0.5.1` tag run failed in the release job's version-verification step: `Permission denied` executing the downloaded `free4chat-agent-linux-amd64`. `actions/upload-artifact`/`download-artifact` v4 does not preserve file mode bits, so assembled binaries arrive non-executable.

**Fix:** `chmod +x` the four assembled assets before checksumming and verification. Reproduced the failure locally with the exact download-artifact layout (0644 files) and verified the fixed pipeline end-to-end: assemble → chmod → SHA256SUMS over exactly the four → `sha256sum -c` → execute host binary → reports `version 0.5.2`, `runtime go`, `media.engine pion`.

**Version:** the immutable `agent-v0.5.0` and `agent-v0.5.1` tags are never moved; the corrected first published release ships as `agent-v0.5.2` (`doctor.Version`, User-Agent literals, and the installer pin example follow).

## Exact base

`6156130f9234d88c90040f271961ef4d4db49fb9` (origin/cf-sfu, merged PR #151)

## Changed files

- `.github/workflows/agent-release.yml` — `chmod +x` of the four assembled assets in the release job
- `agent/internal/doctor/doctor.go` — `Version = "0.5.2"`
- `agent/internal/free4chat/client.go` — User-Agent literal 0.5.2
- `agent/internal/media/rest.go` — User-Agent literal 0.5.2
- `app/public/agent.md` — pin example `FREE4CHAT_AGENT_VERSION=0.5.2`

## Tests

- `actionlint` clean
- full release-job pipeline replayed locally with the download-artifact layout (0644 inputs): assemble, chmod, SHA256SUMS, verification, binary execution
- Go: `gofmt` clean, `go vet`, `go build`, `go test ./... -count=1 -timeout 300s` (10/10)
- `git diff --check` clean; `agent/scripts/check-cleanup.sh` OK; prettier check on `app/public/agent.md` OK
- protected surfaces unchanged (`experiments/pion-cloudflare`, `docs/agent-runtime/voice-relay-diagnostics.md`)

## Scope

No #149/media/browser/Worker/RoomSession/RTP changes. Release-validation follow-up only.
