### PR TITLE
chore: restore production Turnstile verification

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -72,14 +72,12 @@ jobs:
         working-directory: app
         env:
           NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
-          # Temporary development/E2E switch. Remove this line to restore the
-          # client Turnstile widget after media experiments are complete.
-          NEXT_PUBLIC_TURNSTILE_DISABLED: "1"
 
       - name: Validate deployment variables
-        run: test -n "$SFU_APP_ID"
+        run: test -n "$SFU_APP_ID" && test -n "$NEXT_PUBLIC_TURNSTILE_SITE_KEY"
         env:
           SFU_APP_ID: ${{ secrets.SFU_APP_ID }}
+          NEXT_PUBLIC_TURNSTILE_SITE_KEY: ${{ secrets.NEXT_PUBLIC_TURNSTILE_SITE_KEY }}
 
       # Second, independent guard against a stale deploy (the concurrency
       # group above should normally prevent this by cancelling an
@@ -111,13 +109,9 @@ jobs:
       - name: Deploy
         if: steps.freshness.outputs.stale != 'true'
         run: |
-          # Temporary development/E2E switch. The Worker secret remains
-          # configured; remove this --var and the client build flag above to
-          # restore Turnstile verification without changing code.
           npx wrangler deploy \
             --var "SFU_APP_ID:${SFU_APP_ID}" \
-            --var "AGENT_MEDIA_ENABLED:true" \
-            --var "TURNSTILE_DISABLED:true"
+            --var "AGENT_MEDIA_ENABLED:true"
         working-directory: app
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- remove the temporary production Turnstile bypass from the client build and Worker deploy
- require the production public site key in deployment validation
- keep local and test-environment bypass behavior unchanged

## Validation
- git diff --check
- reviewed against the existing Turnstile client and Worker verification paths

This is intentionally limited to production deployment configuration; no Agent, SFU, media, or room behavior changes.