### PR TITLE
analytics: track Human + Agent collaboration lifecycle

### DIFF
--- a/app/src/common/collabAnalytics.test.ts
+++ b/app/src/common/collabAnalytics.test.ts
@@ -3,11 +3,12 @@ import { describe, expect, it } from "vitest"
 import {
   ANALYTICS_PROPERTY_KEYS,
   createCollabAnalyticsTracker,
+  delegationTopology,
   roomComposition,
   resolveParticipantKind,
   type CollabAnalyticsContext,
 } from "./collabAnalytics"
-import type { CollabEvent } from "../room/types"
+import type { CollabEvent, CollabEventKind } from "../room/types"
 
 const ROOM_TYPE = "audio"
 const ROOM_HASH = "a1b2c3d4"
@@ -28,8 +29,15 @@ function context(
 
 const HUMAN = { peerId: "raw-self-id", kind: "human" as const }
 const AGENT = { peerId: "agent-1", kind: "agent" as const }
+const AGENT_2 = { peerId: "agent-2", kind: "agent" as const }
 
-function collabEvent(overrides: Partial<CollabEvent>): CollabEvent {
+/**
+ * Production routing shape (do/collab.ts): a request travels from the
+ * original requester to the original target, while the canonical registry
+ * rewrites every response/result envelope in the reverse direction —
+ * from=responder (the original target), target=the original requester.
+ */
+function requestEnvelope(overrides: Partial<CollabEvent> = {}): CollabEvent {
   return {
     requestId: "req-1",
     kind: "request",
@@ -39,41 +47,77 @@ function collabEvent(overrides: Partial<CollabEvent>): CollabEvent {
   }
 }
 
+function terminalEnvelope(
+  kind: Extract<CollabEventKind, "declined" | "completed" | "failed">,
+  overrides: Partial<CollabEvent> = {}
+): CollabEvent {
+  return {
+    requestId: "req-1",
+    kind,
+    fromParticipantId: "agent-1",
+    targetParticipantId: "raw-self-id",
+    ...overrides,
+  }
+}
+
 describe("AgentJoined presence analytics", () => {
-  it("emits for a newly present Agent and not for ordinary Human presence", () => {
+  it("does not count Agents of the initial snapshot, then emits genuinely new joins once", () => {
     const tracker = createCollabAnalyticsTracker()
 
-    const humanOnly = tracker.observePresence(context([HUMAN]))
-    expect(humanOnly).toEqual([])
+    // Before the connection is established the roster is observed without
+    // baseline semantics: nothing may emit yet.
+    expect(tracker.observePresence(context([HUMAN, AGENT]))).toEqual([])
 
-    const withAgent = tracker.observePresence(context([HUMAN, AGENT]))
-    expect(withAgent).toHaveLength(1)
-    expect(withAgent[0]).toEqual({
+    // Initial post-join snapshot: Agents already present are baselined
+    // silently instead of being counted as having just joined.
+    expect(
+      tracker.observePresence(
+        context([HUMAN, AGENT], { presenceBaseline: true })
+      )
+    ).toEqual([])
+
+    // Replays/re-renders of the baselined roster stay silent.
+    expect(
+      tracker.observePresence(
+        context([HUMAN, AGENT], { presenceBaseline: true })
+      )
+    ).toEqual([])
+
+    // A genuinely new Agent after observation began emits exactly once.
+    const joined = tracker.observePresence(
+      context([HUMAN, AGENT, AGENT_2], { presenceBaseline: true })
+    )
+    expect(joined).toHaveLength(1)
+    expect(joined[0]).toEqual({
       roomType: ROOM_TYPE,
       roomHash: ROOM_HASH,
       participantBucket: "2-3",
-      roomComposition: "human-agent",
+      roomComposition: "mixed",
     })
+
+    // Reconnect-style replay of the same roster never re-emits.
+    expect(
+      tracker.observePresence(
+        context([HUMAN, AGENT, AGENT_2], { presenceBaseline: true })
+      )
+    ).toEqual([])
   })
 
-  it("does not re-emit for replayed, re-observed, or reconnected presence", () => {
+  it("baselines an initially empty room, so the first real Agent join emits", () => {
     const tracker = createCollabAnalyticsTracker()
-    expect(tracker.observePresence(context([HUMAN, AGENT]))).toHaveLength(1)
+    expect(
+      tracker.observePresence(context([HUMAN], { presenceBaseline: true }))
+    ).toEqual([])
 
-    // Same roster observed again (re-render / state refresh / replay).
-    expect(tracker.observePresence(context([HUMAN, AGENT]))).toEqual([])
+    const joined = tracker.observePresence(
+      context([HUMAN, AGENT], { presenceBaseline: true })
+    )
+    expect(joined).toHaveLength(1)
+    expect(joined[0]?.roomComposition).toBe("human-agent")
 
-    // Reconnect: roster momentarily empties, then the same Agent returns.
+    // The same Agent leaving and returning is not a second join.
     expect(tracker.observePresence(context([HUMAN]))).toEqual([])
     expect(tracker.observePresence(context([HUMAN, AGENT]))).toEqual([])
-
-    // A genuinely different Agent participant is a new, distinct join.
-    const second = tracker.observePresence(
-      context([HUMAN, AGENT, { peerId: "agent-2", kind: "agent" }])
-    )
-    expect(second).toHaveLength(1)
-    expect(second[0]?.roomComposition).toBe("mixed")
-    expect(second[0]?.participantBucket).toBe("2-3")
   })
 })
 
@@ -82,7 +126,7 @@ describe("CollabRequested / CollabOutcome analytics", () => {
     const tracker = createCollabAnalyticsTracker()
     const ctx = context([HUMAN, AGENT])
 
-    const first = tracker.observeCollabEvent(ctx, collabEvent({}))
+    const first = tracker.observeCollabEvent(ctx, requestEnvelope(), Date.now())
     expect(first).toEqual({
       name: "CollabRequested",
       properties: {
@@ -95,20 +139,44 @@ describe("CollabRequested / CollabOutcome analytics", () => {
     })
 
     // Room state refresh / resync replay re-delivers the same envelope.
-    expect(tracker.observeCollabEvent(ctx, collabEvent({}))).toBeNull()
-    expect(tracker.observeCollabEvent(ctx, collabEvent({ ...{} }))).toBeNull()
+    expect(
+      tracker.observeCollabEvent(ctx, requestEnvelope(), Date.now())
+    ).toBeNull()
+  })
+
+  it("keeps requester/target meaning the original delegation across outcomes", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+    tracker.observeCollabEvent(ctx, requestEnvelope(), Date.now())
+
+    // The terminal envelope reverses direction (the responder is the Agent);
+    // analytics must still report the ORIGINAL Human -> Agent delegation.
+    const outcome = tracker.observeCollabEvent(
+      ctx,
+      terminalEnvelope("completed"),
+      Date.now()
+    )
+    expect(outcome).toEqual({
+      name: "CollabOutcome",
+      properties: expect.objectContaining({
+        outcome: "completed",
+        requesterKind: "human",
+        targetKind: "agent",
+      }),
+    })
   })
 
   it("emits agent-to-agent requester and target kinds", () => {
     const tracker = createCollabAnalyticsTracker()
-    const ctx = context([AGENT, { peerId: "agent-2", kind: "agent" }])
+    const ctx = context([AGENT, AGENT_2])
 
     const emitted = tracker.observeCollabEvent(
       ctx,
-      collabEvent({
+      requestEnvelope({
         fromParticipantId: "agent-1",
         targetParticipantId: "agent-2",
-      })
+      }),
+      Date.now()
     )
     expect(emitted).toEqual({
       name: "CollabRequested",
@@ -118,60 +186,130 @@ describe("CollabRequested / CollabOutcome analytics", () => {
         roomComposition: "agent-only",
       }),
     })
+
+    // The Agent-to-Agent outcome keeps the same original topology.
+    const outcome = tracker.observeCollabEvent(
+      ctx,
+      terminalEnvelope("declined", {
+        fromParticipantId: "agent-2",
+        targetParticipantId: "agent-1",
+      }),
+      Date.now()
+    )
+    expect(outcome).toEqual({
+      name: "CollabOutcome",
+      properties: expect.objectContaining({
+        outcome: "declined",
+        requesterKind: "agent",
+        targetKind: "agent",
+      }),
+    })
   })
 
-  it("maps terminal kinds to CollabOutcome outcomes exactly once", () => {
+  it("never emits for the intermediate accepted kind", () => {
     const tracker = createCollabAnalyticsTracker()
     const ctx = context([HUMAN, AGENT])
-
-    const declined = tracker.observeCollabEvent(
-      ctx,
-      collabEvent({ kind: "declined" })
-    )
-    expect(declined).toEqual({
-      name: "CollabOutcome",
-      properties: expect.objectContaining({ outcome: "declined" }),
-    })
-    expect(
-      tracker.observeCollabEvent(ctx, collabEvent({ kind: "declined" }))
-    ).toBeNull()
-
-    const completed = tracker.observeCollabEvent(
-      ctx,
-      collabEvent({ requestId: "req-2", kind: "completed" })
-    )
-    expect(completed).toEqual({
-      name: "CollabOutcome",
-      properties: expect.objectContaining({ outcome: "completed" }),
-    })
-
-    const failed = tracker.observeCollabEvent(
-      ctx,
-      collabEvent({ requestId: "req-3", kind: "failed" })
-    )
-    expect(failed).toEqual({
-      name: "CollabOutcome",
-      properties: expect.objectContaining({ outcome: "failed" }),
-    })
     expect(
       tracker.observeCollabEvent(
         ctx,
-        collabEvent({ requestId: "req-3", kind: "failed" })
+        requestEnvelope({ kind: "accepted" }),
+        Date.now()
       )
     ).toBeNull()
   })
 
-  it("sets hasArtifact only from attachment presence, never contents", () => {
+  it("emits an outcome even if the request envelope was never observed", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+    const outcome = tracker.observeCollabEvent(
+      ctx,
+      terminalEnvelope("completed"),
+      Date.now()
+    )
+    expect(outcome).toEqual({
+      name: "CollabOutcome",
+      properties: expect.objectContaining({ outcome: "completed" }),
+    })
+    // And the later replayed request envelope does not emit retroactively.
+    expect(
+      tracker.observeCollabEvent(ctx, requestEnvelope(), Date.now())
+    ).toBeNull()
+  })
+})
+
+describe("historical Room state baseline", () => {
+  it("stays silent for envelopes created before observation began", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+    const historical = Date.now() - 60_000
+
+    // Old request retained in Room state when the Human entered.
+    expect(
+      tracker.observeCollabEvent(ctx, requestEnvelope(), historical)
+    ).toBeNull()
+    // Its replays stay silent too.
+    expect(
+      tracker.observeCollabEvent(ctx, requestEnvelope(), historical)
+    ).toBeNull()
+
+    // Old terminal state is likewise never reattributed.
+    expect(
+      tracker.observeCollabEvent(ctx, terminalEnvelope("completed"), historical)
+    ).toBeNull()
+    expect(
+      tracker.observeCollabEvent(ctx, terminalEnvelope("failed"), historical)
+    ).toBeNull()
+
+    // A genuinely new request after observation began emits exactly once.
+    const fresh = tracker.observeCollabEvent(
+      ctx,
+      requestEnvelope({ requestId: "req-new" }),
+      Date.now()
+    )
+    expect(fresh).toEqual({
+      name: "CollabRequested",
+      properties: expect.objectContaining({ requesterKind: "human" }),
+    })
+    expect(
+      tracker.observeCollabEvent(
+        ctx,
+        requestEnvelope({ requestId: "req-new" }),
+        Date.now()
+      )
+    ).toBeNull()
+  })
+
+  it("does not reattribute retained history across a page reload", () => {
+    // A reload creates a fresh tracker (new observation clock); the retained
+    // lifecycle is again older than the boundary and stays silent.
+    const reloadedTracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+    expect(
+      reloadedTracker.observeCollabEvent(
+        ctx,
+        requestEnvelope({ requestId: "req-old" }),
+        Date.now() - 60_000
+      )
+    ).toBeNull()
+    expect(
+      reloadedTracker.observeCollabEvent(
+        ctx,
+        terminalEnvelope("completed", { requestId: "req-old" }),
+        Date.now() - 60_000
+      )
+    ).toBeNull()
+  })
+})
+
+describe("hasArtifact", () => {
+  it("reflects attachment presence only, never contents", () => {
     const tracker = createCollabAnalyticsTracker()
     const ctx = context([HUMAN, AGENT])
 
     const withArtifact = tracker.observeCollabEvent(
       ctx,
-      collabEvent({
-        requestId: "req-a",
-        kind: "completed",
-        attachmentIds: ["att-1"],
-      })
+      terminalEnvelope("completed", { attachmentIds: ["att-1"] }),
+      Date.now()
     )
     expect(withArtifact).toEqual({
       name: "CollabOutcome",
@@ -183,38 +321,16 @@ describe("CollabRequested / CollabOutcome analytics", () => {
 
     const withoutArtifact = tracker.observeCollabEvent(
       ctx,
-      collabEvent({ requestId: "req-b", kind: "completed" })
+      terminalEnvelope("failed", { requestId: "req-2" }),
+      Date.now()
     )
     expect(withoutArtifact).toEqual({
       name: "CollabOutcome",
       properties: expect.objectContaining({
-        outcome: "completed",
+        outcome: "failed",
         hasArtifact: false,
       }),
     })
-  })
-
-  it("never emits for the intermediate accepted kind", () => {
-    const tracker = createCollabAnalyticsTracker()
-    const ctx = context([HUMAN, AGENT])
-    expect(
-      tracker.observeCollabEvent(ctx, collabEvent({ kind: "accepted" }))
-    ).toBeNull()
-  })
-
-  it("emits an outcome even if the request envelope was never observed", () => {
-    const tracker = createCollabAnalyticsTracker()
-    const ctx = context([HUMAN, AGENT])
-    const outcome = tracker.observeCollabEvent(
-      ctx,
-      collabEvent({ kind: "completed" })
-    )
-    expect(outcome).toEqual({
-      name: "CollabOutcome",
-      properties: expect.objectContaining({ outcome: "completed" }),
-    })
-    // And the later replayed request envelope does not emit retroactively.
-    expect(tracker.observeCollabEvent(ctx, collabEvent({}))).toBeNull()
   })
 })
 
@@ -223,7 +339,9 @@ describe("analytics privacy shape", () => {
     const tracker = createCollabAnalyticsTracker()
     const ctx = context([HUMAN, AGENT])
 
-    const presence = tracker.observePresence(ctx)
+    const presence = tracker.observePresence(
+      context([HUMAN, AGENT], { presenceBaseline: true })
+    )
     for (const payload of presence) {
       expect(Object.keys(payload)).toEqual([
         ...ANALYTICS_PROPERTY_KEYS.AgentJoined,
@@ -232,11 +350,12 @@ describe("analytics privacy shape", () => {
 
     const requested = tracker.observeCollabEvent(
       ctx,
-      collabEvent({
+      requestEnvelope({
         requestId: "raw-request-id",
         summary: "please deploy the secret feature",
         details: { command: "rm -rf /" },
-      })
+      }),
+      Date.now()
     )
     expect(requested).not.toBeNull()
     expect(Object.keys(requested!.properties)).toEqual([
@@ -245,13 +364,13 @@ describe("analytics privacy shape", () => {
 
     const outcome = tracker.observeCollabEvent(
       ctx,
-      collabEvent({
+      terminalEnvelope("completed", {
         requestId: "raw-request-id",
-        kind: "completed",
         summary: "deployed the secret feature",
         details: { url: "https://internal.example.invalid" },
         attachmentIds: ["att-raw-id"],
-      })
+      }),
+      Date.now()
     )
     expect(outcome).not.toBeNull()
     expect(Object.keys(outcome!.properties)).toEqual([
@@ -278,10 +397,11 @@ describe("analytics privacy shape", () => {
     const ctx = context([HUMAN])
     const emitted = tracker.observeCollabEvent(
       ctx,
-      collabEvent({
+      requestEnvelope({
         fromParticipantId: "gone-agent",
         targetParticipantId: "gone-agent",
-      })
+      }),
+      Date.now()
     )
     expect(emitted).toEqual({
       name: "CollabRequested",
@@ -299,9 +419,18 @@ describe("pure helpers", () => {
     expect(roomComposition([HUMAN])).toBe("human-only")
     expect(roomComposition([AGENT])).toBe("agent-only")
     expect(roomComposition([HUMAN, AGENT])).toBe("human-agent")
-    expect(
-      roomComposition([HUMAN, AGENT, { peerId: "agent-2", kind: "agent" }])
-    ).toBe("mixed")
+    expect(roomComposition([HUMAN, AGENT, AGENT_2])).toBe("mixed")
+  })
+
+  it("normalizes the reversed response/result envelope direction", () => {
+    expect(delegationTopology(requestEnvelope())).toEqual({
+      requesterId: "raw-self-id",
+      targetId: "agent-1",
+    })
+    expect(delegationTopology(terminalEnvelope("completed"))).toEqual({
+      requesterId: "raw-self-id",
+      targetId: "agent-1",
+    })
   })
 
   it("resolves the local Human from either its roster entry or raw id", () => {

--- a/app/src/common/collabAnalytics.test.ts
+++ b/app/src/common/collabAnalytics.test.ts
@@ -1,0 +1,314 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  ANALYTICS_PROPERTY_KEYS,
+  createCollabAnalyticsTracker,
+  roomComposition,
+  resolveParticipantKind,
+  type CollabAnalyticsContext,
+} from "./collabAnalytics"
+import type { CollabEvent } from "../room/types"
+
+const ROOM_TYPE = "audio"
+const ROOM_HASH = "a1b2c3d4"
+
+function context(
+  participants: CollabAnalyticsContext["participants"],
+  overrides: Partial<CollabAnalyticsContext> = {}
+): CollabAnalyticsContext {
+  return {
+    roomType: ROOM_TYPE,
+    roomHash: ROOM_HASH,
+    participants,
+    selfPeerId: "local-peer-id",
+    selfParticipantId: "raw-self-id",
+    ...overrides,
+  }
+}
+
+const HUMAN = { peerId: "raw-self-id", kind: "human" as const }
+const AGENT = { peerId: "agent-1", kind: "agent" as const }
+
+function collabEvent(overrides: Partial<CollabEvent>): CollabEvent {
+  return {
+    requestId: "req-1",
+    kind: "request",
+    fromParticipantId: "raw-self-id",
+    targetParticipantId: "agent-1",
+    ...overrides,
+  }
+}
+
+describe("AgentJoined presence analytics", () => {
+  it("emits for a newly present Agent and not for ordinary Human presence", () => {
+    const tracker = createCollabAnalyticsTracker()
+
+    const humanOnly = tracker.observePresence(context([HUMAN]))
+    expect(humanOnly).toEqual([])
+
+    const withAgent = tracker.observePresence(context([HUMAN, AGENT]))
+    expect(withAgent).toHaveLength(1)
+    expect(withAgent[0]).toEqual({
+      roomType: ROOM_TYPE,
+      roomHash: ROOM_HASH,
+      participantBucket: "2-3",
+      roomComposition: "human-agent",
+    })
+  })
+
+  it("does not re-emit for replayed, re-observed, or reconnected presence", () => {
+    const tracker = createCollabAnalyticsTracker()
+    expect(tracker.observePresence(context([HUMAN, AGENT]))).toHaveLength(1)
+
+    // Same roster observed again (re-render / state refresh / replay).
+    expect(tracker.observePresence(context([HUMAN, AGENT]))).toEqual([])
+
+    // Reconnect: roster momentarily empties, then the same Agent returns.
+    expect(tracker.observePresence(context([HUMAN]))).toEqual([])
+    expect(tracker.observePresence(context([HUMAN, AGENT]))).toEqual([])
+
+    // A genuinely different Agent participant is a new, distinct join.
+    const second = tracker.observePresence(
+      context([HUMAN, AGENT, { peerId: "agent-2", kind: "agent" }])
+    )
+    expect(second).toHaveLength(1)
+    expect(second[0]?.roomComposition).toBe("mixed")
+    expect(second[0]?.participantBucket).toBe("2-3")
+  })
+})
+
+describe("CollabRequested / CollabOutcome analytics", () => {
+  it("emits exactly one CollabRequested per canonical request", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+
+    const first = tracker.observeCollabEvent(ctx, collabEvent({}))
+    expect(first).toEqual({
+      name: "CollabRequested",
+      properties: {
+        roomType: ROOM_TYPE,
+        roomHash: ROOM_HASH,
+        requesterKind: "human",
+        targetKind: "agent",
+        roomComposition: "human-agent",
+      },
+    })
+
+    // Room state refresh / resync replay re-delivers the same envelope.
+    expect(tracker.observeCollabEvent(ctx, collabEvent({}))).toBeNull()
+    expect(tracker.observeCollabEvent(ctx, collabEvent({ ...{} }))).toBeNull()
+  })
+
+  it("emits agent-to-agent requester and target kinds", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([AGENT, { peerId: "agent-2", kind: "agent" }])
+
+    const emitted = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({
+        fromParticipantId: "agent-1",
+        targetParticipantId: "agent-2",
+      })
+    )
+    expect(emitted).toEqual({
+      name: "CollabRequested",
+      properties: expect.objectContaining({
+        requesterKind: "agent",
+        targetKind: "agent",
+        roomComposition: "agent-only",
+      }),
+    })
+  })
+
+  it("maps terminal kinds to CollabOutcome outcomes exactly once", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+
+    const declined = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({ kind: "declined" })
+    )
+    expect(declined).toEqual({
+      name: "CollabOutcome",
+      properties: expect.objectContaining({ outcome: "declined" }),
+    })
+    expect(
+      tracker.observeCollabEvent(ctx, collabEvent({ kind: "declined" }))
+    ).toBeNull()
+
+    const completed = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({ requestId: "req-2", kind: "completed" })
+    )
+    expect(completed).toEqual({
+      name: "CollabOutcome",
+      properties: expect.objectContaining({ outcome: "completed" }),
+    })
+
+    const failed = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({ requestId: "req-3", kind: "failed" })
+    )
+    expect(failed).toEqual({
+      name: "CollabOutcome",
+      properties: expect.objectContaining({ outcome: "failed" }),
+    })
+    expect(
+      tracker.observeCollabEvent(
+        ctx,
+        collabEvent({ requestId: "req-3", kind: "failed" })
+      )
+    ).toBeNull()
+  })
+
+  it("sets hasArtifact only from attachment presence, never contents", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+
+    const withArtifact = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({
+        requestId: "req-a",
+        kind: "completed",
+        attachmentIds: ["att-1"],
+      })
+    )
+    expect(withArtifact).toEqual({
+      name: "CollabOutcome",
+      properties: expect.objectContaining({
+        outcome: "completed",
+        hasArtifact: true,
+      }),
+    })
+
+    const withoutArtifact = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({ requestId: "req-b", kind: "completed" })
+    )
+    expect(withoutArtifact).toEqual({
+      name: "CollabOutcome",
+      properties: expect.objectContaining({
+        outcome: "completed",
+        hasArtifact: false,
+      }),
+    })
+  })
+
+  it("never emits for the intermediate accepted kind", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+    expect(
+      tracker.observeCollabEvent(ctx, collabEvent({ kind: "accepted" }))
+    ).toBeNull()
+  })
+
+  it("emits an outcome even if the request envelope was never observed", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+    const outcome = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({ kind: "completed" })
+    )
+    expect(outcome).toEqual({
+      name: "CollabOutcome",
+      properties: expect.objectContaining({ outcome: "completed" }),
+    })
+    // And the later replayed request envelope does not emit retroactively.
+    expect(tracker.observeCollabEvent(ctx, collabEvent({}))).toBeNull()
+  })
+})
+
+describe("analytics privacy shape", () => {
+  it("sends only the agreed coarse properties, never private content", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN, AGENT])
+
+    const presence = tracker.observePresence(ctx)
+    for (const payload of presence) {
+      expect(Object.keys(payload)).toEqual([
+        ...ANALYTICS_PROPERTY_KEYS.AgentJoined,
+      ])
+    }
+
+    const requested = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({
+        requestId: "raw-request-id",
+        summary: "please deploy the secret feature",
+        details: { command: "rm -rf /" },
+      })
+    )
+    expect(requested).not.toBeNull()
+    expect(Object.keys(requested!.properties)).toEqual([
+      ...ANALYTICS_PROPERTY_KEYS.CollabRequested,
+    ])
+
+    const outcome = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({
+        requestId: "raw-request-id",
+        kind: "completed",
+        summary: "deployed the secret feature",
+        details: { url: "https://internal.example.invalid" },
+        attachmentIds: ["att-raw-id"],
+      })
+    )
+    expect(outcome).not.toBeNull()
+    expect(Object.keys(outcome!.properties)).toEqual([
+      ...ANALYTICS_PROPERTY_KEYS.CollabOutcome,
+    ])
+
+    const serialized = JSON.stringify([presence, requested, outcome])
+    for (const secret of [
+      "raw-request-id",
+      "secret feature",
+      "rm -rf",
+      "internal.example",
+      "att-raw-id",
+      "agent-1",
+      "raw-self-id",
+      "test-room-name",
+    ]) {
+      expect(serialized).not.toContain(secret)
+    }
+  })
+
+  it("keeps unresolvable participant ids out of payloads", () => {
+    const tracker = createCollabAnalyticsTracker()
+    const ctx = context([HUMAN])
+    const emitted = tracker.observeCollabEvent(
+      ctx,
+      collabEvent({
+        fromParticipantId: "gone-agent",
+        targetParticipantId: "gone-agent",
+      })
+    )
+    expect(emitted).toEqual({
+      name: "CollabRequested",
+      properties: expect.objectContaining({
+        requesterKind: "unknown",
+        targetKind: "unknown",
+        roomComposition: "human-only",
+      }),
+    })
+  })
+})
+
+describe("pure helpers", () => {
+  it("buckets room composition by participant kinds", () => {
+    expect(roomComposition([HUMAN])).toBe("human-only")
+    expect(roomComposition([AGENT])).toBe("agent-only")
+    expect(roomComposition([HUMAN, AGENT])).toBe("human-agent")
+    expect(
+      roomComposition([HUMAN, AGENT, { peerId: "agent-2", kind: "agent" }])
+    ).toBe("mixed")
+  })
+
+  it("resolves the local Human from either its roster entry or raw id", () => {
+    const ctx = context([AGENT])
+    expect(resolveParticipantKind(ctx, "raw-self-id")).toBe("human")
+    expect(resolveParticipantKind(ctx, "local-peer-id")).toBe("human")
+    expect(resolveParticipantKind(ctx, "agent-1")).toBe("agent")
+    expect(resolveParticipantKind(ctx, "unknown-id")).toBe("unknown")
+  })
+})

--- a/app/src/common/collabAnalytics.ts
+++ b/app/src/common/collabAnalytics.ts
@@ -9,6 +9,14 @@ import type { CollabEvent } from "../room/types"
  * browser observes — the participant roster and persisted collaboration
  * envelopes — never from button clicks or transient UI state.
  *
+ * Observation baseline: facts that already existed when this browser began
+ * observing the Room (Agents in the initial connected roster, collaboration
+ * envelopes created before observation started) are recorded silently and
+ * never emitted under this browser's analytics identity. Only facts that
+ * become new after observation begins are emitted, and each is emitted at
+ * most once per browser session — resync replay, reconnect, and re-render
+ * never re-count.
+ *
  * Privacy: payloads are intentionally coarse. Room names are hashed with the
  * shared hashRoom helper; participant kinds and counts are bucketed. Request
  * summaries, capability strings, participant names, and raw request or
@@ -64,6 +72,12 @@ export interface CollabAnalyticsContext {
   selfPeerId: string
   /** The browser's raw Room participant id, when the session has one. */
   selfParticipantId?: string
+  /**
+   * True only while this observation reflects the initial post-join snapshot
+   * (the connection is established). The tracker baselines Agents present in
+   * that first snapshot instead of counting them as having just joined.
+   */
+  presenceBaseline?: boolean
 }
 
 const AGENT_JOINED_PROPERTIES = [
@@ -122,24 +136,50 @@ export function resolveParticipantKind(
   return participant?.kind ?? "unknown"
 }
 
+/**
+ * Normalize the canonical envelope routing to the ORIGINAL delegation
+ * topology. Responses/results reverse direction: the registry rewrites them
+ * as from=responder (the original target) and target=the original requester
+ * (see do/collab.ts). requesterKind/targetKind must consistently mean the
+ * original requester and target across CollabRequested and CollabOutcome.
+ */
+export function delegationTopology(event: CollabEvent): {
+  requesterId: string
+  targetId: string
+} {
+  return event.kind === "request"
+    ? {
+        requesterId: event.fromParticipantId,
+        targetId: event.targetParticipantId,
+      }
+    : {
+        requesterId: event.targetParticipantId,
+        targetId: event.fromParticipantId,
+      }
+}
+
 export interface CollabAnalyticsTracker {
   /**
-   * Observe the current roster. Returns one payload per Agent participant
-   * id seen for the first time by this browser session; replay, reconnect,
-   * and re-render of already-seen participants return an empty array.
+   * Observe the current roster. The first observation flagged as the initial
+   * post-join snapshot baselines every Agent present without emitting; after
+   * that, each Agent participant id seen for the first time emits exactly
+   * one payload, and replay/reconnect/re-render of known ids emit nothing.
    */
   observePresence(context: CollabAnalyticsContext): AgentJoinedPayload[]
   /**
-   * Observe one canonical collaboration envelope from Room state. Returns
-   * at most one analytics event per canonical requestId per browser
-   * session: the first observation of a request emits CollabRequested, the
-   * first observation of a terminal kind (declined/completed/failed) emits
-   * CollabOutcome, and every later observation of either returns null.
-   * accepted is an intermediate lifecycle kind and never emits.
+   * Observe one canonical collaboration envelope from Room state with its
+   * persisted createdAt. Envelopes created before this tracker's observation
+   * began are historical: they are recorded silently so replays of retained
+   * Room history never emit under this browser's identity. Otherwise, at
+   * most one analytics event per canonical requestId per browser session:
+   * the first new request emits CollabRequested, the first new terminal kind
+   * (declined/completed/failed) emits CollabOutcome, and every later
+   * observation of either returns null. accepted never emits.
    */
   observeCollabEvent(
     context: CollabAnalyticsContext,
-    event: CollabEvent
+    event: CollabEvent,
+    createdAt?: number
   ): CollabAnalyticsEmission | null
 }
 
@@ -147,9 +187,28 @@ export function createCollabAnalyticsTracker(): CollabAnalyticsTracker {
   const seenAgentParticipantIds = new Set<string>()
   const seenRequestIds = new Set<string>()
   const seenOutcomeRequestIds = new Set<string>()
+  // Observation began when the browser mounted the Room; collab envelopes
+  // carry the DO-side creation clock, so this boundary classifies retained
+  // history as historical. Small client/server clock skew can only move the
+  // edge by the skew amount — the same tradeoff the reaction precedent in
+  // RoomContent accepts for its pre-join guard.
+  const observationStartedAt = Date.now()
+  let presenceBaselined = false
 
   return {
     observePresence(context) {
+      if (!presenceBaselined) {
+        if (context.presenceBaseline !== true) return []
+        // Initial post-join snapshot: Agents already present did not "just
+        // join" — record them silently and start observing for new joins.
+        presenceBaselined = true
+        for (const participant of context.participants) {
+          if (participant.kind === "agent") {
+            seenAgentParticipantIds.add(participant.peerId)
+          }
+        }
+        return []
+      }
       const joined: AgentJoinedPayload[] = []
       for (const participant of context.participants) {
         if (participant.kind !== "agent") continue
@@ -165,8 +224,18 @@ export function createCollabAnalyticsTracker(): CollabAnalyticsTracker {
       return joined
     },
 
-    observeCollabEvent(context, event) {
+    observeCollabEvent(context, event, createdAt) {
       if (event.kind === "accepted") return null
+
+      // Retained history predating observation: seed the dedup sets so
+      // replays of the same lifecycle can never emit, but stay silent.
+      if (createdAt !== undefined && createdAt < observationStartedAt) {
+        if (event.kind === "request") seenRequestIds.add(event.requestId)
+        else seenOutcomeRequestIds.add(event.requestId)
+        return null
+      }
+
+      const topology = delegationTopology(event)
 
       if (event.kind === "request") {
         // A request that already reached a terminal outcome in this session
@@ -181,14 +250,8 @@ export function createCollabAnalyticsTracker(): CollabAnalyticsTracker {
         const properties: CollabRequestedPayload = {
           roomType: context.roomType,
           roomHash: context.roomHash,
-          requesterKind: resolveParticipantKind(
-            context,
-            event.fromParticipantId
-          ),
-          targetKind: resolveParticipantKind(
-            context,
-            event.targetParticipantId
-          ),
+          requesterKind: resolveParticipantKind(context, topology.requesterId),
+          targetKind: resolveParticipantKind(context, topology.targetId),
           roomComposition: roomComposition(context.participants),
         }
         return { name: "CollabRequested", properties }
@@ -199,8 +262,8 @@ export function createCollabAnalyticsTracker(): CollabAnalyticsTracker {
       seenOutcomeRequestIds.add(event.requestId)
       const properties: CollabOutcomePayload = {
         outcome: event.kind,
-        requesterKind: resolveParticipantKind(context, event.fromParticipantId),
-        targetKind: resolveParticipantKind(context, event.targetParticipantId),
+        requesterKind: resolveParticipantKind(context, topology.requesterId),
+        targetKind: resolveParticipantKind(context, topology.targetId),
         roomType: context.roomType,
         roomHash: context.roomHash,
         hasArtifact: Array.isArray(event.attachmentIds)

--- a/app/src/common/collabAnalytics.ts
+++ b/app/src/common/collabAnalytics.ts
@@ -1,0 +1,220 @@
+import type { UserInfo } from "./types"
+import { participantsBucket } from "./utils"
+import type { CollabEvent } from "../room/types"
+
+/**
+ * Browser-side, evidence-oriented analytics for the Human + Agent
+ * collaboration lifecycle (#106 lifecycle, #155 funnel). Events are derived
+ * from the canonical, already-deduplicated Room state a connected Human
+ * browser observes — the participant roster and persisted collaboration
+ * envelopes — never from button clicks or transient UI state.
+ *
+ * Privacy: payloads are intentionally coarse. Room names are hashed with the
+ * shared hashRoom helper; participant kinds and counts are bucketed. Request
+ * summaries, capability strings, participant names, and raw request or
+ * participant ids never cross this module's output.
+ */
+
+export type RoomComposition =
+  | "human-agent"
+  | "agent-only"
+  | "mixed"
+  | "human-only"
+
+export type ResolvedParticipantKind = "human" | "agent" | "unknown"
+
+export interface AgentJoinedPayload {
+  roomType: string
+  roomHash: string
+  participantBucket: string
+  roomComposition: RoomComposition
+  [key: string]: unknown
+}
+
+export interface CollabRequestedPayload {
+  roomType: string
+  roomHash: string
+  requesterKind: ResolvedParticipantKind
+  targetKind: ResolvedParticipantKind
+  roomComposition: RoomComposition
+  [key: string]: unknown
+}
+
+export interface CollabOutcomePayload {
+  outcome: "completed" | "failed" | "declined"
+  requesterKind: ResolvedParticipantKind
+  targetKind: ResolvedParticipantKind
+  roomType: string
+  roomHash: string
+  hasArtifact: boolean
+  roomComposition: RoomComposition
+  [key: string]: unknown
+}
+
+export type CollabAnalyticsEmission =
+  | { name: "CollabRequested"; properties: CollabRequestedPayload }
+  | { name: "CollabOutcome"; properties: CollabOutcomePayload }
+
+export interface CollabAnalyticsContext {
+  roomType: string
+  roomHash: string
+  /** Current connected roster (server-authoritative presence). */
+  participants: Array<Pick<UserInfo, "peerId" | "kind">>
+  /** The browser's own roster entry (LOCAL_PEER_ID); always the Human. */
+  selfPeerId: string
+  /** The browser's raw Room participant id, when the session has one. */
+  selfParticipantId?: string
+}
+
+const AGENT_JOINED_PROPERTIES = [
+  "roomType",
+  "roomHash",
+  "participantBucket",
+  "roomComposition",
+] as const
+
+const COLLAB_REQUESTED_PROPERTIES = [
+  "roomType",
+  "roomHash",
+  "requesterKind",
+  "targetKind",
+  "roomComposition",
+] as const
+
+const COLLAB_OUTCOME_PROPERTIES = [
+  "outcome",
+  "requesterKind",
+  "targetKind",
+  "roomType",
+  "roomHash",
+  "hasArtifact",
+  "roomComposition",
+] as const
+
+export function roomComposition(
+  participants: Array<Pick<UserInfo, "kind">>
+): RoomComposition {
+  let humans = 0
+  let agents = 0
+  for (const participant of participants) {
+    if (participant.kind === "human") humans += 1
+    if (participant.kind === "agent") agents += 1
+  }
+  if (agents === 0) return "human-only"
+  if (humans === 0) return "agent-only"
+  return agents === 1 ? "human-agent" : "mixed"
+}
+
+export function resolveParticipantKind(
+  context: CollabAnalyticsContext,
+  participantId: string
+): ResolvedParticipantKind {
+  if (
+    context.selfParticipantId !== undefined &&
+    participantId === context.selfParticipantId
+  ) {
+    return "human"
+  }
+  if (participantId === context.selfPeerId) return "human"
+  const participant = context.participants.find(
+    (entry) => entry.peerId === participantId
+  )
+  return participant?.kind ?? "unknown"
+}
+
+export interface CollabAnalyticsTracker {
+  /**
+   * Observe the current roster. Returns one payload per Agent participant
+   * id seen for the first time by this browser session; replay, reconnect,
+   * and re-render of already-seen participants return an empty array.
+   */
+  observePresence(context: CollabAnalyticsContext): AgentJoinedPayload[]
+  /**
+   * Observe one canonical collaboration envelope from Room state. Returns
+   * at most one analytics event per canonical requestId per browser
+   * session: the first observation of a request emits CollabRequested, the
+   * first observation of a terminal kind (declined/completed/failed) emits
+   * CollabOutcome, and every later observation of either returns null.
+   * accepted is an intermediate lifecycle kind and never emits.
+   */
+  observeCollabEvent(
+    context: CollabAnalyticsContext,
+    event: CollabEvent
+  ): CollabAnalyticsEmission | null
+}
+
+export function createCollabAnalyticsTracker(): CollabAnalyticsTracker {
+  const seenAgentParticipantIds = new Set<string>()
+  const seenRequestIds = new Set<string>()
+  const seenOutcomeRequestIds = new Set<string>()
+
+  return {
+    observePresence(context) {
+      const joined: AgentJoinedPayload[] = []
+      for (const participant of context.participants) {
+        if (participant.kind !== "agent") continue
+        if (seenAgentParticipantIds.has(participant.peerId)) continue
+        seenAgentParticipantIds.add(participant.peerId)
+        joined.push({
+          roomType: context.roomType,
+          roomHash: context.roomHash,
+          participantBucket: participantsBucket(context.participants.length),
+          roomComposition: roomComposition(context.participants),
+        })
+      }
+      return joined
+    },
+
+    observeCollabEvent(context, event) {
+      if (event.kind === "accepted") return null
+
+      if (event.kind === "request") {
+        // A request that already reached a terminal outcome in this session
+        // cannot rebuild the funnel; do not emit an out-of-order event.
+        if (
+          seenRequestIds.has(event.requestId) ||
+          seenOutcomeRequestIds.has(event.requestId)
+        ) {
+          return null
+        }
+        seenRequestIds.add(event.requestId)
+        const properties: CollabRequestedPayload = {
+          roomType: context.roomType,
+          roomHash: context.roomHash,
+          requesterKind: resolveParticipantKind(
+            context,
+            event.fromParticipantId
+          ),
+          targetKind: resolveParticipantKind(
+            context,
+            event.targetParticipantId
+          ),
+          roomComposition: roomComposition(context.participants),
+        }
+        return { name: "CollabRequested", properties }
+      }
+
+      // declined | completed | failed: terminal collaboration outcomes.
+      if (seenOutcomeRequestIds.has(event.requestId)) return null
+      seenOutcomeRequestIds.add(event.requestId)
+      const properties: CollabOutcomePayload = {
+        outcome: event.kind,
+        requesterKind: resolveParticipantKind(context, event.fromParticipantId),
+        targetKind: resolveParticipantKind(context, event.targetParticipantId),
+        roomType: context.roomType,
+        roomHash: context.roomHash,
+        hasArtifact: Array.isArray(event.attachmentIds)
+          ? event.attachmentIds.length > 0
+          : false,
+        roomComposition: roomComposition(context.participants),
+      }
+      return { name: "CollabOutcome", properties }
+    },
+  }
+}
+
+export const ANALYTICS_PROPERTY_KEYS = {
+  AgentJoined: AGENT_JOINED_PROPERTIES,
+  CollabRequested: COLLAB_REQUESTED_PROPERTIES,
+  CollabOutcome: COLLAB_OUTCOME_PROPERTIES,
+} as const

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -302,9 +302,11 @@ export default function RoomContent({
 
   // Human + Agent collaboration analytics: derived from canonical Room state
   // (the connected roster and persisted collaboration envelopes), never from
-  // clicks. The tracker keeps page-lifetime dedup sets so Room state refresh,
-  // resync replay, reconnect, and re-render never re-count the same Agent or
-  // the same canonical collab requestId.
+  // clicks. The tracker baselines the initial post-join snapshot (Agents and
+  // collaboration lifecycle that predate this browser's observation stay
+  // silent) and keeps page-lifetime dedup sets, so state refresh, resync
+  // replay, reconnect, and re-render never re-count the same Agent or the
+  // same canonical collab requestId.
   const collabAnalyticsRef = useRef<ReturnType<
     typeof createCollabAnalyticsTracker
   > | null>(null)
@@ -321,11 +323,18 @@ export default function RoomContent({
       participants,
       selfPeerId: LOCAL_PEER_ID,
       selfParticipantId: localParticipantId,
+      presenceBaseline: connectionStatus === "connected",
     }
     for (const properties of tracker.observePresence(context)) {
       trackAnalyticsEvent("AgentJoined", properties)
     }
-  }, [participants, roomName, resolvedRoomType, localParticipantId])
+  }, [
+    connectionStatus,
+    participants,
+    roomName,
+    resolvedRoomType,
+    localParticipantId,
+  ])
 
   useEffect(() => {
     const tracker = collabAnalyticsRef.current
@@ -339,7 +348,7 @@ export default function RoomContent({
     }
     messages.forEach((m) => {
       if (m.actionType !== "collab" || !m.collab) return
-      const emitted = tracker.observeCollabEvent(context, m.collab)
+      const emitted = tracker.observeCollabEvent(context, m.collab, m.createdAt)
       if (emitted) trackAnalyticsEvent(emitted.name, emitted.properties)
     })
   }, [messages, participants, roomName, resolvedRoomType, localParticipantId])

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -15,6 +15,7 @@ import TextChatCard from "./TextChatCard"
 import UserCard from "./UserCard"
 import WorkspaceSnapshots from "./WorkspaceSnapshots"
 import { buildAgentInvitePrompt } from "../common/agentInvite"
+import { createCollabAnalyticsTracker } from "../common/collabAnalytics"
 import type { UserInfo } from "../common/types"
 import {
   umamiEvent,
@@ -152,6 +153,7 @@ export default function RoomContent({
     voiceReplyMediaAvailable,
     startVoiceReply,
     stopVoiceReply,
+    localParticipantId,
   } = useSfuChatRoom(roomName, nickName, roomType, {
     getTurnstileToken: requestToken,
   })
@@ -297,6 +299,50 @@ export default function RoomContent({
 
     return () => window.clearTimeout(timeout)
   }, [connectionStatus, participants.length, resolvedRoomType])
+
+  // Human + Agent collaboration analytics: derived from canonical Room state
+  // (the connected roster and persisted collaboration envelopes), never from
+  // clicks. The tracker keeps page-lifetime dedup sets so Room state refresh,
+  // resync replay, reconnect, and re-render never re-count the same Agent or
+  // the same canonical collab requestId.
+  const collabAnalyticsRef = useRef<ReturnType<
+    typeof createCollabAnalyticsTracker
+  > | null>(null)
+  if (!collabAnalyticsRef.current) {
+    collabAnalyticsRef.current = createCollabAnalyticsTracker()
+  }
+
+  useEffect(() => {
+    const tracker = collabAnalyticsRef.current
+    if (!tracker) return
+    const context = {
+      roomType: resolvedRoomType,
+      roomHash: hashRoom(roomName),
+      participants,
+      selfPeerId: LOCAL_PEER_ID,
+      selfParticipantId: localParticipantId,
+    }
+    for (const properties of tracker.observePresence(context)) {
+      trackAnalyticsEvent("AgentJoined", properties)
+    }
+  }, [participants, roomName, resolvedRoomType, localParticipantId])
+
+  useEffect(() => {
+    const tracker = collabAnalyticsRef.current
+    if (!tracker) return
+    const context = {
+      roomType: resolvedRoomType,
+      roomHash: hashRoom(roomName),
+      participants,
+      selfPeerId: LOCAL_PEER_ID,
+      selfParticipantId: localParticipantId,
+    }
+    messages.forEach((m) => {
+      if (m.actionType !== "collab" || !m.collab) return
+      const emitted = tracker.observeCollabEvent(context, m.collab)
+      if (emitted) trackAnalyticsEvent(emitted.name, emitted.properties)
+    })
+  }, [messages, participants, roomName, resolvedRoomType, localParticipantId])
 
   useEffect(() => {
     messages.forEach((m) => {


### PR DESCRIPTION
## Summary

Smallest tracking change that makes the new core product question measurable:

> After somebody invites an Agent, did an Agent actually enter the Room and did a real Human↔Agent or Agent↔Agent collaboration happen?

Funnel: `AgentInviteCopied → AgentJoined → CollabRequested → CollabOutcome(outcome=completed)`.

Implemented **before** writing code, by inspecting current `cf-sfu`: participant join/presence lifecycle (`buildParticipants` / roster rebuild), Human vs Agent identity (`UserInfo.kind`, `LOCAL_PEER_ID` vs raw participant id), the canonical #106 collab envelope flow (`CollabEvent` kinds `request → accepted | declined → completed | failed` persisted as `actionType: "collab"` Room messages), DO-side request dedup (`CollabRegistry` rebuild), and the existing analytics helpers (`trackAnalyticsEvent` / `hashRoom` / `participantsBucket`) and tests.

## Event semantics

### 1. `AgentJoined`
- **Meaning:** a real Agent participant id appeared for the first time in the connected, server-authoritative roster observed by this browser. Not derived from `AgentInviteCopied` or any click.
- **Dedup:** page-lifetime `Set<participantId>` — React re-render, DO state refresh, resync replay, and Runtime reconnect/rejoin of the same participant never re-emit. A genuinely new Agent participant id later in the session emits once. Full page reload starts a new observer session (documented below).
- **Properties:** `roomType`, `roomHash` (`hashRoom`), `participantBucket` (existing `participantsBucket`), `roomComposition`.

### 2. `CollabRequested`
- **Meaning:** a canonical structured request envelope became part of the observed Room lifecycle — the first observation of `CollabEvent{kind: "request"}` in persisted Room state.
- **Dedup:** page-lifetime `Set<requestId>`; replay/re-delivery of the same canonical request never re-emits. If the outcome was already observed first, the later request envelope does not emit an out-of-order event.
- **Properties:** `roomType`, `roomHash`, `requesterKind`, `targetKind`, `roomComposition`.

### 3. `CollabOutcome` (single terminal event)
- **Meaning:** first observation of `kind: "completed" | "failed" | "declined"` for a request. `accepted` is intermediate and never emits.
- **Properties:** `outcome` (`completed | failed | declined`), `requesterKind`, `targetKind`, `roomType`, `roomHash`, `hasArtifact` (boolean from attachment presence only), `roomComposition`.
- Terminal kinds are deduped by `Set<requestId>` independent of the request set, so an outcome observed without its request envelope still counts exactly once.

### Property values
- `roomComposition` (low-cardinality, from the roster at emit time): `human-agent` (Humans + exactly 1 Agent) · `agent-only` (no Humans) · `mixed` (Humans + ≥2 Agents) · `human-only` (defensive; only reachable when every Agent already left).
- `requesterKind` / `targetKind`: `human | agent | unknown` (`unknown` = participant no longer in the roster and not self).
- **Never sent:** room names, nicknames, Agent names, raw participant ids, raw request ids, prompts/summaries/details, capability strings, filenames, attachment ids, or any Harness/tool/credential information.

## Where events are emitted

`app/src/components/RoomContent.tsx` — two effects observing canonical state: the connected roster (`AgentJoined`) and persisted collaboration envelopes in Room messages (`CollabRequested` / `CollabOutcome`), following the existing `processedReactionIds` dedup pattern. Pure derivation/dedup logic lives in `app/src/common/collabAnalytics.ts` (no React, no analytics calls of its own) so the semantics are unit-testable. All emission goes through the existing `trackAnalyticsEvent` (Umami + Cloudflare Zaraz/Mixpanel) and is fire-and-forget; analytics can never block or fail collaboration.

## Replay / reconnect duplication

Zaraz → Mixpanel transport has no code-level guarantee of a deterministic `` passthrough (Mixpanel tag mapping lives in the Cloudflare dashboard, not this repo), so instead of a speculative insert id this PR uses the simplest local dedup consistent with existing Room event processing: page-lifetime `Set`s keyed by Agent participant id and canonical `requestId`, matching how the DO itself dedups collab retries by `requestId`. No persistent dedup store, no new infrastructure.

## Known limitation: Humanless Agent-only Rooms

There is no existing Worker/DO-side analytics sink (verified: `do/`, `sfu/`, `mcp/`, `worker.ts` contain no analytics calls), and this PR deliberately does not introduce a server-side Mixpanel SDK, token, queue, or service.

> Current Mixpanel collaboration tracking measures browser-observed Rooms and does not yet measure fully Humanless Agent-only Rooms.

Additionally, each observing Human browser counts a canonical request once (per-observer semantics); the funnel in Mixpanel is read per user/session, so this does not distort per-user funnels.

## Product boundaries — unchanged

No Runtime lifecycle, MCP protocol, ACP, collab protocol/schema, request/result semantics, Durable Object retention, reconnect/replay, media/SFU, auth, Room grant, or #160 A2A changes. Diff is additive: one 46-line wiring block in `RoomContent` plus one pure module and its tests.

## Files changed

- `app/src/common/collabAnalytics.ts` (new) — payload types, composition/kind derivation, dedup tracker
- `app/src/common/collabAnalytics.test.ts` (new) — the 8 required semantics: Human presence never emits; Agent presence emits once; replay/re-render/reconnect never re-emit; one `CollabRequested` per canonical request; exact outcomes for completed/failed/declined; duplicate terminal states never re-emit; exact property key sets + payload serialization free of private content; existing helper `participantsBucket` reused
- `app/src/components/RoomContent.tsx` — destructure `localParticipantId`, tracker ref, two observation effects

## Local validation (from actual checkout)

- `npx prettier --check .` ✅
- `yarn lint --max-warnings 0` ✅
- `yarn type-check` ✅
- `yarn test` ✅ 33 files / 372 tests (9 new)
- `yarn cf-build` ✅ (OpenNext Worker build completes locally; production secrets only needed at deploy time)

Refs #51, #106, #155.

## Review fix: original delegation topology + observation baseline

- **CollabOutcome direction.** Production rewrites response/result envelopes in the reverse direction (`do/collab.ts`: `from=responder` — the original target — and `target=the original requester`). All envelopes are now normalized through `delegationTopology()`, so `requesterKind`/`targetKind` consistently mean the ORIGINAL Human → Agent (or Agent → Agent) delegation across `CollabRequested` and `CollabOutcome`. Tests construct terminal envelopes with the same reversed routing shape production emits.
- **Observation baseline.** Facts that predate this browser's observation never emit under its identity:
  - Agents present in the initial post-join snapshot (first roster observation after the connection is established) are baselined silently; only Agents appearing afterwards emit `AgentJoined` exactly once.
  - Collaboration envelopes whose persisted DO-side `createdAt` predates the tracker's observation start are recorded silently — entering/reloading a Room with retained history never reattributes the old lifecycle to the new browser observation (same pre-join boundary tradeoff as the existing reaction guard).
  - Genuinely new requests/outcomes after observation began emit exactly once; replay/reconnect of them never duplicates. An initially empty room baselines cleanly so the first real Agent join emits.
- The Humanless Agent-only Rooms limitation is unchanged.
