### PR TITLE
chore: drop the Powered by i365.tech footer on the homepage

### DIFF
--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -250,17 +250,6 @@ export default function Home() {
               This website will collect some runtime technical data for
               debugging, using at your risk.
             </p>
-            <p className="mt-3 text-center text-xs text-gray-600">
-              Powered by{" "}
-              <a
-                href="https://www.i365.tech/"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-gray-400 underline-offset-2 hover:text-gray-300 hover:underline"
-              >
-                i365.tech
-              </a>
-            </p>
           </div>
         </div>
         <DiscoveryFooter />


### PR DESCRIPTION
## Summary

Removes the `Powered by i365.tech` credit line from the homepage footer.

## Changes

- `app/src/pages/index.tsx`: delete the one `<p>` block (the runtime-data disclaimer above it stays).

## Scope

- Only occurrence of `i365.tech` / `Powered by` in the repo (README, DEVELOPMENT.md, AGENTS.md, and all other pages checked).
- No copy, layout, analytics, or behavior changes beyond removing that line.

## Validation

- `npx prettier --check .` ✅
- `yarn lint --max-warnings 0` ✅
- `yarn type-check` ✅
- `yarn test` ✅ 33 files / 378 tests
- `yarn build` ✅