### PR TITLE
test: clean up detached Agent daemons after CLI tests

### DIFF
--- a/agent/internal/cli/cli_test.go
+++ b/agent/internal/cli/cli_test.go
@@ -2,11 +2,17 @@ package cli
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
+
+	"github.com/i365dev/free4chat/agent/internal/daemon"
 )
 
 var binaryPath string
@@ -14,6 +20,11 @@ var binaryPath string
 // TestMain builds the real free4chat-agent binary once: the routing
 // regression guard (#105 review) pins dispatcher behavior via subprocess
 // exits, which requires the actual executable.
+//
+// After the suite it also enforces the #172 leak invariant: ZERO daemon
+// process spawned by these tests may survive. The scan is keyed on the full
+// unique build path, so it can only ever observe processes from THIS test
+// run — the user's canonical ~/.free4chat-agent daemon can never match.
 func TestMain(m *testing.M) {
 	dir, err := os.MkdirTemp("", "fcagent-cli-")
 	if err != nil {
@@ -26,8 +37,115 @@ func TestMain(m *testing.M) {
 	}
 	binaryPath = bin
 	code := m.Run()
+	leaked := waitForNoTestDaemons(5 * time.Second)
+	if len(leaked) > 0 {
+		fmt.Fprintf(os.Stderr,
+			"\nFAIL: %d detached free4chat-agent daemon(s) leaked from CLI tests (owned by %s):\n",
+			len(leaked), bin)
+		for _, provenance := range leaked {
+			fmt.Fprintln(os.Stderr, "  "+provenance)
+		}
+		if code == 0 {
+			code = 1
+		}
+	}
 	_ = os.RemoveAll(dir)
 	os.Exit(code)
+}
+
+// testDaemonProcs lists "PID command" lines for every process whose command
+// line contains this run's built binary path. pgrep exits 1 on "no match",
+// which is the healthy empty case.
+func testDaemonProcs() ([]string, error) {
+	out, err := exec.Command("pgrep", "-f", regexp.QuoteMeta(binaryPath)).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var provenance []string
+	for _, pid := range strings.Fields(string(out)) {
+		command, procErr := exec.Command("ps", "-p", pid, "-o", "command=").Output()
+		if procErr != nil {
+			// The process may have exited between pgrep and ps: it is gone,
+			// which is the desired state.
+			continue
+		}
+		provenance = append(provenance, strings.TrimSpace(pid+" "+string(command)))
+	}
+	return provenance, nil
+}
+
+// waitForNoTestDaemons polls until no test-owned daemon process remains and
+// returns whatever still survives when the deadline passes.
+func waitForNoTestDaemons(timeout time.Duration) []string {
+	deadline := time.Now().Add(timeout)
+	for {
+		procs, err := testDaemonProcs()
+		if err == nil && len(procs) == 0 {
+			return nil
+		}
+		if err != nil {
+			// The process scan itself is unavailable (no pgrep/ps): degrade
+			// to a warning instead of a false failure.
+			fmt.Fprintf(os.Stderr, "warning: daemon leak scan unavailable: %v\n", err)
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return procs
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}
+
+// withAgentDir scopes FREE4CHAT_AGENT_DIR for one helper call and always
+// restores the previous environment.
+func withAgentDir(dir string, fn func()) {
+	previous, had := os.LookupEnv("FREE4CHAT_AGENT_DIR")
+	_ = os.Setenv("FREE4CHAT_AGENT_DIR", dir)
+	defer func() {
+		if had {
+			_ = os.Setenv("FREE4CHAT_AGENT_DIR", previous)
+		} else {
+			_ = os.Unsetenv("FREE4CHAT_AGENT_DIR")
+		}
+	}()
+	fn()
+}
+
+// daemonReachable reports whether a daemon answers a status probe on this
+// runtime directory's socket.
+func daemonReachable(dir string) bool {
+	reachable := false
+	withAgentDir(dir, func() {
+		_, err := daemon.SendIPC(&daemon.IpcRequest{Op: "status"})
+		reachable = err == nil
+	})
+	return reachable
+}
+
+// stopTestDaemon reclaims the daemon owned by THIS test's runtime directory
+// (#172): it uses the daemon's own stop op over IPC — never a signal or
+// pattern kill — and then waits deterministically until the socket stops
+// answering, which the daemon guarantees during its own shutdown. A daemon
+// that was never spawned for this directory is a no-op.
+func stopTestDaemon(t *testing.T, dir string) {
+	t.Helper()
+	if !daemonReachable(dir) {
+		return
+	}
+	withAgentDir(dir, func() {
+		_, _ = daemon.SendIPC(&daemon.IpcRequest{Op: "stop"})
+	})
+	deadline := time.Now().Add(5 * time.Second)
+	for daemonReachable(dir) {
+		if time.Now().After(deadline) {
+			t.Errorf("test daemon in %s kept its IPC socket after the stop op", dir)
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
 }
 
 func runCli(t *testing.T, args ...string) (string, int) {
@@ -36,7 +154,15 @@ func runCli(t *testing.T, args ...string) (string, int) {
 	if err != nil {
 		t.Fatalf("temp dir failed: %v", err)
 	}
-	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	// #172: any invocation that routes through the daemon (status, leave,
+	// stop, ...) auto-starts a detached daemon in this unique directory via
+	// EnsureDaemon. Reclaim exactly that daemon during cleanup — production
+	// detach semantics stay untouched, and no other daemon can ever match.
+	// Stop MUST happen before the directory removal (socket lives in it).
+	t.Cleanup(func() {
+		stopTestDaemon(t, dir)
+		_ = os.RemoveAll(dir)
+	})
 	cmd := exec.Command(binaryPath, args...)
 	cmd.Env = append(os.Environ(),
 		"FREE4CHAT_AGENT_DIR="+dir,
@@ -54,6 +180,58 @@ func runCli(t *testing.T, args ...string) (string, int) {
 	}
 	t.Fatalf("cli run failed: %v", err)
 	return out, -1
+}
+
+// TestTestDaemonStopIsScopedAndDeterministic pins the reclaim contract the
+// whole suite relies on: the daemon's own stop op tears down the socket and
+// then the process, without any signal or pattern kill, and nothing else is
+// affected.
+func TestTestDaemonStopIsScopedAndDeterministic(t *testing.T) {
+	dir, err := os.MkdirTemp("", "fcagent-")
+	if err != nil {
+		t.Fatalf("temp dir failed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+
+	command := exec.Command(binaryPath, "daemon")
+	command.Env = append(os.Environ(),
+		"FREE4CHAT_AGENT_DIR="+dir,
+		"FREE4CHAT_TEST_DISABLE_NATIVE_CREDENTIAL_STORE=1",
+	)
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if err := command.Start(); err != nil {
+		t.Fatalf("daemon spawn failed: %v", err)
+	}
+	exited := make(chan struct{})
+	go func() {
+		_ = command.Wait()
+		close(exited)
+	}()
+	// Safety net so a mid-test failure cannot leak the daemon past the
+	// TestMain invariant scan.
+	t.Cleanup(func() {
+		_ = command.Process.Kill()
+		<-exited
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	for !daemonReachable(dir) {
+		if time.Now().After(deadline) {
+			t.Fatalf("test daemon never answered on its socket")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	stopTestDaemon(t, dir)
+
+	if daemonReachable(dir) {
+		t.Fatalf("socket must stop answering after the daemon's own stop op")
+	}
+	select {
+	case <-exited:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("daemon process must exit after its stop op")
+	}
 }
 
 func TestCliRoutingNeverFallsThroughSilently(t *testing.T) {


### PR DESCRIPTION
Closes #172. **Not merged** — opened for review.

## Root cause (code-confirmed)

`agent/internal/cli/cli_test.go` builds the real `free4chat-agent` binary and runs every CLI invocation with a unique `FREE4CHAT_AGENT_DIR`. Any op routed through `runViaDaemon` → `EnsureDaemon()` → (no socket) → spawn **detached** `free4chat-agent daemon` (`Setpgid`, `Process.Release()`). The test cleanup only removed the temp directory — never the daemon. Measured on a real dogfood machine before this fix: **130 surviving test daemons**.

## Fix — smallest robust design

- **Per-invocation reclaim**: each `runCli` cleanup stops the daemon owned by *its own* runtime directory using the daemon's **own `stop` op over IPC** (the production shutdown path: `beginStop` → reply → listener teardown → process exit), then deterministically waits until that socket stops answering. No `pkill`, no signals, no process-group sweeps — a daemon that was never spawned for that directory is a no-op, and the user's canonical `~/.free4chat-agent` daemon can never match.
- **Hard invariant in `TestMain`**: after the suite, a bounded scan lists processes whose command line contains *this run's unique build path* (`fcagent-cli-<rand>/free4chat-agent`) — provenance that can only match daemons spawned by this test run. Any survivor fails the suite with full PID + command output. `regexp.QuoteMeta` keeps the pattern literal; if `pgrep`/`ps` are unavailable the scan degrades to a warning instead of a false failure.
- Production `EnsureDaemon` detach semantics are unchanged; real subprocess/CLI routing coverage is unchanged.

Also fixes a subtle ordering bug the first attempt caught via its own invariant: cleanup is LIFO, so directory removal must happen *after* the IPC stop or the socket file disappears before the stop probe.

## Tests

- `TestTestDaemonStopIsScopedAndDeterministic` — spawns a real daemon, pins the full contract: socket answers → stop op → socket dead → process reaped (bounded polls, no sleep-and-hope).
- `TestMain` leak scan runs on **every** `go test` invocation of the package.

## Regression verification (as specified by #172)

- `pgrep -f 'fcagent-cli-'` baseline: 130 (pre-fix accumulation, cleaned); post-fix runs: **0**
- `go test ./internal/cli/ -count=3` → ok, leaked: **0**
- `go test ./... -count=1` (11 packages) → ok, leaked: **0**
- `gofmt` clean, `go vet ./...` clean, `go build ./cmd/free4chat-agent`, linux cross-build OK, `scripts/check-cleanup.sh` OK