### PR TITLE
ux: choose the Voice Reply Agent explicitly

### DIFF
--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -99,6 +99,8 @@ export default function RoomContent({
   const [roomLinkCopied, setRoomLinkCopied] = useState(false)
   const [agentInviteCopied, setAgentInviteCopied] = useState(false)
   const [meetingNotesPickerOpen, setMeetingNotesPickerOpen] = useState(false)
+  // #170: explicit Voice Reply speaker selection.
+  const [voiceReplyPickerOpen, setVoiceReplyPickerOpen] = useState(false)
   const [pendingFiles, setPendingFiles] = useState<
     {
       id: string
@@ -175,16 +177,26 @@ export default function RoomContent({
   const roomAgents = participants.filter((p) => p.kind === "agent")
   // Defensive defaults keep partial hook mocks in tests valid.
   const voiceReply = voiceReplyState ?? { active: false }
-  const connectedAgentForVoice = roomAgents[0]
-  const handleStartVoiceReply = () => {
-    if (!connectedAgentForVoice) return
-    startVoiceReply(connectedAgentForVoice.peerId)
+  // #170: Voice Reply must be explicitly bound to a Human-chosen speaker.
+  // Never silently pick the first Agent in roster order: roster order is
+  // incidental, and an unattended binding can wake the wrong Agent's voice.
+  const handleStartVoiceReply = (agentParticipantId: string) => {
+    startVoiceReply(agentParticipantId)
+    setVoiceReplyPickerOpen(false)
     trackAnalyticsEvent("AgentVoiceStarted", { roomType: resolvedRoomType })
   }
   const handleStopVoiceReply = () => {
     stopVoiceReply()
     trackAnalyticsEvent("AgentVoiceStopped", { roomType: resolvedRoomType })
   }
+  // #170: the active speaker is derived from the server-held grant state;
+  // when the selected Agent departs and the server clears the grant, the UI
+  // goes inactive — never auto-migrated to a rejoined Agent with the same
+  // name (participant ids, not names, are the authorization identity).
+  const voiceReplySpeakerName = voiceReply.active
+    ? roomAgents.find((p) => p.peerId === voiceReply.agentParticipantId)
+        ?.name ?? "an Agent"
+    : null
   const meetingNotesAgentName = meetingNotes.active
     ? roomAgents.find((p) => p.peerId === meetingNotes.agentParticipantId)
         ?.name ?? "an Agent"
@@ -589,21 +601,44 @@ export default function RoomContent({
               type="button"
               onClick={handleStopVoiceReply}
               className="rounded-md border border-rose-700/60 bg-rose-900/30 px-3 py-1 text-xs text-rose-200 hover:bg-rose-800/50"
-              title="Stop Agent voice replies"
+              title={`Stop voice replies from ${voiceReplySpeakerName}`}
             >
-              🔊 Stop voice
+              🔊 Voice: {voiceReplySpeakerName}
             </button>
           ) : (
-            voiceReplyMediaAvailable &&
-            connectedAgentForVoice && (
-              <button
-                type="button"
-                onClick={handleStartVoiceReply}
-                className="rounded-md border border-emerald-700/60 bg-emerald-900/30 px-3 py-1 text-xs text-emerald-200 hover:bg-emerald-800/50"
-                title={`Enable voice replies from ${connectedAgentForVoice.name}`}
-              >
-                🔊 Voice replies
-              </button>
+            voiceReplyMediaAvailable && (
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={() => setVoiceReplyPickerOpen((open) => !open)}
+                  disabled={roomAgents.length === 0}
+                  className="flex items-center gap-1 rounded-md border border-gray-700 bg-gray-800 px-3 py-1 text-xs text-gray-300 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50"
+                  title={
+                    roomAgents.length === 0
+                      ? "Invite an Agent to the room first"
+                      : "Choose the voice reply speaker"
+                  }
+                >
+                  🔊 Voice replies
+                </button>
+                {voiceReplyPickerOpen && roomAgents.length > 0 && (
+                  <div className="absolute right-0 top-full z-20 mt-1 w-48 rounded-md border border-gray-700 bg-gray-800 py-1 shadow-lg">
+                    <p className="px-3 py-1 text-[10px] uppercase tracking-wide text-gray-500">
+                      Speaker
+                    </p>
+                    {roomAgents.map((agent) => (
+                      <button
+                        key={agent.peerId}
+                        type="button"
+                        onClick={() => handleStartVoiceReply(agent.peerId)}
+                        className="block w-full truncate px-3 py-1.5 text-left text-xs text-gray-200 hover:bg-gray-700"
+                      >
+                        {agent.name}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             )
           )}
           {meetingNotes.active ? (

--- a/app/src/components/RoomContent.voiceReply.test.tsx
+++ b/app/src/components/RoomContent.voiceReply.test.tsx
@@ -1,0 +1,251 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+/**
+ * #170 production wiring proof: Voice Reply must be bound only to an
+ * explicitly selected current Agent — never silently to roomAgents[0] — the
+ * active speaker label is derived from the server-held grant, and a departed
+ * speaker's grant clear returns the UI to inactive without auto-migration.
+ * Meeting Notes semantics stay untouched.
+ */
+
+vi.mock("next/router", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+const mockUseSfuChatRoom = vi.fn()
+vi.mock("../hooks/useSfuChatRoom", () => ({
+  useSfuChatRoom: (...args: unknown[]) => mockUseSfuChatRoom(...args),
+}))
+vi.mock("../hooks/useTurnstile", () => ({
+  useTurnstile: () => ({
+    containerRef: { current: null },
+    requestToken: vi.fn(),
+  }),
+}))
+
+import RoomContent from "./RoomContent"
+
+const AGENT_PI = "participant-pi"
+const AGENT_HERMES = "participant-hermes"
+const AGENT_CODEX = "participant-codex"
+
+function agentParticipants(order: Array<[string, string]>) {
+  return [
+    {
+      peerId: "human-h",
+      name: "Hannah",
+      kind: "human" as const,
+      room: "test-room",
+    },
+    ...order.map(([peerId, name]) => ({
+      peerId,
+      name,
+      kind: "agent" as const,
+      room: "test-room",
+    })),
+  ]
+}
+
+beforeEach(() => {
+  // jsdom lacks scrollIntoView; TextChatCard auto-scrolls on new messages.
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+afterEach(cleanup)
+
+function renderRoom({
+  participants,
+  voiceReply = { active: false },
+  meetingNotes = { active: false },
+}: {
+  participants: ReturnType<typeof agentParticipants>
+  voiceReply?: { active: boolean; agentParticipantId?: string }
+  meetingNotes?: { active: boolean; agentParticipantId?: string }
+}) {
+  const startVoiceReply = vi.fn()
+  const stopVoiceReply = vi.fn()
+  const startMeetingNotes = vi.fn()
+  const stopMeetingNotes = vi.fn()
+  mockUseSfuChatRoom.mockReturnValue({
+    participants,
+    messages: [],
+    sendTextMessage: vi.fn(),
+    sendFileMessage: vi.fn(),
+    sendCollabRequest: vi.fn(() => ""),
+    sendCollabResponse: vi.fn(),
+    sendCollabResult: vi.fn(),
+    updateHumanCapabilities: vi.fn(),
+    getLocalRoomAuth: vi.fn(() => ({
+      roomId: "test-room",
+      participantId: "human-h",
+      token: "tok",
+    })),
+    readRoomAttachment: vi.fn(),
+    muteSelf: vi.fn(),
+    toggleScreenShare: vi.fn(),
+    retryVerification: vi.fn(),
+    error: "",
+    connectionStatus: "connected",
+    resolvedRoomType: "audio",
+    meetingNotes,
+    meetingNotesMediaAvailable: true,
+    startMeetingNotes,
+    stopMeetingNotes,
+    voiceReply,
+    voiceReplyMediaAvailable: true,
+    startVoiceReply,
+    stopVoiceReply,
+    localParticipantId: "human-h",
+  })
+  render(
+    <RoomContent roomName="test-room" nickName="Hannah" roomType="audio" />
+  )
+  return {
+    startVoiceReply,
+    stopVoiceReply,
+    startMeetingNotes,
+    stopMeetingNotes,
+  }
+}
+
+// #170: agent names also render on roster UserCards, so picker assertions
+// must be scoped to the dropdown (located via its "Speaker" header).
+function voicePicker(): HTMLElement {
+  const header = screen.getByText("Speaker")
+  const dropdown = header.parentElement
+  if (!dropdown) throw new Error("voice reply picker dropdown not rendered")
+  return dropdown as HTMLElement
+}
+
+describe("Voice Reply explicit speaker selection (#170)", () => {
+  it("never starts voice replies silently: the picker lists every Agent", () => {
+    const { startVoiceReply } = renderRoom({
+      participants: agentParticipants([
+        [AGENT_PI, "Pi-Agent"],
+        [AGENT_HERMES, "Hermes"],
+        [AGENT_CODEX, "Codex"],
+      ]),
+    })
+
+    fireEvent.click(screen.getByText("🔊 Voice replies"))
+    // Opening the picker starts nothing by itself.
+    expect(startVoiceReply).not.toHaveBeenCalled()
+    // Every roster Agent appears in the picker, in roster order.
+    const picker = voicePicker()
+    expect(within(picker).getByText("Pi-Agent")).toBeTruthy()
+    expect(within(picker).getByText("Hermes")).toBeTruthy()
+    expect(within(picker).getByText("Codex")).toBeTruthy()
+    // Dismissing without choosing still starts nothing.
+    fireEvent.click(screen.getByText("🔊 Voice replies"))
+    expect(startVoiceReply).not.toHaveBeenCalled()
+  })
+
+  it("selecting a non-first Agent binds exactly that participantId", () => {
+    const { startVoiceReply } = renderRoom({
+      participants: agentParticipants([
+        [AGENT_PI, "Pi-Agent"],
+        [AGENT_HERMES, "Hermes"],
+        [AGENT_CODEX, "Codex"],
+      ]),
+    })
+
+    fireEvent.click(screen.getByText("🔊 Voice replies"))
+    fireEvent.click(within(voicePicker()).getByText("Hermes"))
+    expect(startVoiceReply).toHaveBeenCalledTimes(1)
+    expect(startVoiceReply).toHaveBeenCalledWith(AGENT_HERMES)
+    // The picker closes after an explicit selection.
+    expect(screen.queryByText("Speaker")).toBeNull()
+  })
+
+  it("selection follows the clicked entry, not roster order", () => {
+    // Same three Agents, deliberately rotated roster order.
+    const first = renderRoom({
+      participants: agentParticipants([
+        [AGENT_PI, "Pi-Agent"],
+        [AGENT_HERMES, "Hermes"],
+        [AGENT_CODEX, "Codex"],
+      ]),
+    })
+    fireEvent.click(screen.getByText("🔊 Voice replies"))
+    fireEvent.click(within(voicePicker()).getByText("Codex"))
+    expect(first.startVoiceReply).toHaveBeenCalledWith(AGENT_CODEX)
+
+    cleanup()
+
+    const second = renderRoom({
+      participants: agentParticipants([
+        [AGENT_CODEX, "Codex"],
+        [AGENT_PI, "Pi-Agent"],
+        [AGENT_HERMES, "Hermes"],
+      ]),
+    })
+    fireEvent.click(screen.getByText("🔊 Voice replies"))
+    fireEvent.click(within(voicePicker()).getByText("Codex"))
+    expect(second.startVoiceReply).toHaveBeenCalledWith(AGENT_CODEX)
+  })
+
+  it("active grant shows the selected speaker, not a generic stop label", () => {
+    const { stopVoiceReply } = renderRoom({
+      participants: agentParticipants([
+        [AGENT_PI, "Pi-Agent"],
+        [AGENT_HERMES, "Hermes"],
+      ]),
+      voiceReply: { active: true, agentParticipantId: AGENT_HERMES },
+    })
+
+    expect(screen.getByText(/Voice: Hermes/)).toBeTruthy()
+    fireEvent.click(screen.getByText(/Voice: Hermes/))
+    expect(stopVoiceReply).toHaveBeenCalledTimes(1)
+    // The stop path is still wired to the hook.
+    expect(screen.queryByText("🔊 Voice replies")).toBeNull()
+  })
+
+  it("a departed speaker or server-cleared grant returns the UI to inactive", () => {
+    // Speaker left the roster while the grant still names it: no crash, no
+    // migration — the label degrades honestly.
+    renderRoom({
+      participants: agentParticipants([[AGENT_PI, "Pi-Agent"]]),
+      voiceReply: { active: true, agentParticipantId: AGENT_HERMES },
+    })
+    expect(screen.getByText(/Voice: an Agent/)).toBeTruthy()
+
+    cleanup()
+
+    // Server cleared the grant after departure: the UI offers a fresh,
+    // explicit selection again — never an automatic rebind.
+    const { startVoiceReply } = renderRoom({
+      participants: agentParticipants([
+        [AGENT_PI, "Pi-Agent"],
+        [AGENT_HERMES, "Hermes"],
+      ]),
+      voiceReply: { active: false },
+    })
+    expect(screen.getByText("🔊 Voice replies")).toBeTruthy()
+    expect(screen.queryByText(/Voice:/)).toBeNull()
+    fireEvent.click(screen.getByText("🔊 Voice replies"))
+    fireEvent.click(within(voicePicker()).getByText("Hermes"))
+    expect(startVoiceReply).toHaveBeenCalledWith(AGENT_HERMES)
+  })
+
+  it("Meeting Notes keeps its own explicit note-taker picker unchanged", () => {
+    const { stopMeetingNotes } = renderRoom({
+      participants: agentParticipants([
+        [AGENT_PI, "Pi-Agent"],
+        [AGENT_HERMES, "Hermes"],
+      ]),
+      meetingNotes: { active: true, agentParticipantId: AGENT_PI },
+    })
+
+    expect(
+      screen.getByText(/Meeting Notes — Listening… \(Pi-Agent\)/)
+    ).toBeTruthy()
+    fireEvent.click(screen.getByText("📝 Stop"))
+    expect(stopMeetingNotes).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Closes #170. **Not merged** — opened for review.

## Root cause (code-confirmed in RoomContent)

```ts
const connectedAgentForVoice = roomAgents[0]
startVoiceReply(connectedAgentForVoice.peerId)
```

Voice Reply was silently bound to the first Agent in roster order — an incidental position, not a decision. In a multi-Agent Room the voice grant could wake the wrong Agent's voice.

## Fix

- Voice Reply now reuses the **Meeting Notes picker interaction**: click `🔊 Voice replies` → pick a `Speaker` → `startVoiceReply(<explicit current participantId>)`. With any number of Agents the binding is always an explicit Human decision; nothing starts silently.
- While active, the control reads `🔊 Voice: <name>` (resolved from the server-held grant's `agentParticipantId`), replacing the generic `Stop voice` label.
- Selected Agent departs → server clears the grant (`clearVoiceReplyIfParticipantDeparting`) → UI returns to inactive with a fresh explicit picker. **No auto-migration** to a rejoined Agent with the same name — participant IDs, not names, remain the authorization identity.
- No credential/provider-key probing, no credential state exposed. Meeting Notes semantics unchanged; #165 text targeting untouched.
- Desktop/mobile share the same cluster styling already used by the Meeting Notes picker.

## Tests (`RoomContent.voiceReply.test.tsx`, 6)

1. Multi-Agent (3) room: opening the picker starts nothing; every roster Agent is listed.
2. Selecting a **non-first** Agent binds exactly that participantId; picker closes.
3. Selection follows the clicked entry under a rotated roster order (order-independence).
4. Active grant shows `Voice: Hermes` and stop stays wired.
5. Departed speaker label degrades honestly (`Voice: an Agent`); cleared grant returns an inactive UI with no automatic rebind.
6. Meeting Notes picker/stop controls unchanged (regression).

## Validation

- `prettier --check` (touched files + CI style), `eslint --max-warnings 0`, `tsc --noEmit`, `vitest` **412 passed (37 files)**, `next build` — all green.