### PR TITLE
fix(agent): report speech prerequisites for the active grant

### DIFF
--- a/agent/internal/media/controller.go
+++ b/agent/internal/media/controller.go
@@ -27,9 +27,11 @@ type ControllerOptions struct {
 	// OnTrackStarted/Ended mirror media bridge events (transcriber wiring).
 	OnTrackStarted func(source speech.AudioSource)
 	OnTrackEnded   func(source speech.AudioSource)
-	// OnGrantActivated fires once per successful grant activation (the
-	// runtime uses it to check speech readiness at grant time).
-	OnGrantActivated func()
+	// OnGrantActivated fires on each grant activation EDGE (#171): a grant
+	// newly targeting this participant, or a fresh epoch of it. The runtime
+	// uses it to evaluate that grant's own speech prerequisite once — never
+	// per poll.
+	OnGrantActivated func(kind GrantKind)
 	// Voice configures outbound Voice Reply (nil = Meeting Notes only).
 	Voice *VoiceConfig
 	// Log receives bounded safe events.
@@ -48,6 +50,16 @@ type VoiceConfig struct {
 	OnSpeakerEvent    func(voice.SpeakerEvent)
 }
 
+// GrantKind identifies which room media grant produced an activation edge.
+// Meeting Notes and Voice Reply are independent grants over one shared
+// media bridge; each carries its own speech prerequisite.
+type GrantKind string
+
+const (
+	GrantMeetingNotes GrantKind = "meeting_notes"
+	GrantVoiceReply   GrantKind = "voice_reply"
+)
+
 // Controller owns the Runtime-side half of the media lifecycle: it polls
 // room_info for the Meeting Notes and voiceReply grants and starts/stops the
 // ONE shared Bridge accordingly. This is the ONLY thing that decides when
@@ -64,12 +76,20 @@ type Controller struct {
 	voiceEpoch         *int64
 	voiceObservedEpoch *int64
 	voiceObservedInit  bool
-	bridge             *Bridge
-	speaker            *voice.Speaker
-	voiceStarting      bool
-	stopped            bool
-	cancel             context.CancelFunc
-	now                func() time.Time
+	// #171 grant-announcement state: the last grant instance (kind + epoch)
+	// whose activation edge was already reported, so an unchanged grant
+	// never re-fires while polls continue. Re-armed when the grant stops
+	// targeting this participant.
+	mnAnnounced      bool
+	mnAnnouncedEpoch *int64
+	vrAnnounced      bool
+	vrAnnouncedEpoch *int64
+	bridge           *Bridge
+	speaker          *voice.Speaker
+	voiceStarting    bool
+	stopped          bool
+	cancel           context.CancelFunc
+	now              func() time.Time
 }
 
 // NewController builds an idle controller.
@@ -222,11 +242,47 @@ func (c *Controller) poll() {
 		}
 	}
 
+	// #171: per-grant activation edges. Each grant announces ONCE per grant
+	// instance (kind + epoch): a grant that stays active across polls never
+	// re-fires; a stop/start (new epoch) or a reassignment to this
+	// participant produces a fresh edge. Edges fire even while the shared
+	// bridge is already running, so a second grant added later still gets
+	// its own prerequisite evaluation without splitting the bridge.
 	c.mu.Lock()
 	stopped = c.stopped
+	// A missing epoch (malformed/partial room_info) never participates in
+	// edge comparison: an already-announced grant cannot re-fire from it.
+	mnEdge := authorized &&
+		(!c.mnAnnounced || (epoch != nil && !int64Equal(c.mnAnnouncedEpoch, epoch)))
+	vrEdge := vrAuthorized &&
+		(!c.vrAnnounced || (vrEpoch != nil && !int64Equal(c.vrAnnouncedEpoch, vrEpoch)))
+	if mnEdge {
+		c.mnAnnounced = true
+		if epoch != nil {
+			c.mnAnnouncedEpoch = epoch
+		}
+	} else if !authorized {
+		c.mnAnnounced = false
+		c.mnAnnouncedEpoch = nil
+	}
+	if vrEdge {
+		c.vrAnnounced = true
+		if vrEpoch != nil {
+			c.vrAnnouncedEpoch = vrEpoch
+		}
+	} else if !vrAuthorized {
+		c.vrAnnounced = false
+		c.vrAnnouncedEpoch = nil
+	}
 	c.mu.Unlock()
 	if stopped {
 		return
+	}
+	if mnEdge && c.options.OnGrantActivated != nil {
+		c.options.OnGrantActivated(GrantMeetingNotes)
+	}
+	if vrEdge && c.options.OnGrantActivated != nil {
+		c.options.OnGrantActivated(GrantVoiceReply)
 	}
 
 	anyGrantActive := authorized || vrAuthorized
@@ -352,9 +408,6 @@ func (c *Controller) ensureRunning() {
 	c.state = "running"
 	c.mu.Unlock()
 	c.log("meeting_notes_media_started", nil)
-	if c.options.OnGrantActivated != nil {
-		c.options.OnGrantActivated()
-	}
 }
 
 func (c *Controller) buildBridge() (*Bridge, error) {

--- a/agent/internal/media/controller.go
+++ b/agent/internal/media/controller.go
@@ -204,6 +204,11 @@ func (c *Controller) poll() {
 	var epoch *int64
 	vrAuthorized := false
 	var vrEpoch *int64
+	// #175 review fix: only a SUCCESSFUL RoomInfo observation may re-arm the
+	// announcement state. A transient failure leaves the grants unknown —
+	// the last announced epoch must survive it, so a recovery that observes
+	// the SAME grant epoch never re-announces the prerequisite.
+	roomInfoObserved := false
 
 	info, err := c.options.Client.RoomInfo(c.options.RoomID)
 	if err != nil {
@@ -212,6 +217,7 @@ func (c *Controller) poll() {
 		vrAuthorized = false
 		c.log("voice_reply_room_info_failed", map[string]string{"code": safeDiagnosticCode(err)})
 	} else {
+		roomInfoObserved = true
 		if c.options.Voice != nil {
 			vrTargetsSelf := info.VoiceReply.AgentParticipantID == c.options.ParticipantID
 			vrAuthorized = info.VoiceReplyMediaAvailable &&
@@ -261,7 +267,9 @@ func (c *Controller) poll() {
 		if epoch != nil {
 			c.mnAnnouncedEpoch = epoch
 		}
-	} else if !authorized {
+	} else if roomInfoObserved && !authorized {
+		// Positively observed inactive: re-arm for a future grant instance.
+		// A transport failure must NOT reach this branch.
 		c.mnAnnounced = false
 		c.mnAnnouncedEpoch = nil
 	}
@@ -270,7 +278,9 @@ func (c *Controller) poll() {
 		if vrEpoch != nil {
 			c.vrAnnouncedEpoch = vrEpoch
 		}
-	} else if !vrAuthorized {
+	} else if roomInfoObserved && !vrAuthorized {
+		// Positively observed inactive: re-arm for a future grant instance.
+		// A transport failure must NOT reach this branch.
 		c.vrAnnounced = false
 		c.vrAnnouncedEpoch = nil
 	}

--- a/agent/internal/media/controller_grantnotice_test.go
+++ b/agent/internal/media/controller_grantnotice_test.go
@@ -1,0 +1,156 @@
+package media
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/i365dev/free4chat/agent/internal/speech"
+)
+
+// kindRecorder collects OnGrantActivated edges in order.
+type kindRecorder struct {
+	mu    sync.Mutex
+	kinds []GrantKind
+}
+
+func (r *kindRecorder) record(kind GrantKind) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.kinds = append(r.kinds, kind)
+}
+
+func (r *kindRecorder) snapshot() []GrantKind {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]GrantKind(nil), r.kinds...)
+}
+
+func kindsEqual(got []GrantKind, want ...GrantKind) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// controllerWithRecorder builds a synchronous (no background loop) controller
+// whose grant edges land in the recorder.
+func controllerWithRecorder(t *testing.T, client *fakeRoomClient) (*Controller, *kindRecorder) {
+	t.Helper()
+	voiceCfg := &VoiceConfig{
+		TrackName: "agent-voice",
+		CreateTtsProvider: func() (speech.StreamingTtsProvider, error) {
+			return nil, nil
+		},
+	}
+	controller, _ := newControllerHarness(t, client, voiceCfg)
+	// Drive poll() directly: no background loop, fully deterministic.
+	controller.stopped = false
+	rec := &kindRecorder{}
+	controller.options.OnGrantActivated = rec.record
+	t.Cleanup(controller.Stop)
+	return controller, rec
+}
+
+// #171: every grant instance (kind + epoch) announces exactly once; an
+// unchanged grant never re-fires while polls continue; a later grant on the
+// already-running shared bridge still gets its own edge.
+func TestControllerGrantActivationEdgesFireOncePerGrantInstance(t *testing.T) {
+	client := &fakeRoomClient{}
+	controller, rec := controllerWithRecorder(t, client)
+
+	// Meeting Notes only (epoch 111): exactly one MN edge.
+	client.setRoom("on", "on", "agent", 111, "off", "on", "agent", 0, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes) {
+		t.Fatalf("first MN activation must fire exactly one MN edge, got %v", got)
+	}
+
+	// The same grant stays active across polls: no spam.
+	controller.poll()
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes) {
+		t.Fatalf("unchanged grant must not re-fire, got %v", got)
+	}
+
+	// Voice Reply joins later on the shared bridge: its own VR edge.
+	client.setRoom("on", "on", "agent", 111, "on", "on", "agent", 555, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes, GrantVoiceReply) {
+		t.Fatalf("later VR activation must fire its own edge, got %v", got)
+	}
+
+	// Both grants remain active: still no spam.
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes, GrantVoiceReply) {
+		t.Fatalf("steady state must stay quiet, got %v", got)
+	}
+
+	// MN stop/start produces a fresh MN edge (new epoch 222).
+	client.setRoom("off", "on", "agent", 0, "off", "on", "agent", 0, nil)
+	controller.poll()
+	client.setRoom("on", "on", "agent", 222, "off", "on", "agent", 0, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got,
+		GrantMeetingNotes, GrantVoiceReply, GrantMeetingNotes) {
+		t.Fatalf("new MN grant epoch must produce a fresh edge, got %v", got)
+	}
+
+	// VR stop/start likewise (new epoch 556).
+	client.setRoom("on", "on", "agent", 222, "on", "on", "agent", 556, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got,
+		GrantMeetingNotes, GrantVoiceReply, GrantMeetingNotes, GrantVoiceReply) {
+		t.Fatalf("new VR grant epoch must produce a fresh edge, got %v", got)
+	}
+}
+
+// #171: both grants activating on the same poll evaluate independently —
+// two edges, Meeting Notes first, Voice Reply second.
+func TestControllerBothGrantsSamePollFireBothEdges(t *testing.T) {
+	client := &fakeRoomClient{}
+	controller, rec := controllerWithRecorder(t, client)
+
+	client.setRoom("on", "on", "agent", 100, "on", "on", "agent", 200, nil)
+	controller.poll()
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes, GrantVoiceReply) {
+		t.Fatalf("both grants must fire both edges exactly once, got %v", got)
+	}
+}
+
+// #171: reassignment A -> B lets the new holder evaluate its own
+// prerequisites; the previous holder stays quiet and re-arms.
+func TestControllerGrantReassignmentLetsNewHolderAnnounce(t *testing.T) {
+	client := &fakeRoomClient{}
+	controllerA, recA := controllerWithRecorder(t, client)
+	controllerB, recB := controllerWithRecorder(t, client)
+	controllerB.options.ParticipantID = "agent-b"
+
+	// Grant targets A: A announces, B is not targeted and stays quiet.
+	client.setRoom("on", "on", "agent", 1, "off", "on", "agent", 0, nil)
+	controllerA.poll()
+	controllerB.poll()
+	if got := recA.snapshot(); !kindsEqual(got, GrantMeetingNotes) {
+		t.Fatalf("targeted holder must announce, got %v", got)
+	}
+	if got := recB.snapshot(); len(got) != 0 {
+		t.Fatalf("non-targeted holder must stay quiet, got %v", got)
+	}
+
+	// Reassignment to B with a fresh epoch: A re-arms without a new notice;
+	// B announces its own edge.
+	client.setRoom("on", "on", "agent-b", 2, "off", "on", "agent", 0, nil)
+	controllerA.poll()
+	controllerB.poll()
+	if got := recA.snapshot(); !kindsEqual(got, GrantMeetingNotes) {
+		t.Fatalf("previous holder must not re-announce after reassignment, got %v", got)
+	}
+	if got := recB.snapshot(); !kindsEqual(got, GrantMeetingNotes) {
+		t.Fatalf("new holder must announce its own activation, got %v", got)
+	}
+}

--- a/agent/internal/media/controller_grantnotice_test.go
+++ b/agent/internal/media/controller_grantnotice_test.go
@@ -1,6 +1,7 @@
 package media
 
 import (
+	"errors"
 	"sync"
 	"testing"
 
@@ -152,5 +153,98 @@ func TestControllerGrantReassignmentLetsNewHolderAnnounce(t *testing.T) {
 	}
 	if got := recB.snapshot(); !kindsEqual(got, GrantMeetingNotes) {
 		t.Fatalf("new holder must announce its own activation, got %v", got)
+	}
+}
+
+// #175 review blocker: a transient RoomInfo failure between two successful
+// observations of the SAME grant epoch must NOT re-announce the prerequisite.
+// The announcement survives transport failures; re-arming happens only when
+// a successful observation positively reports the grant inactive.
+func TestControllerTransientRoomInfoFailureDoesNotReannounceMeetingNotes(t *testing.T) {
+	client := &fakeRoomClient{}
+	controller, rec := controllerWithRecorder(t, client)
+
+	// Active Meeting Notes epoch 111: exactly one edge.
+	client.setRoom("on", "on", "agent", 111, "off", "on", "agent", 0, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes) {
+		t.Fatalf("first MN activation must fire once, got %v", got)
+	}
+
+	// Transient RoomInfo failure while the grant stays active server-side.
+	client.setRoom("off", "on", "agent", 0, "off", "on", "agent", 0, errors.New("network"))
+	controller.poll()
+
+	// Recovery observes the SAME epoch: no second prerequisite notice.
+	client.setRoom("on", "on", "agent", 111, "off", "on", "agent", 0, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes) {
+		t.Fatalf("recovery with the same epoch must not re-announce, got %v", got)
+	}
+
+	// A positively observed inactivity still re-arms: the next genuinely new
+	// grant instance (fresh epoch) announces again.
+	client.setRoom("off", "on", "agent", 0, "off", "on", "agent", 0, nil)
+	controller.poll()
+	client.setRoom("on", "on", "agent", 222, "off", "on", "agent", 0, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes, GrantMeetingNotes) {
+		t.Fatalf("fresh grant instance after positive inactivity must announce, got %v", got)
+	}
+}
+
+// #175 review blocker, Voice Reply side: identical guarantee over the shared
+// bridge's second grant.
+func TestControllerTransientRoomInfoFailureDoesNotReannounceVoiceReply(t *testing.T) {
+	client := &fakeRoomClient{}
+	controller, rec := controllerWithRecorder(t, client)
+
+	// Active Voice Reply epoch 555: exactly one VR edge.
+	client.setRoom("off", "on", "agent", 0, "on", "on", "agent", 555, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantVoiceReply) {
+		t.Fatalf("first VR activation must fire once, got %v", got)
+	}
+
+	// Transient RoomInfo failure while the grant stays active server-side.
+	client.setRoom("off", "on", "agent", 0, "off", "on", "agent", 0, errors.New("network"))
+	controller.poll()
+
+	// Recovery observes the SAME epoch: no second prerequisite notice.
+	client.setRoom("off", "on", "agent", 0, "on", "on", "agent", 555, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantVoiceReply) {
+		t.Fatalf("recovery with the same epoch must not re-announce, got %v", got)
+	}
+
+	// Positive inactivity re-arms; a genuinely new instance announces again.
+	client.setRoom("off", "on", "agent", 0, "off", "on", "agent", 0, nil)
+	controller.poll()
+	client.setRoom("off", "on", "agent", 0, "on", "on", "agent", 666, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantVoiceReply, GrantVoiceReply) {
+		t.Fatalf("fresh VR instance after positive inactivity must announce, got %v", got)
+	}
+}
+
+// Both grants active across a transient failure: neither announcement is
+// lost or duplicated.
+func TestControllerTransientRoomInfoFailurePreservesBothAnnouncements(t *testing.T) {
+	client := &fakeRoomClient{}
+	controller, rec := controllerWithRecorder(t, client)
+
+	client.setRoom("on", "on", "agent", 111, "on", "on", "agent", 555, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes, GrantVoiceReply) {
+		t.Fatalf("both grants must announce once, got %v", got)
+	}
+
+	client.setRoom("off", "off", "agent", 0, "off", "off", "agent", 0, errors.New("network"))
+	controller.poll()
+
+	client.setRoom("on", "on", "agent", 111, "on", "on", "agent", 555, nil)
+	controller.poll()
+	if got := rec.snapshot(); !kindsEqual(got, GrantMeetingNotes, GrantVoiceReply) {
+		t.Fatalf("recovery with unchanged epochs must not re-announce either grant, got %v", got)
 	}
 }

--- a/agent/internal/runtime/media.go
+++ b/agent/internal/runtime/media.go
@@ -120,8 +120,8 @@ func (r *ResidentRuntime) restartMediaController(participantHandle string) {
 				r.transcriber.TrackEnded(source)
 			}
 		},
-		OnGrantActivated: func() {
-			r.notifySpeechPrerequisite()
+		OnGrantActivated: func(kind media.GrantKind) {
+			r.notifySpeechPrerequisite(kind)
 		},
 		Voice: voiceConfig,
 	})
@@ -132,11 +132,12 @@ func (r *ResidentRuntime) restartMediaController(participantHandle string) {
 	go controller.Start(context.Background())
 }
 
-// notifySpeechPrerequisite tells the room ONCE, at grant activation, when
-// the missing piece is local speech configuration — pointing at the agent's
-// own session, never soliciting secrets in room chat.
-func (r *ResidentRuntime) notifySpeechPrerequisite() {
-	notice := buildSpeechNotice(r.speechSnapshot())
+// notifySpeechPrerequisite tells the room ONCE per grant activation edge
+// (#171), evaluating exactly that grant's own speech prerequisite — Meeting
+// Notes requires STT, Voice Reply requires TTS. It points at the agent's
+// own session and never solicits secrets in room chat.
+func (r *ResidentRuntime) notifySpeechPrerequisite(kind media.GrantKind) {
+	notice := buildSpeechNotice(r.speechSnapshot(), kind)
 	if notice == "" {
 		return
 	}
@@ -151,13 +152,23 @@ func (r *ResidentRuntime) notifySpeechPrerequisite() {
 	}
 }
 
-// buildSpeechNotice returns the room message when STT is missing at grant
-// time, or "" when there is nothing to tell the room.
-func buildSpeechNotice(config speech.Config) string {
-	if !config.STTEnabled {
-		return "Meeting Notes was requested, but no speech-to-text provider is configured in my local runtime. I'll complete speech setup in my own session before transcribing — please don't paste API keys into this room."
+// buildSpeechNotice evaluates the speech prerequisite of the grant that
+// activated (#171) and returns the room message, or "" when that
+// prerequisite is satisfied. The shared media bridge is intentionally not
+// split: the grant kind decides which local slot (STT or TTS) must exist.
+func buildSpeechNotice(config speech.Config, kind media.GrantKind) string {
+	switch kind {
+	case media.GrantVoiceReply:
+		if !config.TTSEnabled {
+			return "Voice Reply was requested, but no text-to-speech provider is configured in my local runtime. I'll complete speech setup in my own session before speaking — please don't paste API keys into this room."
+		}
+		return ""
+	default:
+		if !config.STTEnabled {
+			return "Meeting Notes was requested, but no speech-to-text provider is configured in my local runtime. I'll complete speech setup in my own session before transcribing — please don't paste API keys into this room."
+		}
+		return ""
 	}
-	return ""
 }
 
 // logVoiceSpeakerEvent maps speaker lifecycle events to bounded safe logs.

--- a/agent/internal/runtime/speech_notice_test.go
+++ b/agent/internal/runtime/speech_notice_test.go
@@ -1,0 +1,126 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/i365dev/free4chat/agent/internal/media"
+	"github.com/i365dev/free4chat/agent/internal/speech"
+)
+
+// speechConfig builds a speech config with explicit slot readiness.
+func speechConfig(stt, tts bool) speech.Config {
+	return speech.Config{APIKey: "local-key", STTEnabled: stt, TTSEnabled: tts}
+}
+
+// #171: the notice evaluates ONLY the prerequisite of the grant that
+// activated — Meeting Notes requires STT, Voice Reply requires TTS — over
+// one shared media bridge. The opposite slot's state is irrelevant, and a
+// Voice-only grant must never claim Meeting Notes was requested.
+func TestBuildSpeechNoticeEvaluatesOnlyTheActivatedGrant(t *testing.T) {
+	cases := []struct {
+		name          string
+		config        speech.Config
+		kind          media.GrantKind
+		wantSubstring string
+	}{
+		{
+			name:          "voice-only with TTS missing reports the voice prerequisite",
+			config:        speechConfig(false, false),
+			kind:          media.GrantVoiceReply,
+			wantSubstring: "Voice Reply was requested",
+		},
+		{
+			name:          "voice-only with TTS ready stays silent even if STT is missing",
+			config:        speechConfig(false, true),
+			kind:          media.GrantVoiceReply,
+			wantSubstring: "",
+		},
+		{
+			name:          "notes-only with STT missing reports the notes prerequisite",
+			config:        speechConfig(false, false),
+			kind:          media.GrantMeetingNotes,
+			wantSubstring: "Meeting Notes was requested",
+		},
+		{
+			name:          "notes-only with STT ready stays silent even if TTS is missing",
+			config:        speechConfig(true, false),
+			kind:          media.GrantMeetingNotes,
+			wantSubstring: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			notice := buildSpeechNotice(tc.config, tc.kind)
+			if tc.wantSubstring == "" {
+				if notice != "" {
+					t.Fatalf("satisfied prerequisite must not notify, got %q", notice)
+				}
+				return
+			}
+			if !strings.Contains(notice, tc.wantSubstring) {
+				t.Fatalf("notice mismatch: want %q in %q", tc.wantSubstring, notice)
+			}
+			// The other grant's wording must never leak into this notice.
+			other := "Meeting Notes was requested"
+			if tc.kind == media.GrantMeetingNotes {
+				other = "Voice Reply was requested"
+			}
+			if strings.Contains(notice, other) {
+				t.Fatalf("notice for %v must not mention the other grant: %q", tc.kind, notice)
+			}
+			// Keys are never requested in the room.
+			if strings.Contains(notice, "API keys into this room.") == false {
+				t.Fatalf("notice must keep the no-keys-in-room guidance: %q", notice)
+			}
+		})
+	}
+}
+
+// #171: the runtime sends the grant-specific notice through the ordinary
+// unaddressed send path (#165: nil targets — room context for everyone).
+func TestNotifySpeechPrerequisiteSendsGrantSpecificUnaddressedNotice(t *testing.T) {
+	client := &fakeClient{}
+	rt := NewResidentRuntime(Options{
+		InstanceID: "inst-notice",
+		RoomID:     "test-notice",
+		Name:       "Pi",
+		Client:     client,
+		Adapter:    &fakeAdapter{name: "pi"},
+	})
+	func() {
+		rt.mu.Lock()
+		defer rt.mu.Unlock()
+		rt.participantHandle = "secret-handle"
+		rt.speechConfig = speechConfig(false, false)
+	}()
+
+	rt.notifySpeechPrerequisite(media.GrantVoiceReply)
+	sent := client.snapshotSent()
+	targets := client.snapshotSentTargets()
+	if len(sent) != 1 || !strings.Contains(sent[0], "Voice Reply was requested") {
+		t.Fatalf("voice grant must send the voice notice, got %v", sent)
+	}
+	if len(targets) != 1 || targets[0] != nil {
+		t.Fatalf("notice must stay an ordinary unaddressed message, got %v", targets)
+	}
+
+	// Meeting Notes edge over the same state reports the notes prerequisite.
+	rt.notifySpeechPrerequisite(media.GrantMeetingNotes)
+	sent = client.snapshotSent()
+	if len(sent) != 2 || !strings.Contains(sent[1], "Meeting Notes was requested") {
+		t.Fatalf("notes grant must send the notes notice, got %v", sent)
+	}
+
+	// A satisfied prerequisite sends nothing at all.
+	func() {
+		rt.mu.Lock()
+		defer rt.mu.Unlock()
+		rt.speechConfig = speechConfig(true, true)
+	}()
+	rt.notifySpeechPrerequisite(media.GrantMeetingNotes)
+	rt.notifySpeechPrerequisite(media.GrantVoiceReply)
+	if got := len(client.snapshotSent()); got != 2 {
+		t.Fatalf("satisfied prerequisites must not notify, saw %d sends", got)
+	}
+}


### PR DESCRIPTION
Closes #171. **Not merged** — opened for review.

## Root cause (code-confirmed)

The media Controller serves Meeting Notes and Voice Reply over ONE shared Pion bridge (by design). But `OnGrantActivated` fired from the bridge-start completion path — which runs for **any** grant that starts the bridge — and `buildSpeechNotice` checked **only `STTEnabled`**, always emitting "Meeting Notes was requested…". A Voice-Reply-only grant could therefore falsely claim Meeting Notes was requested.

## Fix (no bridge split)

- **Grant-edge model in the controller poll** (#171): each grant kind announces exactly once per grant **instance** (kind + `StartedAt` epoch):
  - unchanged grant across 5s polls → no re-fire (no spam);
  - stop/start or re-grant → fresh epoch → fresh edge;
  - reassignment A → B → A re-arms silently, B's own runtime announces its own edge;
  - a second grant added while the shared bridge is already running still gets its own edge — evaluated independently **without splitting the bridge**.
- Malformed/partial `room_info` (missing epoch) can never re-trigger an already-announced grant.
- `OnGrantActivated` now carries `GrantKind` (`meeting_notes` | `voice_reply`); `buildSpeechNotice(config, kind)` evaluates exactly that grant's prerequisite:
  - Meeting Notes → STT only: *"Meeting Notes was requested, but no speech-to-text provider is configured…"*
  - Voice Reply → TTS only: *"Voice Reply was requested, but no text-to-speech provider is configured…"*
  - both grants → both evaluated independently.
- Wording stays concise and keeps the **no-API-keys-in-the-room** guidance. Notices ride the ordinary **unaddressed** send path (#165, nil targets). #167 credential provisioning / hot reload untouched (a reloaded config is picked up by the next grant edge); credential values never leave the Runtime boundary; text remains fully functional without speech.

## Tests

Controller (`controller_grantnotice_test.go`, deterministic synchronous polls):
1. edges fire once per grant instance; unchanged grant = no spam;
2. later VR grant on the running shared bridge gets its own edge;
3. both grants on one poll → both edges, MN then VR;
4. stop/start → fresh edge per kind (new epochs);
5. reassignment A → B: A quiet, B announces.

Runtime (`speech_notice_test.go`):
6. `buildSpeechNotice` table — voice-only TTS missing → voice notice; voice-only TTS ready (STT missing) → silent **and never mentions Meeting Notes**; notes-only STT missing → notes notice; notes-only STT ready (TTS missing) → silent; keys guidance preserved;
7. `notifySpeechPrerequisite` sends the grant-specific notice via the ordinary unaddressed send (nil targets) and sends nothing when the prerequisite is satisfied.

## Validation

`gofmt` clean, `go vet ./...` clean, `go test ./... -count=1` (11 packages, incl. full media + runtime suites) green, `go build ./cmd/free4chat-agent`, linux + darwin cross-builds, `scripts/check-cleanup.sh` OK.