### PR TITLE
[codex] media: make Agent voice independently controllable per participant

### DIFF
--- a/agent/internal/daemon/daemon.go
+++ b/agent/internal/daemon/daemon.go
@@ -19,6 +19,7 @@ import (
 	"github.com/i365dev/free4chat/agent/internal/runtime"
 	"github.com/i365dev/free4chat/agent/internal/speech"
 	"github.com/i365dev/free4chat/agent/internal/types"
+	"github.com/i365dev/free4chat/agent/internal/voice"
 )
 
 // residentInstance is one live room runtime owned by the daemon.
@@ -38,6 +39,7 @@ type Daemon struct {
 	stopping   bool
 	finalized  bool
 	finishOnce sync.Once
+	voiceGate  voice.Gate
 }
 
 // New creates an idle daemon.
@@ -45,6 +47,7 @@ func New() *Daemon {
 	return &Daemon{
 		instances: make(map[string]*residentInstance),
 		closed:    make(chan struct{}),
+		voiceGate: voice.NewGate(),
 	}
 }
 
@@ -423,6 +426,7 @@ func (d *Daemon) prepareRuntime(
 		TranscriptPath: transcriptPath,
 		Speech:         &speechConfig,
 		HostSeed:       hostSeed,
+		HostVoiceGate:  d.voiceGate,
 		// Natural room expiry must release the resident registry entry and
 		// its private workspace, matching the Node reference's onRoomExpired
 		// wiring — otherwise status keeps showing a ghost instance and the

--- a/agent/internal/free4chat/agent_voice_test.go
+++ b/agent/internal/free4chat/agent_voice_test.go
@@ -1,0 +1,19 @@
+package free4chat
+
+import "testing"
+
+func TestParseAgentVoiceFailsClosedAndUsesCurrentParticipantIDs(t *testing.T) {
+	grants := parseAgentVoice(map[string]any{
+		"agent-a": map[string]any{"enabled": true, "enabledAt": float64(101)},
+		"agent-b": map[string]any{"enabled": false, "enabledAt": float64(102)},
+		"agent-c": map[string]any{"enabled": true, "enabledAt": "bad"},
+		"agent-d": map[string]any{"enabled": true, "enabledAt": float64(1.5)},
+		"agent-e": map[string]any{"enabled": true, "enabledAt": float64(1 << 63)},
+	})
+	if len(grants) != 1 || grants["agent-a"].EnabledAt != 101 {
+		t.Fatalf("strict Agent Voice parse failed closed: %+v", grants)
+	}
+	if _, ok := grants["same-runtime-host"]; ok {
+		t.Fatal("Runtime Host identity must never authorize a different Agent")
+	}
+}

--- a/agent/internal/free4chat/client.go
+++ b/agent/internal/free4chat/client.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"time"
@@ -285,8 +286,8 @@ func (c *Client) RoomInfo(roomID string) (types.RoomInfo, error) {
 	}
 	info.MeetingNotes = parseGrantState(result["meetingNotes"])
 	info.MeetingNotesMediaAvailable = result["meetingNotesMediaAvailable"] == true
-	info.VoiceReply = parseVoiceReplyState(result["voiceReply"])
-	info.VoiceReplyMediaAvailable = result["voiceReplyMediaAvailable"] == true
+	info.AgentVoice = parseAgentVoice(result["agentVoice"])
+	info.AgentVoiceMediaAvailable = result["agentVoiceMediaAvailable"] == true
 	return info, nil
 }
 
@@ -306,20 +307,24 @@ func parseGrantState(raw any) types.MeetingNotesInfo {
 	return info
 }
 
-func parseVoiceReplyState(raw any) types.VoiceReplyInfo {
+func parseAgentVoice(raw any) map[string]types.AgentVoiceGrant {
 	record, _ := raw.(map[string]any)
-	info := types.VoiceReplyInfo{}
-	if record == nil {
-		return info
+	grants := make(map[string]types.AgentVoiceGrant)
+	for participantID, rawGrant := range record {
+		grant, ok := rawGrant.(map[string]any)
+		if !ok || grant["enabled"] != true {
+			continue
+		}
+		enabledAt, ok := grant["enabledAt"].(float64)
+		if !ok ||
+			enabledAt <= 0 ||
+			enabledAt >= 1<<63 ||
+			enabledAt != math.Trunc(enabledAt) {
+			continue
+		}
+		grants[participantID] = types.AgentVoiceGrant{EnabledAt: int64(enabledAt)}
 	}
-	info.Active = record["active"] == true
-	if id, ok := record["agentParticipantId"].(string); ok {
-		info.AgentParticipantID = id
-	}
-	if started, ok := record["startedAt"].(float64); ok {
-		info.StartedAt = int64(started)
-	}
-	return info
+	return grants
 }
 
 func parseJoinLike(result map[string]any) (types.JoinResult, error) {

--- a/agent/internal/media/bridge.go
+++ b/agent/internal/media/bridge.go
@@ -41,6 +41,10 @@ type EngineLike interface {
 	ValidateTurn(token uint64) bool
 	WritePCM(chunk []byte, token uint64) error
 	FlushAudio(token uint64) error
+	// FlushAudioAndWait returns only once the paced writer has consumed the
+	// final marker. Host-level Agent Voice serialization depends on this
+	// acknowledgement: enqueueing the marker alone leaves prior PCM audible.
+	FlushAudioAndWait(token uint64) error
 	PublishCounts() map[string]uint64
 	RtpCounts() map[string]uint64
 	Close()
@@ -76,7 +80,7 @@ type BridgeOptions struct {
 	Now func() time.Time
 }
 
-// PublishConfig is the voiceReply publication shape.
+// PublishConfig is the Agent Voice publication shape.
 type PublishConfig struct {
 	TrackName string
 }
@@ -116,7 +120,7 @@ func subscriptionKey(participantID, sessionID, trackName string) string {
 
 // Bridge owns the ONE shared Pion PeerConnection / Cloudflare Agent session
 // serving both grants. Meeting Notes controls Human-audio subscribe/input;
-// voiceReply controls this Agent's local publish/output. Exactly one session
+// Agent Voice controls this Agent's local publish/output. Exactly one session
 // exists whenever EITHER grant is live.
 type Bridge struct {
 	options BridgeOptions
@@ -945,7 +949,7 @@ func (b *Bridge) flushEngine(token uint64) error {
 	if engine == nil {
 		return errors.New("bridge_not_running")
 	}
-	return engine.FlushAudio(token)
+	return engine.FlushAudioAndWait(token)
 }
 
 // bootstrapErrorClass maps a sanitized bootstrap failure onto a bounded

--- a/agent/internal/media/bridge_test.go
+++ b/agent/internal/media/bridge_test.go
@@ -151,6 +151,9 @@ func (f *fakeEngine) FlushAudio(token uint64) error {
 	f.mu.Unlock()
 	return nil
 }
+func (f *fakeEngine) FlushAudioAndWait(token uint64) error {
+	return f.FlushAudio(token)
+}
 func (f *fakeEngine) PublishCounts() map[string]uint64 {
 	return map[string]uint64{"opus_frames_written": uint64(len(f.snapshotWrites()))}
 }

--- a/agent/internal/media/controller.go
+++ b/agent/internal/media/controller.go
@@ -32,7 +32,7 @@ type ControllerOptions struct {
 	// uses it to evaluate that grant's own speech prerequisite once — never
 	// per poll.
 	OnGrantActivated func(kind GrantKind)
-	// Voice configures outbound Voice Reply (nil = Meeting Notes only).
+	// Voice configures outbound Agent Voice (nil = Meeting Notes only).
 	Voice *VoiceConfig
 	// Log receives bounded safe events.
 	Log func(event string, details map[string]string)
@@ -47,21 +47,25 @@ type VoiceConfig struct {
 	TrackName         string
 	CreateTtsProvider func() (speech.StreamingTtsProvider, error)
 	MaxChunkChars     int
+	HostVoiceGate     voice.Gate
 	OnSpeakerEvent    func(voice.SpeakerEvent)
 }
 
 // GrantKind identifies which room media grant produced an activation edge.
-// Meeting Notes and Voice Reply are independent grants over one shared
+// Meeting Notes and Agent Voice are independent grants over one shared
 // media bridge; each carries its own speech prerequisite.
 type GrantKind string
 
 const (
 	GrantMeetingNotes GrantKind = "meeting_notes"
-	GrantVoiceReply   GrantKind = "voice_reply"
+	GrantAgentVoice   GrantKind = "agent_voice"
+	// Deprecated internal spelling retained only for existing adapter tests;
+	// it maps to the participant-specific Agent Voice grant above.
+	GrantVoiceReply = GrantAgentVoice
 )
 
 // Controller owns the Runtime-side half of the media lifecycle: it polls
-// room_info for the Meeting Notes and voiceReply grants and starts/stops the
+// room_info for the Meeting Notes and Agent Voice grants and starts/stops the
 // ONE shared Bridge accordingly. This is the ONLY thing that decides when
 // this process may hold an active media session — authorization always comes
 // from the room-visible grant, never from a local decision.
@@ -164,7 +168,7 @@ func (c *Controller) Stop() {
 	c.teardownBridge()
 }
 
-// CurrentVoiceOutput returns the speakable output while a voiceReply grant
+// CurrentVoiceOutput returns the speakable output while an Agent Voice grant
 // is active; nil when inactive/starting (callers stay text-only).
 func (c *Controller) CurrentVoiceOutput() *voice.Speaker {
 	c.mu.Lock()
@@ -219,11 +223,10 @@ func (c *Controller) poll() {
 	} else {
 		roomInfoObserved = true
 		if c.options.Voice != nil {
-			vrTargetsSelf := info.VoiceReply.AgentParticipantID == c.options.ParticipantID
-			vrAuthorized = info.VoiceReplyMediaAvailable &&
-				info.VoiceReply.Active && vrTargetsSelf
-			if info.VoiceReply.StartedAt > 0 {
-				value := info.VoiceReply.StartedAt
+			grant, vrTargetsSelf := info.AgentVoice[c.options.ParticipantID]
+			vrAuthorized = info.AgentVoiceMediaAvailable && vrTargetsSelf && grant.EnabledAt > 0
+			if grant.EnabledAt > 0 {
+				value := grant.EnabledAt
 				vrEpoch = &value
 			}
 			c.mu.Lock()
@@ -232,8 +235,8 @@ func (c *Controller) poll() {
 			c.voiceObservedInit = true
 			c.mu.Unlock()
 			c.log("voice_reply_state", map[string]string{
-				"voice_reply_media_available":     bool01(info.VoiceReplyMediaAvailable),
-				"voice_reply_active":              bool01(info.VoiceReply.Active),
+				"agent_voice_media_available":     bool01(info.AgentVoiceMediaAvailable),
+				"agent_voice_enabled":             bool01(vrAuthorized),
 				"voice_reply_targets_self":        bool01(vrTargetsSelf),
 				"voice_reply_grant_epoch_present": bool01(vrEpoch != nil),
 				"voice_reply_grant_epoch_changed": bool01(epochChanged),
@@ -292,7 +295,7 @@ func (c *Controller) poll() {
 		c.options.OnGrantActivated(GrantMeetingNotes)
 	}
 	if vrEdge && c.options.OnGrantActivated != nil {
-		c.options.OnGrantActivated(GrantVoiceReply)
+		c.options.OnGrantActivated(GrantAgentVoice)
 	}
 
 	anyGrantActive := authorized || vrAuthorized
@@ -493,6 +496,7 @@ func (c *Controller) ensureVoice() {
 			return &bridgeVoiceSink{bridge: bridge, token: token}, nil
 		},
 		MaxChunkChars: voiceConfig.MaxChunkChars,
+		Gate:          voiceConfig.HostVoiceGate,
 		OnEvent:       voiceConfig.OnSpeakerEvent,
 	})
 	c.mu.Lock()

--- a/agent/internal/media/controller_test.go
+++ b/agent/internal/media/controller_test.go
@@ -52,10 +52,15 @@ func (f *fakeRoomClient) RoomInfo(string) (types.RoomInfo, error) {
 			Active: f.mnActive, AgentParticipantID: f.mnAgent, StartedAt: f.mnStarted,
 		},
 		MeetingNotesMediaAvailable: f.mnAvail,
-		VoiceReply: types.VoiceReplyInfo{
-			Active: f.vrActive, AgentParticipantID: f.vrAgent, StartedAt: f.vrStarted,
-		},
-		VoiceReplyMediaAvailable: f.vrAvail,
+		AgentVoice: func() map[string]types.AgentVoiceGrant {
+			if !f.vrActive || f.vrAgent == "" || f.vrStarted <= 0 {
+				return map[string]types.AgentVoiceGrant{}
+			}
+			return map[string]types.AgentVoiceGrant{
+				f.vrAgent: {EnabledAt: f.vrStarted},
+			}
+		}(),
+		AgentVoiceMediaAvailable: f.vrAvail,
 	}, nil
 }
 

--- a/agent/internal/media/engine.go
+++ b/agent/internal/media/engine.go
@@ -131,6 +131,11 @@ type Engine struct {
 	silenceFills  uint64
 	fillRun       uint64 // consecutive fills (bounded)
 	turnOpen      bool
+	// turnInvalidated closes as soon as the active turn is cancelled or its
+	// publication is revoked. A flush marker may already be inside a paced
+	// writer sleep at that point, so its waiter must not depend on the writer
+	// waking before it can release the host voice gate.
+	turnInvalidated chan struct{}
 }
 
 // framePacer spaces outbound Opus frames one frame-duration apart (ported
@@ -454,6 +459,7 @@ func (e *Engine) ActivatePublish() error {
 	}
 	e.publishOn = true
 	e.pubGeneration++
+	e.invalidateTurnLocked()
 	e.pacer = newFramePacer(e.nowFn, e.sleepFn)
 	e.pacer.onGap = func() {
 		e.mu.Lock()
@@ -483,6 +489,7 @@ func (e *Engine) DeactivatePublish() {
 	e.turnOpen = false
 	e.highestAdmitted = 0
 	e.cancelledThrough = 0
+	e.invalidateTurnLocked()
 	e.mu.Unlock()
 	e.clearQueueAndCarry()
 }
@@ -496,6 +503,20 @@ type queueItem struct {
 	turnGen uint64 // turn generation at enqueue (utterance boundary)
 	token   uint64 // turn ADMISSION token (speaker turn identity)
 	data    []byte // nil = flush marker
+	// flushDone is present only for a caller that must wait until the paced
+	// writer consumes this marker. It is buffered so cancellation/revocation
+	// can unblock the waiter without depending on it being scheduled first.
+	flushDone chan error
+}
+
+func finishFlush(item queueItem, err error) {
+	if item.flushDone == nil {
+		return
+	}
+	select {
+	case item.flushDone <- err:
+	default:
+	}
 }
 
 // enqueueItem appends one item under the single queue lock, with BOUNDED
@@ -668,8 +689,19 @@ func (e *Engine) CancelTurn(token uint64) {
 	}
 	e.turnGeneration++
 	e.turnOpen = false
+	e.invalidateTurnLocked()
 	e.mu.Unlock()
 	e.clearQueueAndCarry()
+}
+
+// invalidateTurnLocked releases final-flush waiters immediately. Caller
+// holds e.mu. The next accepted turn uses a fresh channel so a past cancel
+// can never poison a later utterance.
+func (e *Engine) invalidateTurnLocked() {
+	if e.turnInvalidated != nil {
+		close(e.turnInvalidated)
+	}
+	e.turnInvalidated = make(chan struct{})
 }
 
 // clearQueueAndCarry discards queued PCM and the partial frame so stale
@@ -682,14 +714,21 @@ func (e *Engine) clearQueueAndCarry() {
 	// mutated together. queueBytes ends at exactly the sum of the drained
 	// reservations subtracted from the previous total — arithmetically zero.
 	e.writerMu.Lock()
+	flushes := make([]queueItem, 0)
 	e.carry = nil
 	for _, item := range e.queueRing {
 		if item.data != nil {
 			e.queueBytes -= len(item.data)
 		}
+		if item.flushDone != nil {
+			flushes = append(flushes, item)
+		}
 	}
 	e.queueRing = nil
 	e.writerMu.Unlock()
+	for _, item := range flushes {
+		finishFlush(item, errPublishNotActive)
+	}
 	select {
 	case e.writerSpace <- struct{}{}:
 	default:
@@ -754,10 +793,58 @@ func (e *Engine) FlushAudio(token uint64) error {
 	return e.enqueueItem(queueItem{gen: gen, turnGen: turnGen, token: token}) // data nil = flush marker
 }
 
+// FlushAudioAndWait enqueues the normal-completion marker then waits until
+// the paced writer has consumed every preceding PCM item and processed that
+// marker. This is the completion boundary for a host-local voice gate: the
+// next Agent must not start publishing while this Agent's queued PCM is still
+// audible. Revocation, cancellation, and Close all unblock this wait with a
+// fail-closed error.
+func (e *Engine) FlushAudioAndWait(token uint64) error {
+	e.mu.Lock()
+	active := e.publishOn
+	gen := e.pubGeneration
+	turnGen := e.turnGeneration
+	invalidated := e.turnInvalidated
+	e.mu.Unlock()
+	if !active {
+		return errPublishNotActive
+	}
+	ack := make(chan error, 1)
+	if err := e.enqueueItem(queueItem{
+		gen: gen, turnGen: turnGen, token: token, flushDone: ack,
+	}); err != nil {
+		return err
+	}
+	e.writerMu.Lock()
+	stop := e.writerStop
+	e.writerMu.Unlock()
+	if stop == nil {
+		return errPublishNotActive
+	}
+	select {
+	case err := <-ack:
+		return err
+	case <-invalidated:
+		return errPublishNotActive
+	case <-stop:
+		return errPublishNotActive
+	}
+}
+
 func (e *Engine) publishActive() bool {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	return e.publishOn
+}
+
+// currentPacer snapshots the publication's pacing state under the same lock
+// that replaces it on reactivation. The writer deliberately runs the copied
+// pacer outside that lock: a concurrent revoke/restart may make its frame
+// stale, and the post-pace generation checks below will then discard it.
+func (e *Engine) currentPacer() *framePacer {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.pacer
 }
 
 // PCMCarryLen exposes the writer's buffered unframed byte count (tests).
@@ -820,6 +907,7 @@ func (e *Engine) writerLoop(stop, done chan struct{}) {
 				(item.token != 0 && item.token != e.currentAdmittedTurn()) {
 				// Stale grant, stale utterance, or cancelled-turn PCM:
 				// discard entirely (popItem released the reservation).
+				finishFlush(item, errPublishNotActive)
 				continue
 			}
 			if item.data != nil {
@@ -832,12 +920,17 @@ func (e *Engine) writerLoop(stop, done chan struct{}) {
 				// Flush marker: pad and emit the partial tail. A concurrent
 				// revocation makes this a discard-only no-op — the loop
 				// continues, never exits.
-				if err := e.writerEmitCarry(item.token, track(), writer()); err != nil {
-					_ = err // dropped frame; writer stays alive
-				}
+				err := e.writerEmitCarry(
+					item.gen,
+					item.turnGen,
+					item.token,
+					track(),
+					writer(),
+				)
 				e.mu.Lock()
 				e.turnOpen = false
 				e.mu.Unlock()
+				finishFlush(item, err)
 				continue
 			}
 			if err := e.writerWriteChunk(item.gen, item.turnGen, item.token, item.data, track(), writer()); err != nil {
@@ -864,7 +957,11 @@ func (e *Engine) writerWriteChunk(gen, turnGen, token uint64, chunk []byte, trac
 	e.writerMu.Unlock()
 
 	for f := 0; f < frames; f++ {
-		e.pacer.pace()
+		pacer := e.currentPacer()
+		if pacer == nil {
+			return errPublishNotActive
+		}
+		pacer.pace()
 		// The activation flag, the PUBLICATION generation AND the TURN
 		// generation must all still match: a cancel or revoke landing
 		// between paced waits discards the stale burst before any frame
@@ -886,7 +983,10 @@ func (e *Engine) writerWriteChunk(gen, turnGen, token uint64, chunk []byte, trac
 }
 
 // writerEmitCarry zero-pads the partial tail and emits it in its own slot.
-func (e *Engine) writerEmitCarry(token uint64, track *webrtc.TrackLocalStaticSample, enc *opus.Encoder) error {
+// It carries the item generations through the paced wait: a revoke followed
+// by a new publication can otherwise make publishActive true again before the
+// old tail wakes, which would leak prior-turn PCM into the new grant.
+func (e *Engine) writerEmitCarry(gen, turnGen, token uint64, track *webrtc.TrackLocalStaticSample, enc *opus.Encoder) error {
 	e.writerMu.Lock()
 	carry := e.carry
 	e.carry = nil
@@ -897,10 +997,16 @@ func (e *Engine) writerEmitCarry(token uint64, track *webrtc.TrackLocalStaticSam
 	if len(carry)%2 == 1 {
 		carry = append(carry, 0)
 	}
-	e.pacer.pace()
+	pacer := e.currentPacer()
+	if pacer == nil {
+		return errPublishNotActive
+	}
+	pacer.pace()
 	// Re-validate after the paced wait: a cancel landing DURING the wait
 	// must discard the pending tail before any sample goes out.
 	if !e.publishActive() ||
+		e.currentGeneration() != gen ||
+		e.currentTurnGeneration() != turnGen ||
 		(token != 0 && !e.ValidateTurn(token)) {
 		return errPublishNotActive
 	}
@@ -923,10 +1029,11 @@ func (e *Engine) fillSilenceIfMidTurn(track *webrtc.TrackLocalStaticSample, enc 
 	}
 	open := e.turnOpen && e.publishOn
 	e.mu.Unlock()
-	if !open || !e.pacer.scheduled() {
+	pacer := e.currentPacer()
+	if !open || pacer == nil || !pacer.scheduled() {
 		return false
 	}
-	e.pacer.pace()
+	pacer.pace()
 	// Re-check after the paced wait: a cancel during the wait must stop the
 	// fill before any silence frame is emitted.
 	e.mu.Lock()

--- a/agent/internal/media/engine_test.go
+++ b/agent/internal/media/engine_test.go
@@ -500,6 +500,77 @@ func TestConcurrentRevokeAndFlushKeepsWriterAlive(t *testing.T) {
 	}
 }
 
+// FlushAudioAndWait is the host-gate completion boundary: it must not return
+// merely because a marker is queued. The paced writer has to consume every
+// prior audio frame and the marker first.
+func TestFlushAudioAndWaitBlocksUntilPacedWriterConsumesMarker(t *testing.T) {
+	engine := newTestEngine(t)
+	_ = engine.ArmPublish()
+	sleepFn, release := blockingSleepFunc()
+	engine.sleepFn = sleepFn
+	if err := engine.ActivatePublish(); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	if err := engine.WritePCM(make([]byte, 2*960), 1); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	waitForRealFrames(t, engine, 1) // second frame is held in the paced writer
+	done := make(chan error, 1)
+	go func() { done <- engine.FlushAudioAndWait(1) }()
+	select {
+	case err := <-done:
+		t.Fatalf("flush returned before paced PCM drained: %v", err)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("flush completion: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("flush did not acknowledge paced marker consumption")
+	}
+	if got := engine.realFramesWritten(); got != 2 {
+		t.Fatalf("flush acknowledged before all audible frames: got %d, want 2", got)
+	}
+}
+
+func TestFlushAudioAndWaitUnblocksWhenCancelledDuringMarkerPace(t *testing.T) {
+	engine := newTestEngine(t)
+	_ = engine.ArmPublish()
+	sleepFn, release := blockingSleepFunc()
+	engine.sleepFn = sleepFn
+	if err := engine.ActivatePublish(); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	if err := engine.WritePCM(make([]byte, 960), 1); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := engine.WritePCM(make([]byte, 500), 1); err != nil {
+		t.Fatalf("tail write: %v", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- engine.FlushAudioAndWait(1) }()
+	// The immediate frame, tail, and marker were enqueued as one burst, so
+	// the writer consumes them in order and blocks in the marker's paced wait
+	// (rather than an idle gap-fill) before this condition is satisfied.
+	// Cancellation must release the host-gate waiter without waiting for that
+	// paced writer to resume.
+	waitForRingEmpty(t, engine)
+	time.Sleep(30 * time.Millisecond)
+	engine.CancelTurn(1)
+	select {
+	case err := <-done:
+		if !errors.Is(err, errPublishNotActive) {
+			t.Fatalf("cancelled flush error = %v, want publish inactive", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancelled flush waiter remained blocked")
+	}
+	close(release)
+}
+
 // TestReactivateAfterDeactivateWritesAudio covers the plain
 // deactivate->reactivate cycle: no truncation, no silence.
 func TestReactivateAfterDeactivateWritesAudio(t *testing.T) {
@@ -1409,6 +1480,36 @@ func TestCarryCancelDuringPaceRejected(t *testing.T) {
 	}
 	if got := engine.PCMCarry(); got != 0 {
 		t.Fatalf("carry not discarded: %d", got)
+	}
+}
+
+// TestCarryRevokeAndReactivateDuringPaceRejected covers the stronger
+// publication boundary. A blocked old flush tail must not become audible if
+// revocation is immediately followed by a fresh grant before the old paced
+// writer wakes.
+func TestCarryRevokeAndReactivateDuringPaceRejected(t *testing.T) {
+	engine := newTestEngine(t)
+	_ = engine.ArmPublish()
+	sleepFn, release := blockingSleepFunc()
+	engine.sleepFn = sleepFn
+	if err := engine.ActivatePublish(); err != nil {
+		t.Fatalf("activate: %v", err)
+	}
+	_ = engine.WritePCM(make([]byte, 960), 1)
+	_ = engine.WritePCM(make([]byte, 500), 1)
+	_ = engine.FlushAudio(1)
+	waitForRingEmpty(t, engine)
+	time.Sleep(30 * time.Millisecond)
+
+	engine.DeactivatePublish()
+	if err := engine.ActivatePublish(); err != nil {
+		t.Fatalf("reactivate: %v", err)
+	}
+	close(release)
+
+	time.Sleep(30 * time.Millisecond)
+	if got := engine.realFramesWritten(); got != 1 {
+		t.Fatalf("old carry leaked after revoke+reactivate: real frames=%d, want 1", got)
 	}
 }
 

--- a/agent/internal/media/rest.go
+++ b/agent/internal/media/rest.go
@@ -68,7 +68,7 @@ const (
 
 // HumanMediaDiscoveryDenied is the DO's agent-room-media denial for an agent
 // whose room has no active Meeting Notes grant — expected and tolerated at
-// bootstrap when the shared session was admitted under voiceReply only.
+// bootstrap when the shared session was admitted under Agent Voice only.
 const HumanMediaDiscoveryDenied = "meeting_notes_not_authorized"
 
 // RoomMediaParticipant describes one Human's media state.

--- a/agent/internal/runtime/media.go
+++ b/agent/internal/runtime/media.go
@@ -89,6 +89,7 @@ func (r *ResidentRuntime) restartMediaController(participantHandle string) {
 	voiceConfig = &media.VoiceConfig{
 		TrackName:     "agent-voice",
 		MaxChunkChars: 220,
+		HostVoiceGate: r.options.HostVoiceGate,
 		CreateTtsProvider: func() (speech.StreamingTtsProvider, error) {
 			if !speechConfig.TTSEnabled {
 				return nil, nil
@@ -158,7 +159,7 @@ func (r *ResidentRuntime) notifySpeechPrerequisite(kind media.GrantKind) {
 // split: the grant kind decides which local slot (STT or TTS) must exist.
 func buildSpeechNotice(config speech.Config, kind media.GrantKind) string {
 	switch kind {
-	case media.GrantVoiceReply:
+	case media.GrantAgentVoice:
 		if !config.TTSEnabled {
 			return "Voice Reply was requested, but no text-to-speech provider is configured in my local runtime. I'll complete speech setup in my own session before speaking — please don't paste API keys into this room."
 		}
@@ -214,7 +215,7 @@ func (r *ResidentRuntime) logVoiceBridgeStats(event string) {
 }
 
 // voiceOutput returns the current speakable output (nil when no live
-// voiceReply grant); callers stay text-only on nil.
+// Agent Voice grant); callers stay text-only on nil.
 func (r *ResidentRuntime) voiceOutput() *voice.Speaker {
 	if r.voiceSrc == nil {
 		return nil

--- a/agent/internal/runtime/runtime.go
+++ b/agent/internal/runtime/runtime.go
@@ -70,6 +70,9 @@ type Options struct {
 	HostSeed string
 	// Voice configures outbound Voice Reply (nil = Meeting Notes only).
 	Voice *media.VoiceConfig
+	// HostVoiceGate is daemon-owned and shared by every resident Runtime on
+	// this local Runtime Host. It serializes full TTS+publication operations.
+	HostVoiceGate voice.Gate
 }
 
 // ResidentRuntime owns exactly one Free4Chat participant across many Harness

--- a/agent/internal/types/types.go
+++ b/agent/internal/types/types.go
@@ -349,11 +349,11 @@ type MeetingNotesInfo struct {
 	StartedAt          int64  `json:"startedAt,omitempty"`
 }
 
-// VoiceReplyInfo is the room-visible voiceReply grant state (#83).
-type VoiceReplyInfo struct {
-	Active             bool   `json:"active"`
-	AgentParticipantID string `json:"agentParticipantId,omitempty"`
-	StartedAt          int64  `json:"startedAt,omitempty"`
+// AgentVoiceGrant is one participant-specific outbound voice authorization.
+// Its presence (not a display name or Runtime Host) is the only Runtime-side
+// permission to speak; EnabledAt is the authorization epoch.
+type AgentVoiceGrant struct {
+	EnabledAt int64 `json:"enabledAt"`
 }
 
 // RoomInfo is the sanitized room_info projection. It never contains tokens,
@@ -364,9 +364,9 @@ type RoomInfo struct {
 	MeetingNotes MeetingNotesInfo         `json:"meetingNotes"`
 	// Fail closed: only explicit true counts. Media is PR 2 scope in the Go
 	// runtime; these fields remain part of the transport contract.
-	MeetingNotesMediaAvailable bool           `json:"meetingNotesMediaAvailable"`
-	VoiceReply                 VoiceReplyInfo `json:"voiceReply"`
-	VoiceReplyMediaAvailable   bool           `json:"voiceReplyMediaAvailable"`
+	MeetingNotesMediaAvailable bool                       `json:"meetingNotesMediaAvailable"`
+	AgentVoice                 map[string]AgentVoiceGrant `json:"agentVoice"`
+	AgentVoiceMediaAvailable   bool                       `json:"agentVoiceMediaAvailable"`
 }
 
 // WaitResult is wait_for_events' long-poll result with the advanced cursor.

--- a/agent/internal/voice/gate.go
+++ b/agent/internal/voice/gate.go
@@ -1,0 +1,34 @@
+package voice
+
+import (
+	"context"
+	"sync"
+)
+
+// Gate serializes a complete audible voice operation. It is intentionally
+// small: no queue persistence, scheduling, or mixing policy. A cancelled
+// waiter must return without later publishing stale audio.
+type Gate interface {
+	Acquire(context.Context) (release func(), err error)
+}
+
+// NewGate returns a FIFO-like host-local semaphore. A single daemon shares
+// this instance with each resident Runtime it creates; direct runtimes get an
+// independent default gate through NewSpeaker.
+func NewGate() Gate {
+	gate := &semaphoreGate{token: make(chan struct{}, 1)}
+	gate.token <- struct{}{}
+	return gate
+}
+
+type semaphoreGate struct{ token chan struct{} }
+
+func (g *semaphoreGate) Acquire(ctx context.Context) (func(), error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-g.token:
+	}
+	var once sync.Once
+	return func() { once.Do(func() { g.token <- struct{}{} }) }, nil
+}

--- a/agent/internal/voice/gate_test.go
+++ b/agent/internal/voice/gate_test.go
@@ -1,0 +1,48 @@
+package voice
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestGateSerializesAndCancelledWaiterNeverAcquires(t *testing.T) {
+	gate := NewGate()
+	releaseA, err := gate.Acquire(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseA()
+
+	ctxB, cancelB := context.WithCancel(context.Background())
+	defer cancelB()
+	acquiredB := make(chan struct{})
+	resultB := make(chan error, 1)
+	go func() {
+		release, err := gate.Acquire(ctxB)
+		if err != nil {
+			resultB <- err
+			return
+		}
+		close(acquiredB)
+		release()
+		resultB <- nil
+	}()
+
+	select {
+	case <-acquiredB:
+		t.Fatal("second host voice execution overlapped the first")
+	case <-time.After(30 * time.Millisecond):
+	}
+	cancelB()
+	if err := <-resultB; !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled queued voice must not acquire: %v", err)
+	}
+	releaseA()
+	select {
+	case <-acquiredB:
+		t.Fatal("cancelled queued voice acquired after the gate released")
+	case <-time.After(30 * time.Millisecond):
+	}
+}

--- a/agent/internal/voice/speaker.go
+++ b/agent/internal/voice/speaker.go
@@ -1,6 +1,7 @@
 package voice
 
 import (
+	"context"
 	"sync"
 	"unicode"
 
@@ -37,7 +38,10 @@ type Options struct {
 	CreateSink      func(token uint64) (Sink, error)
 	MaxQueuedChunks int
 	MaxChunkChars   int
-	OnEvent         func(SpeakerEvent)
+	// Gate spans provider synthesis through final audible flush. A nil gate
+	// gives a direct/test Runtime its own gate.
+	Gate    Gate
+	OnEvent func(SpeakerEvent)
 }
 
 // Speaker is the runtime-owned bridge between response text and the
@@ -57,6 +61,7 @@ type Speaker struct {
 	maxQueuedChunks int
 	maxChunkChars   int
 	onEvent         func(SpeakerEvent)
+	gate            Gate
 
 	mu             sync.Mutex
 	pending        []string
@@ -70,6 +75,7 @@ type Speaker struct {
 	sinkBroken     bool
 	draining       bool
 	drainDone      chan struct{}
+	drainCancel    context.CancelFunc
 }
 
 // NewSpeaker builds an idle speaker.
@@ -85,12 +91,17 @@ func NewSpeaker(options Options) *Speaker {
 	if onEvent == nil {
 		onEvent = func(SpeakerEvent) {}
 	}
+	gate := options.Gate
+	if gate == nil {
+		gate = NewGate()
+	}
 	return &Speaker{
 		provider:        options.Provider,
 		createSink:      options.CreateSink,
 		maxQueuedChunks: maxQueued,
 		maxChunkChars:   options.MaxChunkChars,
 		onEvent:         onEvent,
+		gate:            gate,
 	}
 }
 
@@ -166,6 +177,7 @@ func (s *Speaker) cancelLocked() func() {
 	if s.lastStartedSet {
 		token = uint64(s.lastStarted)
 	}
+	drainCancel := s.drainCancel
 	var action func()
 	sink := s.sink
 	sinkTurn := s.sinkTurn
@@ -185,7 +197,15 @@ func (s *Speaker) cancelLocked() func() {
 	if s.lastStartedSet {
 		s.onEventUnlocked(SpeakerEvent{Type: "turnCancelled", Turn: s.lastStarted})
 	}
-	return action
+	if drainCancel == nil {
+		return action
+	}
+	return func() {
+		drainCancel()
+		if action != nil {
+			action()
+		}
+	}
 }
 
 func (s *Speaker) onEventUnlocked(event SpeakerEvent) {
@@ -204,7 +224,11 @@ func (s *Speaker) Close() error {
 	done := s.drainDone
 	sink := s.sink
 	s.sink = nil
+	cancel := s.drainCancel
 	s.mu.Unlock()
+	if cancel != nil {
+		cancel()
+	}
 	if done != nil {
 		<-done
 	}
@@ -222,13 +246,16 @@ func (s *Speaker) startDrain() {
 	}
 	s.draining = true
 	done := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
 	s.drainDone = done
+	s.drainCancel = cancel
 	s.mu.Unlock()
 	go func() {
-		s.drain()
+		s.drain(ctx)
 		s.mu.Lock()
 		s.draining = false
 		s.drainDone = nil
+		s.drainCancel = nil
 		restart := !s.stopped && len(s.pending) > 0
 		s.mu.Unlock()
 		close(done)
@@ -238,7 +265,12 @@ func (s *Speaker) startDrain() {
 	}()
 }
 
-func (s *Speaker) drain() {
+func (s *Speaker) drain(ctx context.Context) {
+	release, err := s.gate.Acquire(ctx)
+	if err != nil {
+		return
+	}
+	defer release()
 	s.mu.Lock()
 	epoch := s.epoch
 	s.mu.Unlock()

--- a/agent/internal/voice/speaker_host_gate_test.go
+++ b/agent/internal/voice/speaker_host_gate_test.go
@@ -1,0 +1,182 @@
+package voice
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/i365dev/free4chat/agent/internal/speech"
+)
+
+type blockedTtsProvider struct {
+	started chan struct{}
+	release chan struct{}
+	active  *atomic.Int32
+	max     *atomic.Int32
+}
+
+func (p *blockedTtsProvider) CreateSession() (speech.StreamingTtsSession, error) {
+	return p, nil
+}
+
+func (p *blockedTtsProvider) Synthesize(_ string, emit func(speech.TtsAudioChunk) error) error {
+	active := p.active.Add(1)
+	for {
+		seen := p.max.Load()
+		if active <= seen || p.max.CompareAndSwap(seen, active) {
+			break
+		}
+	}
+	defer p.active.Add(-1)
+	p.started <- struct{}{}
+	<-p.release
+	return emit(speech.TtsAudioChunk{
+		Codec: "pcm_s16le", SampleRateHz: 24000, Channels: 1, Data: []byte{1},
+	})
+}
+
+func (*blockedTtsProvider) Close() error { return nil }
+
+func newBlockedSpeaker(gate Gate, provider *blockedTtsProvider, sink *recordingSink) *Speaker {
+	return NewSpeaker(Options{
+		Provider:   provider,
+		CreateSink: func(uint64) (Sink, error) { return sink, nil },
+		Gate:       gate,
+	})
+}
+
+func waitSignal(t *testing.T, signal <-chan struct{}, message string) {
+	t.Helper()
+	select {
+	case <-signal:
+	case <-time.After(time.Second):
+		t.Fatal(message)
+	}
+}
+
+func TestHostVoiceGateSerializesCompleteSpeakerTurns(t *testing.T) {
+	gate := NewGate()
+	var active, max atomic.Int32
+	providerA := &blockedTtsProvider{make(chan struct{}, 1), make(chan struct{}), &active, &max}
+	providerB := &blockedTtsProvider{make(chan struct{}, 1), make(chan struct{}), &active, &max}
+	speakerA := newBlockedSpeaker(gate, providerA, &recordingSink{})
+	speakerB := newBlockedSpeaker(gate, providerB, &recordingSink{})
+	t.Cleanup(func() { _ = speakerA.Close(); _ = speakerB.Close() })
+
+	speakerA.Speak("Agent A")
+	waitSignal(t, providerA.started, "Agent A never began synthesis")
+	speakerB.Speak("Agent B")
+	select {
+	case <-providerB.started:
+		t.Fatal("Agent B began before Agent A released the shared host gate")
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(providerA.release)
+	waitSignal(t, providerB.started, "Agent B did not begin after Agent A completed")
+	close(providerB.release)
+	if got := max.Load(); got != 1 {
+		t.Fatalf("shared host gate allowed %d simultaneous voice operations", got)
+	}
+}
+
+func TestQueuedSpeakerCancellationNeverPublishesAfterGateRelease(t *testing.T) {
+	gate := NewGate()
+	var active, max atomic.Int32
+	providerA := &blockedTtsProvider{make(chan struct{}, 1), make(chan struct{}), &active, &max}
+	providerB := &blockedTtsProvider{make(chan struct{}, 1), make(chan struct{}), &active, &max}
+	sinkB := &recordingSink{}
+	speakerA := newBlockedSpeaker(gate, providerA, &recordingSink{})
+	speakerB := newBlockedSpeaker(gate, providerB, sinkB)
+	t.Cleanup(func() { _ = speakerA.Close(); _ = speakerB.Close() })
+
+	speakerA.Speak("Agent A")
+	waitSignal(t, providerA.started, "Agent A never began synthesis")
+	speakerB.Speak("Agent B")
+	speakerB.Cancel()
+	close(providerA.release)
+	select {
+	case <-providerB.started:
+		t.Fatal("cancelled queued Agent B acquired the host gate")
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := len(sinkB.order); got != 0 {
+		t.Fatalf("cancelled queued Agent B published %d stale audio bytes", got)
+	}
+}
+
+type immediateTtsProvider struct{ started chan struct{} }
+
+func (p *immediateTtsProvider) CreateSession() (speech.StreamingTtsSession, error) {
+	return p, nil
+}
+
+func (p *immediateTtsProvider) Synthesize(_ string, emit func(speech.TtsAudioChunk) error) error {
+	p.started <- struct{}{}
+	return emit(speech.TtsAudioChunk{
+		Codec: "pcm_s16le", SampleRateHz: 24000, Channels: 1, Data: []byte{1},
+	})
+}
+
+func (*immediateTtsProvider) Close() error { return nil }
+
+type flushBarrierSink struct {
+	*recordingSink
+	entered    chan struct{}
+	release    chan struct{}
+	cancelled  chan struct{}
+	cancelOnce sync.Once
+}
+
+func (s *flushBarrierSink) EndTurn() error {
+	s.entered <- struct{}{}
+	select {
+	case <-s.release:
+	case <-s.cancelled:
+		return errStaleTurn
+	}
+	return s.recordingSink.EndTurn()
+}
+
+func (s *flushBarrierSink) CancelTurn() error {
+	s.cancelOnce.Do(func() { close(s.cancelled) })
+	return s.recordingSink.CancelTurn()
+}
+
+func TestHostVoiceGateWaitsForAudibleFlushCompletion(t *testing.T) {
+	gate := NewGate()
+	providerA := &immediateTtsProvider{started: make(chan struct{}, 1)}
+	providerB := &immediateTtsProvider{started: make(chan struct{}, 1)}
+	sinkA := &flushBarrierSink{
+		recordingSink: &recordingSink{},
+		entered:       make(chan struct{}, 1),
+		release:       make(chan struct{}),
+		cancelled:     make(chan struct{}),
+	}
+	speakerA := NewSpeaker(Options{
+		Provider: providerA,
+		CreateSink: func(uint64) (Sink, error) {
+			return sinkA, nil
+		},
+		Gate: gate,
+	})
+	speakerB := NewSpeaker(Options{
+		Provider: providerB,
+		CreateSink: func(uint64) (Sink, error) {
+			return &recordingSink{}, nil
+		},
+		Gate: gate,
+	})
+	t.Cleanup(func() { _ = speakerA.Close(); _ = speakerB.Close() })
+
+	speakerA.Speak("Agent A")
+	waitSignal(t, sinkA.entered, "Agent A never reached final flush")
+	speakerB.Speak("Agent B")
+	select {
+	case <-providerB.started:
+		t.Fatal("Agent B started while Agent A audio was still flushing")
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(sinkA.release)
+	waitSignal(t, providerB.started, "Agent B did not start after Agent A flush completed")
+}

--- a/app/src/common/types.tsx
+++ b/app/src/common/types.tsx
@@ -15,6 +15,10 @@ export interface UserInfo {
   // #176 Phase A: the Room-scoped Runtime Host id behind this Agent (agents
   // only). Readiness itself travels once per host in Room state.
   runtimeHostId?: string
+  // Derived client-side from one Runtime Host TTS projection plus the Room's
+  // participant-specific agentVoice authorization. Never persisted here.
+  voiceAvailable?: boolean
+  voiceEnabled?: boolean
 }
 
 export type MessageType = "text" | "image" | "file" | "action"

--- a/app/src/components/RoomContent.tsx
+++ b/app/src/components/RoomContent.tsx
@@ -149,10 +149,8 @@ export default function RoomContent({
     meetingNotesMediaAvailable,
     startMeetingNotes,
     stopMeetingNotes,
-    voiceReply: voiceReplyState,
-    voiceReplyMediaAvailable,
-    startVoiceReply,
-    stopVoiceReply,
+    agentVoiceMediaAvailable,
+    setAgentVoice,
     localParticipantId,
   } = useSfuChatRoom(roomName, nickName, roomType, {
     getTurnstileToken: requestToken,
@@ -173,17 +171,13 @@ export default function RoomContent({
     )
 
   const roomAgents = participants.filter((p) => p.kind === "agent")
-  // Defensive defaults keep partial hook mocks in tests valid.
-  const voiceReply = voiceReplyState ?? { active: false }
-  const connectedAgentForVoice = roomAgents[0]
-  const handleStartVoiceReply = () => {
-    if (!connectedAgentForVoice) return
-    startVoiceReply(connectedAgentForVoice.peerId)
-    trackAnalyticsEvent("AgentVoiceStarted", { roomType: resolvedRoomType })
-  }
-  const handleStopVoiceReply = () => {
-    stopVoiceReply()
-    trackAnalyticsEvent("AgentVoiceStopped", { roomType: resolvedRoomType })
+  const toggleAgentVoice = (participant: UserInfo) => {
+    if (!participant.voiceAvailable) return
+    const enabled = !participant.voiceEnabled
+    setAgentVoice(participant.peerId, enabled)
+    trackAnalyticsEvent(enabled ? "AgentVoiceStarted" : "AgentVoiceStopped", {
+      roomType: resolvedRoomType,
+    })
   }
   const meetingNotesAgentName = meetingNotes.active
     ? roomAgents.find((p) => p.peerId === meetingNotes.agentParticipantId)
@@ -584,28 +578,6 @@ export default function RoomContent({
           >
             {agentInviteCopied ? "Copied!" : "Invite Agent"}
           </button>
-          {voiceReply.active ? (
-            <button
-              type="button"
-              onClick={handleStopVoiceReply}
-              className="rounded-md border border-rose-700/60 bg-rose-900/30 px-3 py-1 text-xs text-rose-200 hover:bg-rose-800/50"
-              title="Stop Agent voice replies"
-            >
-              🔊 Stop voice
-            </button>
-          ) : (
-            voiceReplyMediaAvailable &&
-            connectedAgentForVoice && (
-              <button
-                type="button"
-                onClick={handleStartVoiceReply}
-                className="rounded-md border border-emerald-700/60 bg-emerald-900/30 px-3 py-1 text-xs text-emerald-200 hover:bg-emerald-800/50"
-                title={`Enable voice replies from ${connectedAgentForVoice.name}`}
-              >
-                🔊 Voice replies
-              </button>
-            )
-          )}
           {meetingNotes.active ? (
             <button
               type="button"
@@ -781,6 +753,11 @@ export default function RoomContent({
                         onToggleScreenShare={wrappedToggleScreenShare}
                         screenshareAllowed={screenshareAllowed}
                         onRequestWork={() => requestWorkFor(p)}
+                        voiceAvailable={
+                          p.voiceAvailable && agentVoiceMediaAvailable
+                        }
+                        voiceEnabled={p.voiceEnabled}
+                        onToggleAgentVoice={() => toggleAgentVoice(p)}
                         className="w-20"
                         compact
                       />
@@ -807,6 +784,11 @@ export default function RoomContent({
                       onMuteSelf={muteSelf}
                       onToggleScreenShare={wrappedToggleScreenShare}
                       onRequestWork={() => requestWorkFor(p)}
+                      voiceAvailable={
+                        p.voiceAvailable && agentVoiceMediaAvailable
+                      }
+                      voiceEnabled={p.voiceEnabled}
+                      onToggleAgentVoice={() => toggleAgentVoice(p)}
                       screenshareAllowed={screenshareAllowed}
                       onEditCapabilities={
                         p.kind === "human" && p.peerId === LOCAL_PEER_ID

--- a/app/src/components/UserCard.agentVoice.test.tsx
+++ b/app/src/components/UserCard.agentVoice.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import UserCard from "./UserCard"
+
+function card(overrides: Record<string, unknown> = {}) {
+  return {
+    name: "Pi",
+    kind: "agent" as const,
+    room: "room",
+    peerId: "pi",
+    voiceAvailable: true,
+    voiceEnabled: false,
+    onToggleAgentVoice: vi.fn(),
+    ...overrides,
+  }
+}
+
+describe("UserCard Agent Voice", () => {
+  it("shows an accessible per-Agent enable control", () => {
+    const props = card()
+    const { getByRole } = render(<UserCard {...props} />)
+    fireEvent.click(getByRole("button", { name: "Enable voice for Pi" }))
+    expect(props.onToggleAgentVoice).toHaveBeenCalledOnce()
+  })
+
+  it("renders an independent enabled control and a disabled unavailable control", () => {
+    const { getByRole, rerender } = render(
+      <UserCard {...card({ voiceEnabled: true })} />
+    )
+    expect(getByRole("button", { name: "Mute Pi" })).not.toBeDisabled()
+    rerender(<UserCard {...card({ voiceAvailable: false })} />)
+    expect(getByRole("button", { name: "Voice unavailable" })).toBeDisabled()
+  })
+})

--- a/app/src/components/UserCard.tsx
+++ b/app/src/components/UserCard.tsx
@@ -19,6 +19,10 @@ interface UserCardProps extends UserInfo {
   /** #119: present ONLY for the LOCAL Human self — opens the capability
    * editor. Never rendered on remote Humans or Agent cards. */
   onEditCapabilities?: () => void
+  /** Room-wide publish authorization for this eligible Agent only. */
+  voiceAvailable?: boolean
+  voiceEnabled?: boolean
+  onToggleAgentVoice?: () => void
 }
 
 export default function UserCard(user: UserCardProps) {
@@ -98,6 +102,30 @@ export default function UserCard(user: UserCardProps) {
             <span className="mt-1 rounded-full bg-black/20 px-1.5 py-0.5 text-[9px] text-white/50">
               🤖 Agent
             </span>
+          )}
+          {user.kind === "agent" && (
+            <button
+              type="button"
+              onClick={user.onToggleAgentVoice}
+              disabled={!user.voiceAvailable}
+              title={
+                !user.voiceAvailable
+                  ? "Voice unavailable"
+                  : user.voiceEnabled
+                  ? `Mute ${user.name}`
+                  : `Enable voice for ${user.name}`
+              }
+              aria-label={
+                !user.voiceAvailable
+                  ? "Voice unavailable"
+                  : user.voiceEnabled
+                  ? `Mute ${user.name}`
+                  : `Enable voice for ${user.name}`
+              }
+              className="mt-1 min-h-6 rounded-full border border-gray-500 px-2 text-[9px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {user.voiceEnabled ? "🔊" : "🔇"}
+            </button>
           )}
           {user.kind === "agent" && user.onRequestWork && !isSelf && (
             <button
@@ -286,6 +314,30 @@ export default function UserCard(user: UserCardProps) {
               className="rounded-full bg-blue-600/80 px-2 py-0.5 text-[10px] text-white hover:bg-blue-500"
             >
               Request work
+            </button>
+          )}
+          {user.kind === "agent" && (
+            <button
+              type="button"
+              onClick={user.onToggleAgentVoice}
+              disabled={!user.voiceAvailable}
+              title={
+                !user.voiceAvailable
+                  ? "Voice unavailable"
+                  : user.voiceEnabled
+                  ? `Mute ${user.name}`
+                  : `Enable voice for ${user.name}`
+              }
+              aria-label={
+                !user.voiceAvailable
+                  ? "Voice unavailable"
+                  : user.voiceEnabled
+                  ? `Mute ${user.name}`
+                  : `Enable voice for ${user.name}`
+              }
+              className="min-h-7 rounded-full border border-gray-500 px-2 text-[10px] text-white hover:bg-black/20 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {user.voiceEnabled ? "🔊 Voice" : "🔇 Voice"}
             </button>
           )}
           {isSelf && user.kind === "human" && user.onEditCapabilities && (

--- a/app/src/do/RoomSession.ts
+++ b/app/src/do/RoomSession.ts
@@ -18,16 +18,12 @@ import {
 import {
   agentMediaPermissions,
   clearGrantIfParticipantDeparting,
-  clearVoiceReplyIfParticipantDeparting,
   isAgentAuthorizedForMedia,
   isAgentAuthorizedForSharedMedia,
-  isAgentAuthorizedForVoiceReply,
-  isValidVoiceReplyState,
+  isAgentAuthorizedForVoice,
   NO_MEETING_NOTES,
-  NO_VOICE_REPLY,
   resolveAgentPurposePermission,
   startMeetingNotes,
-  startVoiceReply,
 } from "./meetingNotesAuth"
 import {
   closeRealtimeTracks,
@@ -51,12 +47,12 @@ import {
 } from "./surface"
 import type {
   AgentCapabilities,
+  AgentVoiceState,
   AgentEvent,
   RoomCapabilities,
   RoomAttachment,
   MeetingNotesState,
   PendingMediaCleanup,
-  VoiceReplyState,
   RoomMediaTrack,
   AgentAttachmentMimeType,
   RoomMessage,
@@ -172,7 +168,7 @@ interface StoredRoom
     | "attachments"
     | "nextMessageSequence"
     | "meetingNotes"
-    | "voiceReply"
+    | "agentVoice"
     | "pendingMediaCleanup"
   > {
   participants: Record<string, StoredParticipant>
@@ -180,7 +176,9 @@ interface StoredRoom
   attachments?: RoomAttachment[]
   nextMessageSequence?: number
   meetingNotes?: MeetingNotesState
-  voiceReply?: VoiceReplyState
+  // Legacy singleton state is read only to fail closed during migration.
+  voiceReply?: unknown
+  agentVoice?: unknown
   pendingMediaCleanup?: PendingMediaCleanup[]
 }
 
@@ -446,21 +444,18 @@ type ClientMessage =
   | { type: "leave" }
   | { type: "meeting-notes-start"; agentParticipantId: string }
   | { type: "meeting-notes-stop" }
-  | { type: "voice-reply-start"; agentParticipantId: string }
-  | { type: "voice-reply-stop" }
+  | {
+      type: "agent-voice-set"
+      agentParticipantId: string
+      enabled: boolean
+    }
 
-/** #83 live-fix storage hygiene for one Agent participant's media block:
- * an agent holding the ACTIVE voiceReply grant may keep its single published
- * outbound audio track (and the registered mid Stop needs for revocation)
- * across room loads. Every other shape — no grant, wrong agent, multiple
- * tracks, video, or a mid without a matching track or pending track name — is
- * stripped exactly as the old subscribe-only rule did. A pending publication
- * is kept private until the Runtime confirms its first PCM write. This
- * preserves an authorized publication across DO eviction/restart; it never
- * loosens who may create one. */
+/** Storage hygiene for one Agent participant's published voice media. A
+ * current per-participant grant is required to retain its revocation handle;
+ * every other shape is stripped fail closed on load. */
 export function normalizeAgentParticipantMedia(
   media: RoomParticipant["media"],
-  voiceReply: VoiceReplyState,
+  agentVoice: AgentVoiceState,
   participantId: string
 ): { media: RoomParticipant["media"]; changed: boolean } {
   if (!media) return { media, changed: false }
@@ -475,11 +470,8 @@ export function normalizeAgentParticipantMedia(
     media.agentPublishedTrackName.length > 0
       ? media.agentPublishedTrackName
       : undefined
-  // Callers pass the ALREADY-NORMALIZED grant (normalizeRoom hoists
-  // isValidVoiceReplyState above this decision); authorization reuses the
-  // exact production predicate so no second rule can drift.
   const authorized =
-    isAgentAuthorizedForVoiceReply(voiceReply, participantId) &&
+    isAgentAuthorizedForVoice(agentVoice, participantId) &&
     publishedMid !== undefined &&
     ((tracks.length === 1 && tracks[0]!.kind === "audio") ||
       (tracks.length === 0 && pendingTrackName !== undefined))
@@ -537,7 +529,14 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     const stored = await this.ctx.storage.get<StoredRoom>("room")
     if (!stored) return null
     const normalized = this.normalizeRoom(stored)
-    if (normalized.changed) await this.saveRoom(normalized.room)
+    if (normalized.changed) {
+      // A legacy-voice migration may have staged an already-flowing RTP mid.
+      // Persist and arm the short cleanup retry before this normalized Room
+      // state is ever returned to a caller; do not fetch here, because that
+      // would leave the caller holding a stale RoomRecord across I/O.
+      await this.saveRoom(normalized.room)
+      await this.scheduleNextAlarm(normalized.room)
+    }
     return normalized.room
   }
 
@@ -546,14 +545,6 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     changed: boolean
   } {
     let changed = false
-    // Normalize the voiceReply grant FIRST so agent media hygiene below
-    // sees the post-validation state — a persisted {active:true, matching
-    // agent} block with a missing/invalid startedAt must degrade to
-    // NO_VOICE_REPLY before the publication-preservation decision, never
-    // after (P1 fail-closed ordering).
-    const normalizedVoiceReply = isValidVoiceReplyState(stored.voiceReply)
-      ? stored.voiceReply
-      : NO_VOICE_REPLY
     const participants: Record<string, RoomParticipant> = {}
 
     for (const [id, rawParticipant] of Object.entries(stored.participants)) {
@@ -600,15 +591,6 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
             delete participant[key]
             changed = true
           }
-        }
-        const normalizedAgentMedia = normalizeAgentParticipantMedia(
-          participant.media,
-          normalizedVoiceReply,
-          participant.id
-        )
-        if (normalizedAgentMedia.changed) {
-          participant.media = normalizedAgentMedia.media
-          changed = true
         }
         if (participant.media?.agentSubscribedMids !== undefined) {
           const validMids = Array.isArray(participant.media.agentSubscribedMids)
@@ -740,23 +722,54 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       changed = true
     }
 
-    let voiceReply: VoiceReplyState = normalizedVoiceReply
-    if (
-      voiceReply.active &&
-      (!voiceReply.agentParticipantId ||
-        participants[voiceReply.agentParticipantId]?.kind !== "agent")
-    ) {
-      // Stale grant (departed/never-agent) must not keep authorizing.
-      voiceReply = NO_VOICE_REPLY
-      changed = true
-    }
-
     let pendingMediaCleanup: PendingMediaCleanup[]
     if (this.validPendingMediaCleanup(stored.pendingMediaCleanup)) {
       pendingMediaCleanup = stored.pendingMediaCleanup
     } else {
       pendingMediaCleanup = []
       changed = true
+    }
+
+    // #170 migration deliberately ignores every legacy singleton
+    // voiceReply as authorization. Before dropping that state, however,
+    // durable-stage its known outbound mid: an established Cloudflare track
+    // keeps flowing after Room state has been rewritten unless the server
+    // still owns the tracks/close handle. This is corrective revocation, not
+    // a grant transfer — the Agent remains muted in agentVoice.
+    const legacyVoiceParticipantId = this.legacyVoiceParticipantId(
+      stored.voiceReply
+    )
+    if (stored.voiceReply !== undefined) changed = true
+    if (legacyVoiceParticipantId) {
+      const legacyParticipant = participants[legacyVoiceParticipantId]
+      const legacyMid = legacyParticipant?.media?.agentPublishedMid
+      if (legacyParticipant?.kind === "agent" && legacyMid) {
+        pendingMediaCleanup = stageAgentMediaRevocation(
+          legacyParticipant,
+          pendingMediaCleanup,
+          "published"
+        )
+        changed = true
+      }
+    }
+    const normalizedAgentVoice = this.normalizeAgentVoice(
+      stored.agentVoice,
+      participants,
+      runtimeHosts
+    )
+    if (normalizedAgentVoice.changed) changed = true
+    const agentVoice = normalizedAgentVoice.agentVoice
+    for (const participant of Object.values(participants)) {
+      if (participant.kind !== "agent") continue
+      const normalizedAgentMedia = normalizeAgentParticipantMedia(
+        participant.media,
+        agentVoice,
+        participant.id
+      )
+      if (normalizedAgentMedia.changed) {
+        participant.media = normalizedAgentMedia.media
+        changed = true
+      }
     }
 
     return {
@@ -769,7 +782,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         attachments,
         nextMessageSequence,
         meetingNotes,
-        voiceReply,
+        agentVoice,
         pendingMediaCleanup,
       },
       changed,
@@ -788,8 +801,53 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
     )
   }
 
-  private validVoiceReply(value: unknown): value is VoiceReplyState {
-    return isValidVoiceReplyState(value)
+  private normalizeAgentVoice(
+    value: unknown,
+    participants: Record<string, RoomParticipant>,
+    runtimeHosts: Record<string, RuntimeHostProjection>
+  ): { agentVoice: AgentVoiceState; changed: boolean } {
+    const raw =
+      value && typeof value === "object" && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : {}
+    let changed = raw !== value
+    const agentVoice: AgentVoiceState = {}
+    for (const [participantId, rawGrant] of Object.entries(raw)) {
+      const participant = participants[participantId]
+      const host = participant?.runtimeHostId
+        ? runtimeHosts[participant.runtimeHostId]
+        : undefined
+      const grant = rawGrant as Partial<AgentVoiceState[string]> | null
+      const valid =
+        participant?.kind === "agent" &&
+        participant.connected &&
+        host?.speech.tts === true &&
+        Boolean(grant) &&
+        grant?.enabled === true &&
+        typeof grant.enabledAt === "number" &&
+        Number.isFinite(grant.enabledAt) &&
+        grant.enabledAt > 0
+      if (!valid) {
+        changed = true
+        continue
+      }
+      agentVoice[participantId] = {
+        enabled: true,
+        enabledAt: grant.enabledAt!,
+      }
+    }
+    return { agentVoice, changed }
+  }
+
+  private legacyVoiceParticipantId(value: unknown): string | undefined {
+    if (!value || typeof value !== "object") return undefined
+    const candidate = value as {
+      agentParticipantId?: unknown
+    }
+    return typeof candidate.agentParticipantId === "string" &&
+      candidate.agentParticipantId.length > 0
+      ? candidate.agentParticipantId
+      : undefined
   }
 
   private validPendingMediaCleanup(
@@ -906,8 +964,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       messages: room.messages,
       meetingNotes: room.meetingNotes,
       meetingNotesMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
-      voiceReply: room.voiceReply,
-      voiceReplyMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
+      agentVoice: room.agentVoice,
+      agentVoiceMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
     }
   }
 
@@ -1359,12 +1417,12 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         // agentParticipantId is already visible in `participants` above.
         meetingNotes: room?.meetingNotes ?? NO_MEETING_NOTES,
         meetingNotesMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
-        voiceReply: room?.voiceReply ?? NO_VOICE_REPLY,
-        voiceReplyMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
+        agentVoice: room?.agentVoice ?? {},
+        agentVoiceMediaAvailable: this.env.AGENT_MEDIA_ENABLED === "true",
         mediaPermissions: room
           ? agentMediaPermissions(
               room.meetingNotes,
-              room.voiceReply,
+              room.agentVoice,
               request.participantId
             )
           : { canSubscribeHumanAudio: false, canPublishVoice: false },
@@ -1390,7 +1448,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           attachments: [],
           nextMessageSequence: 0,
           meetingNotes: NO_MEETING_NOTES,
-          voiceReply: { active: false },
+          agentVoice: {},
           pendingMediaCleanup: [],
         }
       }
@@ -1506,7 +1564,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         attachments: [],
         nextMessageSequence: 0,
         meetingNotes: NO_MEETING_NOTES,
-        voiceReply: { active: false },
+        agentVoice: {},
         pendingMediaCleanup: [],
       }
       const participant: RoomParticipant = {
@@ -1614,15 +1672,36 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           { error: validated.error, reason: validated.reason },
           400
         )
+      const host = validated.runtimeHost
+      const previousHostId = participant.runtimeHostId
+      const previousProjection = room.runtimeHosts?.[host.runtimeHostId]
       // Canonical Room model (#176): upsert ONE readiness projection per
       // host id, shared by all same-host Agents, then reference it from this
-      // participant. Presence/discovery broadcast only.
-      const host = validated.runtimeHost
+      // participant. #170 makes authorization fail closed on either a host
+      // switch or a same-host TTS readiness loss.
       room.runtimeHosts = {
         ...(room.runtimeHosts ?? {}),
         [host.runtimeHostId]: host,
       }
       participant.runtimeHostId = host.runtimeHostId
+      const revokeVoice = (candidate: RoomParticipant) => {
+        if (!room.agentVoice[candidate.id]) return
+        delete room.agentVoice[candidate.id]
+        this.stageAgentMediaRevocation(room, candidate.id, "published")
+      }
+      if (previousHostId && previousHostId !== host.runtimeHostId)
+        revokeVoice(participant)
+      if (
+        previousProjection?.speech.tts === true &&
+        host.speech.tts === false
+      ) {
+        for (const candidate of Object.values(room.participants))
+          if (
+            candidate.kind === "agent" &&
+            candidate.runtimeHostId === host.runtimeHostId
+          )
+            revokeVoice(candidate)
+      }
       // Re-projection may move this participant to a new host id: collect
       // the previously referenced host if nothing else uses it.
       this.gcRuntimeHosts(room)
@@ -1630,6 +1709,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       await this.saveRoom(room)
       await this.scheduleNextAlarm(room)
       await this.broadcastState(room)
+      await this.attemptCleanupNow(room.pendingMediaCleanup)
       return this.json({
         runtimeHost: host,
         runtimeHosts: room.runtimeHosts,
@@ -1812,7 +1892,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (
         !isAgentAuthorizedForSharedMedia(
           room.meetingNotes,
-          room.voiceReply,
+          room.agentVoice,
           participant.id
         )
       )
@@ -1846,7 +1926,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (
         !isAgentAuthorizedForSharedMedia(
           room.meetingNotes,
-          room.voiceReply,
+          room.agentVoice,
           participant.id
         )
       )
@@ -2115,10 +2195,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         room.meetingNotes,
         participant.id
       )
-      room.voiceReply = clearVoiceReplyIfParticipantDeparting(
-        room.voiceReply,
-        participant.id
-      )
+      delete room.agentVoice[participant.id]
       this.applyEmptyRoomExpiry(room, Date.now())
       await this.saveRoom(room)
       // #111: no surface history survives departure — chunks die after the
@@ -2189,7 +2266,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         }
         if (
           request.wantsVoicePublish === true &&
-          !isAgentAuthorizedForVoiceReply(room.voiceReply, participant.id)
+          !isAgentAuthorizedForVoice(room.agentVoice, participant.id)
         )
           return this.json({ error: "voice_reply_not_authorized" }, 403)
         if (
@@ -2199,7 +2276,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           return this.json({ error: "meeting_notes_not_authorized" }, 403)
         if (
           request.purpose === "voice-reply" &&
-          !isAgentAuthorizedForVoiceReply(room.voiceReply, participant.id)
+          !isAgentAuthorizedForVoice(room.agentVoice, participant.id)
         )
           return this.json({ error: "voice_reply_not_authorized" }, 403)
         // #83 review: the shared transport/bootstrap purpose is authorized
@@ -2210,7 +2287,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           request.purpose === "agent-transport" &&
           !isAgentAuthorizedForSharedMedia(
             room.meetingNotes,
-            room.voiceReply,
+            room.agentVoice,
             participant.id
           )
         )
@@ -2221,8 +2298,8 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         )
           return this.json({ error: "agent_publish_capacity_exceeded" }, 503)
       }
-      // Round 5 (P2): preflight capacity check *before* the Worker ever
-      // calls Cloudflare's tracks/new for these remote subscriptions —
+      // Preflight capacity check *before* the Worker ever
+      // calls Cloudflare's tracks/new for any new Agent media track —
       // catching an already-backpressured room here means it never creates
       // yet another upstream subscription only to have agent-track-
       // subscribed reject it afterward (which would just grow the very
@@ -2231,24 +2308,27 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       // revoked or reassigned in the window between this call and
       // tracks/new actually completing (the TOCTOU race — finding #2/
       // Blocker 2), which only the post-upstream registration can catch.
-      if (
-        participant.kind === "agent" &&
-        request.remoteTrackCount &&
-        request.remoteTrackCount > 0
-      ) {
-        const activeMids = participant.media?.agentSubscribedMids?.length ?? 0
-        if (activeMids + request.remoteTrackCount > MAX_AGENT_SUBSCRIBED_MIDS)
-          return this.json({ error: "agent_media_capacity_exceeded" }, 503)
-        const sessionId =
-          participant.media?.sessionId ?? request.sessionId ?? ""
-        if (
-          !pendingCleanupHasCapacity(
-            room.pendingMediaCleanup,
-            sessionId,
-            request.remoteTrackCount
+      if (participant.kind === "agent") {
+        const remoteTrackCount = request.remoteTrackCount ?? 0
+        const localTrackCount = request.localTrackCount ?? 0
+        if (remoteTrackCount > 0) {
+          const activeMids = participant.media?.agentSubscribedMids?.length ?? 0
+          if (activeMids + remoteTrackCount > MAX_AGENT_SUBSCRIBED_MIDS)
+            return this.json({ error: "agent_media_capacity_exceeded" }, 503)
+        }
+        const newTrackCount = remoteTrackCount + localTrackCount
+        if (newTrackCount > 0) {
+          const sessionId =
+            participant.media?.sessionId ?? request.sessionId ?? ""
+          if (
+            !pendingCleanupHasCapacity(
+              room.pendingMediaCleanup,
+              sessionId,
+              newTrackCount
+            )
           )
-        )
-          return this.json({ error: "agent_media_cleanup_backlog" }, 503)
+            return this.json({ error: "agent_media_cleanup_backlog" }, 503)
+        }
       }
       if (request.trackSessionId && request.trackName) {
         // #83 review: an Agent's exact-track reauthorization must resolve to
@@ -2360,7 +2440,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       if (!participant || participant.kind !== "agent")
         return this.json({ error: "unauthorized" }, 401)
       if (
-        !isAgentAuthorizedForVoiceReply(room.voiceReply, participant.id) ||
+        !isAgentAuthorizedForVoice(room.agentVoice, participant.id) ||
         typeof request.mid !== "string" ||
         request.mid.length === 0
       )
@@ -2372,6 +2452,20 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
         participant.media.agentPublishedMid !== request.mid
       )
         return this.json({ error: "agent_publish_capacity_exceeded" }, 503)
+      // This is the post-upstream half of the local publication admission
+      // check. A cleanup backlog may have filled after /tracks authorize but
+      // before Cloudflare returned this mid; refuse registration so the
+      // Worker closes (or durably hands off) this just-created track rather
+      // than creating more unrevocable RTP pressure.
+      if (
+        !participant.media.agentPublishedMid &&
+        !pendingCleanupHasCapacity(
+          room.pendingMediaCleanup,
+          participant.media.sessionId,
+          1
+        )
+      )
+        return this.json({ error: "agent_media_cleanup_backlog" }, 503)
       participant.media = {
         ...participant.media,
         agentPublishedMid: request.mid,
@@ -2399,7 +2493,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       )
       if (!participant || participant.kind !== "agent")
         return this.json({ error: "unauthorized" }, 401)
-      if (!isAgentAuthorizedForVoiceReply(room.voiceReply, participant.id))
+      if (!isAgentAuthorizedForVoice(room.agentVoice, participant.id))
         return this.json({ error: "voice_reply_not_authorized" }, 403)
       if (!participant.media)
         return this.json({ error: "media_unavailable" }, 400)
@@ -2458,10 +2552,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       room.meetingNotes,
       participant.id
     )
-    room.voiceReply = clearVoiceReplyIfParticipantDeparting(
-      room.voiceReply,
-      participant.id
-    )
+    delete room.agentVoice[participant.id]
     this.applyEmptyRoomExpiry(room, Date.now())
     await this.saveRoom(room)
     await this.broadcastState(room)
@@ -2811,60 +2902,61 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
       await this.attemptCleanupNow(room.pendingMediaCleanup)
       return
     }
-    if (message.type === "voice-reply-start") {
-      if (this.env.AGENT_MEDIA_ENABLED !== "true") {
-        socket.send(
-          JSON.stringify({ type: "error", error: "voice_reply_media_disabled" })
-        )
+    if (message.type === "agent-voice-set") {
+      if (participant.kind !== "human") {
+        socket.send(JSON.stringify({ type: "error", error: "human_only" }))
         return
       }
       const agent = room.participants[message.agentParticipantId]
-      if (!agent || agent.kind !== "agent" || !agent.connected) {
-        socket.send(
-          JSON.stringify({ type: "error", error: "agent_not_in_room" })
+      if (message.enabled) {
+        const host = agent?.runtimeHostId
+          ? room.runtimeHosts?.[agent.runtimeHostId]
+          : undefined
+        if (
+          this.env.AGENT_MEDIA_ENABLED !== "true" ||
+          !agent ||
+          agent.kind !== "agent" ||
+          !agent.connected ||
+          host?.speech.tts !== true
+        ) {
+          socket.send(
+            JSON.stringify({ type: "error", error: "voice_unavailable" })
+          )
+          return
+        }
+        // Idempotent enable preserves the epoch and avoids an unnecessary
+        // Runtime publication restart.
+        if (!isAgentAuthorizedForVoice(room.agentVoice, agent.id)) {
+          // Fast-fail before giving the Runtime a new local publication
+          // authorization. The /tracks authorize preflight below is the
+          // authoritative TOCTOU check immediately before Cloudflare work;
+          // this control-path check simply keeps a backpressured Room muted.
+          const sessionId = agent.media?.sessionId ?? ""
+          if (
+            !pendingCleanupHasCapacity(room.pendingMediaCleanup, sessionId, 1)
+          ) {
+            socket.send(
+              JSON.stringify({
+                type: "error",
+                error: "agent_media_cleanup_backlog",
+              })
+            )
+            return
+          }
+          room.agentVoice[agent.id] = { enabled: true, enabledAt: Date.now() }
+        }
+      } else if (room.agentVoice[message.agentParticipantId]) {
+        delete room.agentVoice[message.agentParticipantId]
+        // Stop only this Agent's outbound publication; Meeting Notes and
+        // every other Agent's independent voice authorization survive.
+        this.stageAgentMediaRevocation(
+          room,
+          message.agentParticipantId,
+          "published"
         )
-        return
       }
-      // Idempotent replay: same speaker must not bump the epoch (the runtime
-      // treats an epoch change as "server tore down the publication").
-      if (isAgentAuthorizedForVoiceReply(room.voiceReply, agent.id)) {
-        socket.send(
-          JSON.stringify({ type: "state", state: this.stateFor(room) })
-        )
-        return
-      }
-      if (room.pendingMediaCleanup.length >= MAX_PENDING_CLEANUP_ENTRIES) {
-        socket.send(
-          JSON.stringify({
-            type: "error",
-            error: "agent_media_cleanup_backlog",
-          })
-        )
-        return
-      }
-      const previousAgentId = room.voiceReply.agentParticipantId
-      room.voiceReply = startVoiceReply(agent.id, Date.now())
-      // Reassignment (A -> B): stage A's established publication durably
-      // before any Cloudflare fetch is attempted — published direction
-      // only: A may still hold an independent active Meeting Notes grant
-      // whose Human->Agent subscriptions must survive this trigger.
-      if (previousAgentId && previousAgentId !== agent.id)
-        this.stageAgentMediaRevocation(room, previousAgentId, "published")
-      await this.saveRoom(room)
-      await this.scheduleNextAlarm(room)
-      await this.broadcastState(room)
-      await this.attemptCleanupNow(room.pendingMediaCleanup)
-      return
-    }
-    if (message.type === "voice-reply-stop") {
-      const previousAgentId = room.voiceReply.agentParticipantId
-      room.voiceReply = NO_VOICE_REPLY
-      // Directional revocation (#83): a voiceReply stop closes only the
-      // stopped grant's Agent->Human published mid and drops the
-      // room-visible Agent audio track — never independent Meeting Notes
-      // subscriptions the same agent may still hold.
-      if (previousAgentId)
-        this.stageAgentMediaRevocation(room, previousAgentId, "published")
+      // This is presence/authorization state only: no RoomMessage, sequence
+      // increment, or Agent waiter wakeup.
       await this.saveRoom(room)
       await this.scheduleNextAlarm(room)
       await this.broadcastState(room)
@@ -3348,10 +3440,7 @@ export class RoomSession extends DurableObject<RoomSessionEnv> {
           room.meetingNotes,
           id
         )
-        room.voiceReply = clearVoiceReplyIfParticipantDeparting(
-          room.voiceReply,
-          id
-        )
+        delete room.agentVoice[id]
         changed = true
         const waiter = this.agentWaiters.get(id)
         if (waiter) {

--- a/app/src/do/meetingNotesAuth.test.ts
+++ b/app/src/do/meetingNotesAuth.test.ts
@@ -4,12 +4,10 @@ import {
   clearGrantIfParticipantDeparting,
   isAgentAuthorizedForMedia,
   isAgentAuthorizedForSharedMedia,
-  isValidVoiceReplyState,
+  isAgentAuthorizedForVoice,
   NO_MEETING_NOTES,
-  NO_VOICE_REPLY,
   resolveAgentPurposePermission,
   startMeetingNotes,
-  startVoiceReply,
 } from "./meetingNotesAuth"
 
 describe("isAgentAuthorizedForMedia", () => {
@@ -98,42 +96,54 @@ describe("full lifecycle", () => {
 describe("isAgentAuthorizedForSharedMedia (#83 review: MN OR VR admission)", () => {
   const mn = (agent?: string) =>
     agent ? startMeetingNotes(agent, 1000) : NO_MEETING_NOTES
-  const vr = (agent?: string) =>
-    agent ? startVoiceReply(agent, 1000) : NO_VOICE_REPLY
+  const voice = (agent?: string) =>
+    agent ? { [agent]: { enabled: true as const, enabledAt: 1000 } } : {}
 
   it("admits the shared session under a Meeting Notes grant alone", () => {
     expect(
-      isAgentAuthorizedForSharedMedia(mn("agent-a"), vr(), "agent-a")
+      isAgentAuthorizedForSharedMedia(mn("agent-a"), voice(), "agent-a")
     ).toBe(true)
   })
 
-  it("admits the shared session under a voiceReply grant alone (MN off, VR on)", () => {
+  it("admits the shared session under an Agent Voice grant alone", () => {
     expect(
-      isAgentAuthorizedForSharedMedia(mn(), vr("agent-a"), "agent-a")
+      isAgentAuthorizedForSharedMedia(mn(), voice("agent-a"), "agent-a")
     ).toBe(true)
   })
 
   it("admits when both grants name the agent", () => {
     expect(
-      isAgentAuthorizedForSharedMedia(mn("agent-a"), vr("agent-a"), "agent-a")
+      isAgentAuthorizedForSharedMedia(
+        mn("agent-a"),
+        voice("agent-a"),
+        "agent-a"
+      )
     ).toBe(true)
   })
 
   it("denies when neither grant is active", () => {
-    expect(isAgentAuthorizedForSharedMedia(mn(), vr(), "agent-a")).toBe(false)
+    expect(isAgentAuthorizedForSharedMedia(mn(), voice(), "agent-a")).toBe(
+      false
+    )
   })
 
   it("denies an agent named by neither grant even while both are active for others", () => {
     expect(
-      isAgentAuthorizedForSharedMedia(mn("agent-b"), vr("agent-c"), "agent-a")
+      isAgentAuthorizedForSharedMedia(
+        mn("agent-b"),
+        voice("agent-c"),
+        "agent-a"
+      )
     ).toBe(false)
   })
 
   it("denies once the only authorizing grant stops", () => {
     const notes = startMeetingNotes("agent-a", 1000)
-    expect(isAgentAuthorizedForSharedMedia(notes, vr(), "agent-a")).toBe(true)
+    expect(isAgentAuthorizedForSharedMedia(notes, voice(), "agent-a")).toBe(
+      true
+    )
     expect(
-      isAgentAuthorizedForSharedMedia(NO_MEETING_NOTES, vr(), "agent-a")
+      isAgentAuthorizedForSharedMedia(NO_MEETING_NOTES, voice(), "agent-a")
     ).toBe(false)
   })
 })
@@ -183,53 +193,11 @@ describe("resolveAgentPurposePermission — agent-transport purpose", () => {
   })
 })
 
-describe("isValidVoiceReplyState (#130 P1)", () => {
-  it("accepts an inactive grant without further fields", () => {
-    expect(isValidVoiceReplyState({ active: false })).toBe(true)
-  })
-
-  it("accepts an active grant with non-empty agent id and numeric startedAt", () => {
-    expect(
-      isValidVoiceReplyState({
-        active: true,
-        agentParticipantId: "agent-1",
-        startedAt: 1000,
-      })
-    ).toBe(true)
-  })
-
-  it("rejects an active grant with a missing or invalid startedAt", () => {
-    expect(
-      isValidVoiceReplyState({ active: true, agentParticipantId: "a" })
-    ).toBe(false)
-    expect(
-      isValidVoiceReplyState({
-        active: true,
-        agentParticipantId: "a",
-        startedAt: "not-a-number",
-      })
-    ).toBe(false)
-  })
-
-  it("rejects an active grant with empty/non-string agent id", () => {
-    expect(
-      isValidVoiceReplyState({
-        active: true,
-        agentParticipantId: "",
-        startedAt: 1,
-      })
-    ).toBe(false)
-    expect(
-      isValidVoiceReplyState({
-        active: true,
-        agentParticipantId: 42,
-        startedAt: 1,
-      })
-    ).toBe(false)
-  })
-
-  it("rejects non-object values", () => {
-    for (const bad of [undefined, null, "nope", 42])
-      expect(isValidVoiceReplyState(bad)).toBe(false)
+describe("isAgentAuthorizedForVoice", () => {
+  it("authorizes only present enabled participant grants", () => {
+    const voice = { "agent-a": { enabled: true as const, enabledAt: 1000 } }
+    expect(isAgentAuthorizedForVoice(voice, "agent-a")).toBe(true)
+    expect(isAgentAuthorizedForVoice(voice, "agent-b")).toBe(false)
+    expect(isAgentAuthorizedForVoice({}, "agent-a")).toBe(false)
   })
 })

--- a/app/src/do/meetingNotesAuth.ts
+++ b/app/src/do/meetingNotesAuth.ts
@@ -1,7 +1,7 @@
 import type {
+  AgentVoiceState,
   AgentMediaPermissions,
   MeetingNotesState,
-  VoiceReplyState,
 } from "../room/types"
 
 export const NO_MEETING_NOTES: MeetingNotesState = { active: false }
@@ -47,35 +47,12 @@ export function startMeetingNotes(
   return { active: true, agentParticipantId, startedAt: now }
 }
 
-export const NO_VOICE_REPLY: VoiceReplyState = { active: false }
-
-/** #83 single-source structural validation for a PERSISTED voiceReply
- * grant. RoomSession.validVoiceReply() delegates here so storage hygiene
- * and media normalization can never drift apart on what counts as a valid
- * active grant (active:false needs nothing further; active:true requires a
- * non-empty agentParticipantId AND a numeric startedAt). */
-export function isValidVoiceReplyState(
-  value: unknown
-): value is VoiceReplyState {
-  if (!value || typeof value !== "object") return false
-  const candidate = value as Partial<VoiceReplyState>
-  if (typeof candidate.active !== "boolean") return false
-  if (!candidate.active) return true
-  return (
-    typeof candidate.agentParticipantId === "string" &&
-    candidate.agentParticipantId.length > 0 &&
-    typeof candidate.startedAt === "number"
-  )
-}
-
-/** #83: may this connected resident Agent publish its single voice track? */
-export function isAgentAuthorizedForVoiceReply(
-  voiceReply: VoiceReplyState,
+/** May this connected resident Agent publish its own outbound voice track? */
+export function isAgentAuthorizedForVoice(
+  agentVoice: AgentVoiceState,
   agentParticipantId: string
 ): boolean {
-  return (
-    voiceReply.active && voiceReply.agentParticipantId === agentParticipantId
-  )
+  return agentVoice[agentParticipantId]?.enabled === true
 }
 
 /**
@@ -88,30 +65,13 @@ export function isAgentAuthorizedForVoiceReply(
  */
 export function isAgentAuthorizedForSharedMedia(
   meetingNotes: MeetingNotesState,
-  voiceReply: VoiceReplyState,
+  agentVoice: AgentVoiceState,
   agentParticipantId: string
 ): boolean {
   return (
     isAgentAuthorizedForMedia(meetingNotes, agentParticipantId) ||
-    isAgentAuthorizedForVoiceReply(voiceReply, agentParticipantId)
+    isAgentAuthorizedForVoice(agentVoice, agentParticipantId)
   )
-}
-
-export function startVoiceReply(
-  agentParticipantId: string,
-  now: number
-): VoiceReplyState {
-  return { active: true, agentParticipantId, startedAt: now }
-}
-
-/** Departure/expiry staleness rule, mirroring Meeting Notes. */
-export function clearVoiceReplyIfParticipantDeparting(
-  voiceReply: VoiceReplyState,
-  departingParticipantId: string
-): VoiceReplyState {
-  if (voiceReply.agentParticipantId !== departingParticipantId)
-    return voiceReply
-  return NO_VOICE_REPLY
 }
 
 export type AgentMediaPurpose =
@@ -151,7 +111,7 @@ export function resolveAgentPurposePermission(args: {
 /** Booleans-only discovery payload for Agent discovery/session responses. */
 export function agentMediaPermissions(
   meetingNotes: MeetingNotesState,
-  voiceReply: VoiceReplyState,
+  agentVoice: AgentVoiceState,
   agentParticipantId: string
 ): AgentMediaPermissions {
   return {
@@ -159,9 +119,6 @@ export function agentMediaPermissions(
       meetingNotes,
       agentParticipantId
     ),
-    canPublishVoice: isAgentAuthorizedForVoiceReply(
-      voiceReply,
-      agentParticipantId
-    ),
+    canPublishVoice: isAgentAuthorizedForVoice(agentVoice, agentParticipantId),
   }
 }

--- a/app/src/do/realtimeMedia.ts
+++ b/app/src/do/realtimeMedia.ts
@@ -187,13 +187,13 @@ export function isHumanAudioTrackTarget(
 // Which Agent media directions a revocation trigger covers (#83 review).
 // The Meeting Notes grant independently authorizes Human→Agent *subscribe*
 // media on the agent's session (tracked as agentSubscribedMids); the
-// voiceReply grant independently authorizes Agent→Human *published* media
+// Agent Voice grant independently authorizes Agent→Human *published* media
 // (agentPublishedMid plus its room-visible audio track entry). Stopping or
 // reassigning ONE grant must never tear down the OTHER grant's
 // still-active media — so every trigger stages exactly its own direction:
 //
 // - "subscribed": meeting-notes-stop / note-taker reassignment only.
-// - "published": voice-reply-stop / speaker reassignment only.
+// - "published": disabling Agent Voice / speaker reassignment only.
 // - "both": participant leave, lease-expiry sweep, and full media-session
 //   rotation (S1→S2), which tear down everything by definition.
 export type AgentMediaRevocationDirection = "subscribed" | "published" | "both"

--- a/app/src/do/roomSessionAgentVoice.test.ts
+++ b/app/src/do/roomSessionAgentVoice.test.ts
@@ -1,0 +1,280 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { RoomSession } from "./RoomSession"
+
+const future = Date.now() + 60_000
+
+function participant(id: string, kind: "human" | "agent", host?: string) {
+  return {
+    id,
+    name: id,
+    kind,
+    connected: true,
+    joinedAt: 1,
+    lastSeenAt: Date.now(),
+    token: `${id}-token`,
+    ...(host ? { runtimeHostId: host } : {}),
+    ...(kind === "human"
+      ? {
+          media: {
+            sessionId: `${id}-session`,
+            muted: false,
+            fileChannelReady: false,
+            tracks: [],
+          },
+        }
+      : {}),
+  }
+}
+
+function roomFixture() {
+  return {
+    createdAt: Date.now(),
+    expiresAt: future,
+    participants: {
+      human: participant("human", "human"),
+      "human-2": participant("human-2", "human"),
+      pi: participant("pi", "agent", "host-ready"),
+      codex: participant("codex", "agent", "host-ready"),
+      claude: participant("claude", "agent", "host-unready"),
+      hermes: participant("hermes", "agent", "host-secondary"),
+      "no-host": participant("no-host", "agent"),
+    },
+    runtimeHosts: {
+      "host-ready": {
+        runtimeHostId: "host-ready",
+        speech: { stt: false, tts: true },
+      },
+      "host-unready": {
+        runtimeHostId: "host-unready",
+        speech: { stt: false, tts: false },
+      },
+      "host-secondary": {
+        runtimeHostId: "host-secondary",
+        speech: { stt: false, tts: true },
+      },
+    },
+    messages: [],
+    attachments: [],
+    nextMessageSequence: 0,
+    meetingNotes: { active: false },
+    agentVoice: {},
+    pendingMediaCleanup: [],
+  }
+}
+
+function harness() {
+  const store = new Map<string, unknown>([["room", roomFixture()]])
+  const ctx = {
+    storage: {
+      get: async (key: string) => store.get(key),
+      put: async (key: string, value: unknown) => void store.set(key, value),
+      delete: async () => undefined,
+      setAlarm: async () => undefined,
+      deleteAlarm: async () => undefined,
+      getAlarm: async () => undefined,
+    },
+  }
+  const session = new RoomSession(
+    ctx as never,
+    {
+      SFU_ROOM: {},
+      AGENT_MEDIA_ENABLED: "true",
+    } as never
+  )
+  vi.spyOn(session as any, "broadcastState").mockResolvedValue(undefined)
+  vi.spyOn(session as any, "scheduleNextAlarm").mockResolvedValue(undefined)
+  vi.spyOn(session as any, "attemptCleanupNow").mockResolvedValue(undefined)
+  const socket = { send: vi.fn(), close: vi.fn() }
+  const sendFrom = async (
+    participantId: string,
+    agentParticipantId: string,
+    enabled: boolean
+  ) =>
+    (session as any).handleClientMessage(
+      socket,
+      {
+        participantId,
+        token: `${participantId}-token`,
+        connectionNonce: "n",
+      },
+      { type: "agent-voice-set", agentParticipantId, enabled }
+    )
+  const send = (agentParticipantId: string, enabled: boolean) =>
+    sendFrom("human", agentParticipantId, enabled)
+  const action = (body: Record<string, unknown>) =>
+    session.fetch(
+      new Request("https://room/control", {
+        method: "POST",
+        body: JSON.stringify(body),
+      })
+    )
+  return { session, socket, store, send, sendFrom, action }
+}
+
+describe("RoomSession Agent Voice", () => {
+  it("enables multiple ready Agents independently and preserves enable epochs", async () => {
+    const { send, store } = harness()
+    await send("pi", true)
+    const first = (store.get("room") as any).agentVoice.pi.enabledAt
+    await send("codex", true)
+    await send("pi", true)
+    const room = store.get("room") as any
+    expect(room.agentVoice).toMatchObject({
+      pi: { enabled: true, enabledAt: first },
+      codex: { enabled: true },
+    })
+    expect(room.nextMessageSequence).toBe(0)
+
+    await send("pi", false)
+    expect((store.get("room") as any).agentVoice).toEqual({
+      codex: expect.objectContaining({ enabled: true }),
+    })
+  })
+
+  it("fails closed for an Agent whose Runtime Host TTS is unavailable", async () => {
+    const { send, socket, store } = harness()
+    await send("claude", true)
+    expect((store.get("room") as any).agentVoice).toEqual({})
+    expect(socket.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: "error", error: "voice_unavailable" })
+    )
+  })
+
+  it("does not enable an Agent without a Runtime Host", async () => {
+    const { send, socket, store } = harness()
+    await send("no-host", true)
+    expect((store.get("room") as any).agentVoice).toEqual({})
+    expect(socket.send).toHaveBeenCalledWith(
+      JSON.stringify({ type: "error", error: "voice_unavailable" })
+    )
+  })
+
+  it("rejects a new enable while media cleanup is backpressured", async () => {
+    const { send, socket, store } = harness()
+    const room = store.get("room") as any
+    room.pendingMediaCleanup = Array.from({ length: 16 }, (_, index) => ({
+      sessionId: `stuck-${index}`,
+      mids: ["mid"],
+    }))
+    await send("pi", true)
+    expect((store.get("room") as any).agentVoice).toEqual({})
+    expect(socket.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: "error",
+        error: "agent_media_cleanup_backlog",
+      })
+    )
+  })
+
+  it("lets any current Human disable just one enabled Agent", async () => {
+    const { send, sendFrom, store } = harness()
+    await send("pi", true)
+    await send("codex", true)
+    await sendFrom("human-2", "pi", false)
+    expect((store.get("room") as any).agentVoice).toEqual({
+      codex: expect.objectContaining({ enabled: true }),
+    })
+  })
+
+  it("revokes every host member when a Runtime Host loses TTS readiness", async () => {
+    const { send, action, store } = harness()
+    await send("pi", true)
+    await send("codex", true)
+    await send("hermes", true)
+    const response = await action({
+      action: "agent-update-runtime-host",
+      participantId: "pi",
+      token: "pi-token",
+      runtimeHost: {
+        runtimeHostId: "host-ready",
+        speech: { stt: false, tts: false },
+      },
+    })
+    expect(response.status).toBe(200)
+    expect((store.get("room") as any).agentVoice).toEqual({
+      hermes: expect.objectContaining({ enabled: true }),
+    })
+  })
+
+  it("does not restore revoked grants when readiness recovers", async () => {
+    const { send, action, store } = harness()
+    await send("pi", true)
+    await action({
+      action: "agent-update-runtime-host",
+      participantId: "pi",
+      token: "pi-token",
+      runtimeHost: {
+        runtimeHostId: "host-ready",
+        speech: { stt: false, tts: false },
+      },
+    })
+    await action({
+      action: "agent-update-runtime-host",
+      participantId: "pi",
+      token: "pi-token",
+      runtimeHost: {
+        runtimeHostId: "host-ready",
+        speech: { stt: false, tts: true },
+      },
+    })
+    expect((store.get("room") as any).agentVoice).toEqual({})
+  })
+
+  it("revokes on host switch and on Agent leave", async () => {
+    const { send, action, store } = harness()
+    await send("pi", true)
+    await action({
+      action: "agent-update-runtime-host",
+      participantId: "pi",
+      token: "pi-token",
+      runtimeHost: {
+        runtimeHostId: "host-secondary",
+        speech: { stt: false, tts: true },
+      },
+    })
+    expect((store.get("room") as any).agentVoice).toEqual({})
+    await send("pi", true)
+    const leave = await action({
+      action: "agent-leave",
+      participantId: "pi",
+      token: "pi-token",
+    })
+    expect(leave.status).toBe(200)
+    expect((store.get("room") as any).agentVoice).toEqual({})
+  })
+
+  it("scrubs malformed state and stages legacy RTP before dropping singleton voice", () => {
+    const { session } = harness()
+    const stored = roomFixture() as any
+    stored.participants.pi.media = {
+      sessionId: "pi-session",
+      muted: true,
+      fileChannelReady: false,
+      tracks: [{ trackName: "agent-voice", kind: "audio" }],
+      agentPublishedMid: "legacy-published-mid",
+      agentPublishedTrackName: "agent-voice",
+    }
+    const normalized = (session as any).normalizeRoom({
+      ...stored,
+      voiceReply: {
+        active: true,
+        agentParticipantId: "pi",
+        startedAt: 1,
+      },
+      agentVoice: {
+        pi: { enabled: true, enabledAt: "bad" },
+        missing: { enabled: true, enabledAt: 1 },
+      },
+    })
+    expect(normalized.changed).toBe(true)
+    expect(normalized.room.agentVoice).toEqual({})
+    expect(normalized.room.pendingMediaCleanup).toEqual([
+      { sessionId: "pi-session", mids: ["legacy-published-mid"] },
+    ])
+    expect(
+      normalized.room.participants.pi.media.agentPublishedMid
+    ).toBeUndefined()
+    expect(normalized.room.participants.pi.media.tracks).toEqual([])
+  })
+})

--- a/app/src/do/roomSessionAuthorize.test.ts
+++ b/app/src/do/roomSessionAuthorize.test.ts
@@ -1,11 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import {
-  NO_MEETING_NOTES,
-  NO_VOICE_REPLY,
-  startMeetingNotes,
-  startVoiceReply,
-} from "./meetingNotesAuth"
+import { NO_MEETING_NOTES, startMeetingNotes } from "./meetingNotesAuth"
 import { RoomSession } from "./RoomSession"
 import type { RoomParticipant } from "../room/types"
 
@@ -36,7 +31,7 @@ function storedHuman(
 
 function buildStoredRoom(grants: {
   meetingNotesFor?: string
-  voiceReplyFor?: string
+  agentVoiceFor?: string
 }) {
   return {
     createdAt: Date.now(),
@@ -56,6 +51,7 @@ function buildStoredRoom(grants: {
         joinedAt: 1,
         lastSeenAt: Date.now(),
         token: "tok-a",
+        runtimeHostId: "host-agent",
         media: {
           sessionId: "asess",
           muted: true,
@@ -65,16 +61,22 @@ function buildStoredRoom(grants: {
         },
       },
     },
+    runtimeHosts: {
+      "host-agent": {
+        runtimeHostId: "host-agent",
+        speech: { stt: false, tts: true },
+      },
+    },
     messages: [],
     nextMessageSequence: 1,
     meetingNotes:
       grants.meetingNotesFor === "agent-a"
         ? startMeetingNotes("agent-a", 1000)
         : NO_MEETING_NOTES,
-    voiceReply:
-      grants.voiceReplyFor === "agent-a"
-        ? startVoiceReply("agent-a", 1000)
-        : NO_VOICE_REPLY,
+    agentVoice:
+      grants.agentVoiceFor === "agent-a"
+        ? { "agent-a": { enabled: true, enabledAt: 1000 } }
+        : {},
     pendingMediaCleanup: [],
   }
 }
@@ -92,30 +94,38 @@ function makeRoomSession(stored: ReturnType<typeof buildStoredRoom>) {
     },
   }
   const rs = new RoomSession(ctx as never, { SFU_ROOM: {} } as never)
+  const control = (
+    body: Record<string, unknown>
+  ): Promise<{
+    status: number
+    json: Record<string, unknown>
+  }> =>
+    rs
+      .fetch(
+        new Request("https://room/control", {
+          method: "POST",
+          body: JSON.stringify(body),
+        })
+      )
+      .then(async (response) => ({
+        status: response.status,
+        json: (await response.json()) as Record<string, unknown>,
+      }))
   return {
     authorize(body: Record<string, unknown>): Promise<{
       status: number
       json: Record<string, unknown>
     }> {
-      return rs
-        .fetch(
-          new Request("https://room/control", {
-            method: "POST",
-            body: JSON.stringify({ action: "authorize", ...body }),
-          })
-        )
-        .then(async (response) => ({
-          status: response.status,
-          json: (await response.json()) as Record<string, unknown>,
-        }))
+      return control({ action: "authorize", ...body })
     },
+    control,
   }
 }
 
 describe("RoomSession authorize — real DO agent matrix (#83 review P1)", () => {
   const room = buildStoredRoom({
     meetingNotesFor: "agent-a",
-    voiceReplyFor: "agent-a",
+    agentVoiceFor: "agent-a",
   })
 
   it("agent-transport datachannels/close correlation (dataChannelSessionId) passes", async () => {
@@ -234,6 +244,85 @@ describe("RoomSession authorize — real DO agent matrix (#83 review P1)", () =>
     })
     expect(result.status).toBe(200)
     expect(result.json.kind).toBe("agent")
+  })
+
+  it("authorizes each enabled Agent independently and fails closed when one is muted", async () => {
+    const multi = buildStoredRoom({ agentVoiceFor: "agent-a" })
+    multi.participants["agent-b"] = {
+      ...(multi.participants["agent-a"] as RoomParticipant),
+      id: "agent-b",
+      token: "tok-b",
+      media: {
+        sessionId: "bsess",
+        muted: true,
+        fileChannelReady: false,
+        tracks: [],
+      },
+    } as RoomParticipant
+    multi.agentVoice["agent-b"] = { enabled: true, enabledAt: 2000 }
+    const { authorize } = makeRoomSession(multi)
+    for (const [participantId, token, sessionId] of [
+      ["agent-a", "tok-a", "asess"],
+      ["agent-b", "tok-b", "bsess"],
+    ]) {
+      const result = await authorize({
+        participantId,
+        token,
+        sessionId,
+        purpose: "voice-reply",
+        wantsVoicePublish: true,
+        localTrackCount: 1,
+      })
+      expect(result.status).toBe(200)
+    }
+
+    delete multi.agentVoice["agent-b"]
+    const muted = await makeRoomSession(multi).authorize({
+      participantId: "agent-b",
+      token: "tok-b",
+      sessionId: "bsess",
+      purpose: "voice-reply",
+      wantsVoicePublish: true,
+      localTrackCount: 1,
+    })
+    expect(muted.status).toBe(403)
+    expect(muted.json.error).toBe("voice_reply_not_authorized")
+  })
+
+  it("rejects a local Agent Voice publication before upstream work when cleanup is full", async () => {
+    const backpressured = buildStoredRoom({ agentVoiceFor: "agent-a" })
+    backpressured.pendingMediaCleanup = Array.from(
+      { length: 16 },
+      (_, index) => ({ sessionId: `stuck-${index}`, mids: ["mid"] })
+    )
+    const result = await makeRoomSession(backpressured).authorize({
+      participantId: "agent-a",
+      token: "tok-a",
+      sessionId: "asess",
+      purpose: "voice-reply",
+      wantsVoicePublish: true,
+      localTrackCount: 1,
+    })
+    expect(result.status).toBe(503)
+    expect(result.json.error).toBe("agent_media_cleanup_backlog")
+  })
+
+  it("rejects post-upstream publication registration when cleanup fills during the race", async () => {
+    const backpressured = buildStoredRoom({ agentVoiceFor: "agent-a" })
+    backpressured.pendingMediaCleanup = Array.from(
+      { length: 16 },
+      (_, index) => ({ sessionId: `stuck-${index}`, mids: ["mid"] })
+    )
+    const result = await makeRoomSession(backpressured).control({
+      action: "agent-track-published",
+      participantId: "agent-a",
+      token: "tok-a",
+      sessionId: "asess",
+      mid: "new-local-mid",
+      trackName: "agent-voice",
+    })
+    expect(result.status).toBe(503)
+    expect(result.json.error).toBe("agent_media_cleanup_backlog")
   })
 
   it("a Human plain authorize needs no purpose (browser paths unaffected)", async () => {

--- a/app/src/do/roomSessionNormalize.test.ts
+++ b/app/src/do/roomSessionNormalize.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest"
 
-import { NO_VOICE_REPLY, isValidVoiceReplyState } from "./meetingNotesAuth"
 import { normalizeAgentParticipantMedia } from "./RoomSession"
 
 const AGENT_ID = "agent-voice-1"
@@ -17,167 +16,57 @@ function media(overrides: Record<string, unknown> = {}) {
   } as Parameters<typeof normalizeAgentParticipantMedia>[0]
 }
 
-function grantedVoice() {
-  return {
-    active: true,
-    agentParticipantId: AGENT_ID,
-    startedAt: 1000,
-  }
+function enabledVoice(participantId = AGENT_ID) {
+  return { [participantId]: { enabled: true as const, enabledAt: 1000 } }
 }
 
-describe("normalizeAgentParticipantMedia (#83 live silence fix)", () => {
-  it("preserves the authorized single audio track + mid across loads", () => {
-    const before = media()
+describe("normalizeAgentParticipantMedia", () => {
+  it("preserves only the enabled Agent's single published audio track", () => {
     const result = normalizeAgentParticipantMedia(
-      before,
-      grantedVoice(),
+      media(),
+      enabledVoice(),
       AGENT_ID
     )
     expect(result.changed).toBe(false)
-    expect(result.media?.tracks).toEqual([
-      { trackName: "agent-voice", kind: "audio" },
-    ])
     expect(result.media?.agentPublishedMid).toBe(MID)
   })
 
-  it("still strips tracks when voiceReply is inactive (Stop semantics)", () => {
-    const inactive = { ...grantedVoice(), active: false }
-    const result = normalizeAgentParticipantMedia(media(), inactive, AGENT_ID)
+  it("strips a muted Agent's prior publication on reload", () => {
+    const result = normalizeAgentParticipantMedia(media(), {}, AGENT_ID)
     expect(result.changed).toBe(true)
     expect(result.media?.tracks).toEqual([])
-    // Stale mid is cleared too so capacity/revocation bookkeeping cannot
-    // reference a dead publication.
     expect(result.media?.agentPublishedMid).toBeUndefined()
   })
 
-  it("preserves a booked publication privately until its first PCM write", () => {
-    const pending = media({
-      tracks: [],
-      agentPublishedTrackName: "agent-voice",
-    })
+  it("does not transfer authorization to another participant", () => {
     const result = normalizeAgentParticipantMedia(
-      pending,
-      grantedVoice(),
+      media(),
+      enabledVoice("agent-other"),
       AGENT_ID
     )
-    expect(result.changed).toBe(false)
-    expect(result.media?.tracks).toEqual([])
-    expect(result.media?.agentPublishedMid).toBe(MID)
-    expect(result.media?.agentPublishedTrackName).toBe("agent-voice")
-  })
-
-  it("strips tracks when the grant names a different agent", () => {
-    const other = { ...grantedVoice(), agentParticipantId: "agent-other" }
-    const result = normalizeAgentParticipantMedia(media(), other, AGENT_ID)
     expect(result.changed).toBe(true)
-    expect(result.media?.tracks).toEqual([])
     expect(result.media?.agentPublishedMid).toBeUndefined()
   })
 
-  it("strips multi-track or video shapes even under an active grant", () => {
-    const two = media({
-      tracks: [
-        { trackName: "a", kind: "audio" },
-        { trackName: "b", kind: "audio" },
-      ],
-    })
+  it("continues to reject malformed multi-track or video publications", () => {
     expect(
-      normalizeAgentParticipantMedia(two, grantedVoice(), AGENT_ID).changed
+      normalizeAgentParticipantMedia(
+        media({
+          tracks: [
+            { trackName: "a", kind: "audio" },
+            { trackName: "b", kind: "audio" },
+          ],
+        }),
+        enabledVoice(),
+        AGENT_ID
+      ).changed
     ).toBe(true)
-
-    const video = media({
-      tracks: [{ trackName: "v", kind: "video" }],
-    })
-    const videoResult = normalizeAgentParticipantMedia(
-      video,
-      grantedVoice(),
-      AGENT_ID
-    )
-    expect(videoResult.changed).toBe(true)
-    expect(videoResult.media?.agentPublishedMid).toBeUndefined()
-  })
-
-  it("strips a mid without a matching track (illegal state)", () => {
-    const orphan = media({ tracks: [] })
-    const result = normalizeAgentParticipantMedia(
-      orphan,
-      grantedVoice(),
-      AGENT_ID
-    )
-    expect(result.changed).toBe(true)
-    expect(result.media?.agentPublishedMid).toBeUndefined()
-  })
-
-  it("leaves absent media untouched", () => {
-    const result = normalizeAgentParticipantMedia(
-      undefined,
-      grantedVoice(),
-      AGENT_ID
-    )
-    expect(result.changed).toBe(false)
-    expect(result.media).toBeUndefined()
-  })
-
-  it("end-to-end: publish writes mid+track, reload keeps them, Stop clears them", () => {
-    // Simulate agent-track-published bookkeeping.
-    const stored = media()
-    // Reload #1: normalization must preserve the live publication.
-    const afterLoad = normalizeAgentParticipantMedia(
-      stored,
-      grantedVoice(),
-      AGENT_ID
-    )
-    expect(afterLoad.changed).toBe(false)
-    // Human resync sees the voice track and can subscribe.
     expect(
-      afterLoad.media?.tracks.some((t) => t.trackName === "agent-voice")
+      normalizeAgentParticipantMedia(
+        media({ tracks: [{ trackName: "v", kind: "video" }] }),
+        enabledVoice(),
+        AGENT_ID
+      ).changed
     ).toBe(true)
-    // Stop flips the grant off; next load clears the dead publication.
-    const stopped = { ...grantedVoice(), active: false }
-    const afterStop = normalizeAgentParticipantMedia(
-      afterLoad.media,
-      stopped,
-      AGENT_ID
-    )
-    expect(afterStop.changed).toBe(true)
-    expect(afterStop.media?.tracks).toEqual([])
-  })
-})
-
-describe("normalizeRoom ordering: invalid grants degrade BEFORE media preservation (#130 P1)", () => {
-  const rawInvalidGrant = {
-    active: true,
-    agentParticipantId: AGENT_ID,
-    // startedAt MISSING — persisted state from an older writer.
-  }
-  const rawInvalidStartedAt = {
-    active: true,
-    agentParticipantId: AGENT_ID,
-    startedAt: "not-a-number",
-  }
-
-  it("isValidVoiceReplyState rejects both malformed raw grants", () => {
-    expect(isValidVoiceReplyState(rawInvalidGrant)).toBe(false)
-    expect(isValidVoiceReplyState(rawInvalidStartedAt)).toBe(false)
-  })
-
-  it("missing startedAt clears tracks and mid instead of preserving them", () => {
-    const normalized = isValidVoiceReplyState(rawInvalidGrant)
-      ? rawInvalidGrant
-      : NO_VOICE_REPLY
-    const result = normalizeAgentParticipantMedia(media(), normalized, AGENT_ID)
-    expect(result.changed).toBe(true)
-    expect(result.media?.tracks).toEqual([])
-    expect(result.media?.agentPublishedMid).toBeUndefined()
-  })
-
-  it("non-numeric startedAt clears tracks and mid instead of preserving them", () => {
-    const normalized = isValidVoiceReplyState(rawInvalidStartedAt)
-      ? rawInvalidStartedAt
-      : NO_VOICE_REPLY
-    const result = normalizeAgentParticipantMedia(media(), normalized, AGENT_ID)
-    expect(result.changed).toBe(true)
-    expect(result.media?.tracks).toEqual([])
-    expect(result.media?.agentPublishedMid).toBeUndefined()
   })
 })

--- a/app/src/do/voiceReplyAuth.test.ts
+++ b/app/src/do/voiceReplyAuth.test.ts
@@ -1,70 +1,32 @@
 import { describe, expect, it } from "vitest"
 
 import {
-  clearVoiceReplyIfParticipantDeparting,
-  isAgentAuthorizedForVoiceReply,
-  NO_VOICE_REPLY,
+  isAgentAuthorizedForVoice,
   resolveAgentPurposePermission,
-  startVoiceReply,
 } from "./meetingNotesAuth"
 
-const GRANTED = startVoiceReply("agent-1", 1000)
-
-describe("voiceReply grant (#83)", () => {
-  it("denies by default and only authorizes the named agent", () => {
-    expect(isAgentAuthorizedForVoiceReply(NO_VOICE_REPLY, "agent-1")).toBe(
-      false
-    )
-    expect(isAgentAuthorizedForVoiceReply(GRANTED, "agent-1")).toBe(true)
-    expect(isAgentAuthorizedForVoiceReply(GRANTED, "agent-2")).toBe(false)
-    const stopped = clearVoiceReplyIfParticipantDeparting(GRANTED, "agent-1")
-    expect(stopped).toEqual(NO_VOICE_REPLY)
-    expect(clearVoiceReplyIfParticipantDeparting(GRANTED, "other")).toBe(
-      GRANTED
-    )
+describe("Agent Voice authorization", () => {
+  it("allows two independently enabled Agents and denies a muted peer", () => {
+    const grants = {
+      "agent-1": { enabled: true as const, enabledAt: 1000 },
+      "agent-2": { enabled: true as const, enabledAt: 2000 },
+    }
+    expect(isAgentAuthorizedForVoice(grants, "agent-1")).toBe(true)
+    expect(isAgentAuthorizedForVoice(grants, "agent-2")).toBe(true)
+    expect(isAgentAuthorizedForVoice(grants, "agent-3")).toBe(false)
   })
 })
 
-describe("agent purpose direction matrix (#83)", () => {
-  it("fails closed on missing/unknown purpose", () => {
-    for (const purpose of [undefined, "", "chat"]) {
-      expect(
-        resolveAgentPurposePermission({
-          purpose,
-          wantsLocalPublish: false,
-          wantsRemoteSubscribe: true,
-          involvesVideo: false,
-        })
-      ).toEqual({ ok: false, error: "agent_media_purpose_required" })
-    }
-  })
-  it("meeting-notes permits only remote subscribe", () => {
-    expect(
-      resolveAgentPurposePermission({
-        purpose: "meeting-notes",
-        wantsLocalPublish: false,
-        wantsRemoteSubscribe: true,
-        involvesVideo: false,
-      }).ok
-    ).toBe(true)
-    expect(
-      resolveAgentPurposePermission({
-        purpose: "meeting-notes",
-        wantsLocalPublish: true,
-        wantsRemoteSubscribe: false,
-        involvesVideo: false,
-      })
-    ).toEqual({ ok: false, error: "agent_media_direction_forbidden" })
-  })
-  it("voice-reply permits only local publish", () => {
+describe("agent purpose direction matrix", () => {
+  it("allows voice local publication and never Human-audio subscription", () => {
     expect(
       resolveAgentPurposePermission({
         purpose: "voice-reply",
         wantsLocalPublish: true,
         wantsRemoteSubscribe: false,
         involvesVideo: false,
-      }).ok
-    ).toBe(true)
+      })
+    ).toEqual({ ok: true })
     expect(
       resolveAgentPurposePermission({
         purpose: "voice-reply",
@@ -73,16 +35,5 @@ describe("agent purpose direction matrix (#83)", () => {
         involvesVideo: false,
       })
     ).toEqual({ ok: false, error: "agent_media_direction_forbidden" })
-  })
-  it("video is always denied", () => {
-    for (const purpose of ["meeting-notes", "voice-reply"]) {
-      const result = resolveAgentPurposePermission({
-        purpose,
-        wantsLocalPublish: false,
-        wantsRemoteSubscribe: false,
-        involvesVideo: true,
-      })
-      expect("error" in result).toBe(true)
-    }
   })
 })

--- a/app/src/hooks/useSfuChatRoom.test.tsx
+++ b/app/src/hooks/useSfuChatRoom.test.tsx
@@ -651,8 +651,8 @@ describe("useSfuChatRoom room attachments (#123)", () => {
             messages: [],
             meetingNotes: { active: false },
             meetingNotesMediaAvailable: true,
-            voiceReply: { active: true },
-            voiceReplyMediaAvailable: true,
+            agentVoice: { "agent-b": { enabled: true, enabledAt: 1 } },
+            agentVoiceMediaAvailable: true,
           },
         }),
       })

--- a/app/src/hooks/useSfuChatRoom.ts
+++ b/app/src/hooks/useSfuChatRoom.ts
@@ -15,8 +15,8 @@ import {
 
 import type { RoomAttachmentRead } from "../room/types"
 import type {
+  SfuAgentVoiceState,
   SfuMeetingNotesState,
-  SfuVoiceReplyState,
   SfuMessage,
   SfuParticipant,
   SfuRoomState,
@@ -286,10 +286,8 @@ export function useSfuChatRoom(
   // arrives, rather than defaulting to an optimistic "available".
   const [meetingNotesMediaAvailable, setMeetingNotesMediaAvailable] =
     useState(false)
-  const [voiceReply, setVoiceReply] = useState<SfuVoiceReplyState>({
-    active: false,
-  })
-  const [voiceReplyMediaAvailable, setVoiceReplyMediaAvailable] =
+  const [agentVoice, setAgentVoiceState] = useState<SfuAgentVoiceState>({})
+  const [agentVoiceMediaAvailable, setAgentVoiceMediaAvailable] =
     useState(false)
 
   const sessionRef = useRef<SfuSession | null>(null)
@@ -374,6 +372,14 @@ export function useSfuChatRoom(
         surface: participant.kind === "agent" ? participant.surface : undefined,
         runtimeHostId:
           participant.kind === "agent" ? participant.runtimeHostId : undefined,
+        voiceAvailable:
+          participant.kind === "agent" &&
+          state?.agentVoiceMediaAvailable === true &&
+          participant.runtimeHostId !== undefined &&
+          state.runtimeHosts?.[participant.runtimeHostId]?.speech.tts === true,
+        voiceEnabled:
+          participant.kind === "agent" &&
+          state?.agentVoice?.[participant.id]?.enabled === true,
         audioStream: remoteAudioStreamsRef.current.get(participant.id) ?? null,
         screenShareEnabled: hasScreenShare,
         screenShareStream:
@@ -1036,8 +1042,8 @@ export function useSfuChatRoom(
       })
       setMeetingNotes(state.meetingNotes)
       setMeetingNotesMediaAvailable(state.meetingNotesMediaAvailable)
-      setVoiceReply(state.voiceReply)
-      setVoiceReplyMediaAvailable(state.voiceReplyMediaAvailable)
+      setAgentVoiceState(state.agentVoice)
+      setAgentVoiceMediaAvailable(state.agentVoiceMediaAvailable)
       for (const participant of state.participants) {
         const previous = participantMapRef.current.get(participant.id)
         if (
@@ -1819,21 +1825,16 @@ export function useSfuChatRoom(
     sendSocketMessage({ type: "meeting-notes-stop" })
   }, [sendSocketMessage])
 
-  // #83: Human grant for exactly one connected resident Agent's outbound
-  // voice; server re-checks sender/target on every control message.
-  const startVoiceReply = useCallback(
-    (agentParticipantId: string) => {
+  const setAgentVoice = useCallback(
+    (agentParticipantId: string, enabled: boolean) => {
       sendSocketMessage({
-        type: "voice-reply-start",
+        type: "agent-voice-set",
         agentParticipantId,
+        enabled,
       })
     },
     [sendSocketMessage]
   )
-
-  const stopVoiceReply = useCallback(() => {
-    sendSocketMessage({ type: "voice-reply-stop" })
-  }, [sendSocketMessage])
 
   const sendFileMessage = useCallback(
     async (file: File) => {
@@ -1971,9 +1972,8 @@ export function useSfuChatRoom(
     meetingNotesMediaAvailable,
     startMeetingNotes,
     stopMeetingNotes,
-    voiceReply,
-    voiceReplyMediaAvailable,
-    startVoiceReply,
-    stopVoiceReply,
+    agentVoice,
+    agentVoiceMediaAvailable,
+    setAgentVoice,
   }
 }

--- a/app/src/room/types.ts
+++ b/app/src/room/types.ts
@@ -185,14 +185,18 @@ export interface MeetingNotesState {
   startedAt?: number
 }
 
-// Room-scoped voiceReply grant (#83): authorizes exactly one connected
-// resident Agent to publish its single outbound audio track. Same shape as
-// MeetingNotesState so "never granted" and "stopped" look identical.
-export interface VoiceReplyState {
-  active: boolean
-  agentParticipantId?: string
-  startedAt?: number
+// A Room-wide publish authorization for one currently connected Agent. The
+// entry exists only while enabled; absence means muted. enabledAt is the
+// participant-specific authorization epoch consumed by resident Runtimes.
+export interface AgentVoiceGrant {
+  enabled: true
+  enabledAt: number
 }
+
+// Canonical Agent Voice authorization. This deliberately carries no false
+// entries and no Runtime Host details: readiness belongs to runtimeHosts and
+// authorization belongs to the participant that will publish the audio.
+export type AgentVoiceState = Record<string, AgentVoiceGrant>
 
 // Directional media permissions for an Agent media session (#83) — booleans
 // only, never secrets or media identifiers.
@@ -217,8 +221,10 @@ export interface RoomState {
   // false: every actual Runtime media request would 403 regardless of the
   // room-visible grant.
   meetingNotesMediaAvailable: boolean
-  voiceReply: VoiceReplyState
-  voiceReplyMediaAvailable: boolean
+  agentVoice: AgentVoiceState
+  // Coarse Worker media admission switch. Per-Agent UI availability still
+  // comes from the Runtime Host's TTS readiness, never from this field.
+  agentVoiceMediaAvailable: boolean
 }
 
 // A Cloudflare Realtime track-close attempt that hasn't been confirmed
@@ -243,7 +249,7 @@ export interface RoomRecord {
   attachments: RoomAttachment[]
   nextMessageSequence: number
   meetingNotes: MeetingNotesState
-  voiceReply: VoiceReplyState
+  agentVoice: AgentVoiceState
   pendingMediaCleanup: PendingMediaCleanup[]
 }
 

--- a/app/src/sfu/server.test.ts
+++ b/app/src/sfu/server.test.ts
@@ -830,6 +830,27 @@ describe("Phase-0 invariant: agent media sessions are subscribe-only", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it("Agent local voice publish is rejected before Cloudflare when cleanup is backpressured", async () => {
+    const seenActions: Array<Record<string, unknown>> = []
+    const env = makeEnv({ AGENT_MEDIA_ENABLED: "true" }, (body) => {
+      seenActions.push(body)
+      if (body.action === "authorize")
+        return { status: 503, body: { error: "agent_media_cleanup_backlog" } }
+      return { status: 200, body: { ok: true } }
+    })
+    const res = await handleSfuRequest(
+      req("tracks", {
+        body: JSON.stringify(voiceReplyTracksBody([localAudio])),
+      }),
+      env
+    )
+    expect(res.status).toBe(503)
+    expect((await json(res)).error).toBe("agent_media_cleanup_backlog")
+    expect(fetchMock).not.toHaveBeenCalled()
+    const authorizeCall = seenActions.find((a) => a.action === "authorize")
+    expect(authorizeCall?.localTrackCount).toBe(1)
+  })
+
   it("Granted Agent + exactly one local audio track with purpose voice-reply => forwarded upstream once and booked via agent-track-published", async () => {
     const roomActions: Array<Record<string, unknown>> = []
     const env = makeEnv({ AGENT_MEDIA_ENABLED: "true" }, (body) => {

--- a/app/src/sfu/types.ts
+++ b/app/src/sfu/types.ts
@@ -1,6 +1,6 @@
 export type {
+  AgentVoiceState as SfuAgentVoiceState,
   MeetingNotesState as SfuMeetingNotesState,
-  VoiceReplyState as SfuVoiceReplyState,
   ParticipantKind,
   RoomMessage as SfuMessage,
   RoomParticipant as SfuParticipant,


### PR DESCRIPTION
Closes #170

## Summary

- Depends on merged #178 Runtime Host readiness. Runtime Host TTS readiness remains the single capability source; `agentVoice` is participant-specific Room authorization.
- Replaces the singleton Voice Reply state with `agentVoice[participantId] = { enabled: true, enabledAt }`. Multiple current Agents can be enabled concurrently; new and rejoined participants start muted.
- Validates Human-only `agent-voice-set` controls, fails closed when the target lacks a TTS-ready Runtime Host, revokes relevant grants on host changes/leave/expiry, and keeps old `voiceReply` state inert during migration.
- Preserves Meeting Notes directionality: Agent Voice permits only that Agent's local outbound audio publication, never Human-audio subscription.
- Adds one host-local shared voice gate per daemon. It serializes synthesis through audible publication across all resident Agents on that Runtime Host and discards cancelled queued work.
- Text replies and structured-targeting/Harness activation semantics are unchanged. #175 prerequisite-notice epoch behavior remains covered.

## Not included

- #177 Live Transcript, Human↔Runtime ownership proof, #157 shared transcript/context, #156 speech-to-speech, and #180 Agent screen sharing are intentionally untouched.

## Validation

- App: Prettier, ESLint with zero warnings, TypeScript check, 409 Vitest tests, and OpenNext/Cloudflare production build.
- Runtime: gofmt, `go vet ./...`, `go test ./... -count=1`, `go build ./cmd/free4chat-agent`, cleanup contract, and darwin/linux arm64/amd64 release cross-build with SHA256 verification.
- Added focused Room state, media authorization, Go RoomInfo parsing, per-Agent UI, and shared host voice-gate tests.

## Manual dogfood

Pending a real Room with Pi and Codex on TTS-ready H1 (optional Claude/Hermes on H2): enable Pi and Codex independently; address each and verify text plus only its audio; mute Pi and verify its text-only response while Codex remains audible; toggle H1 TTS off/on and verify both become unavailable/muted and remain muted after recovery; ensure simultaneous replies do not overlap and a transient RoomInfo failure does not duplicate prerequisite notices.
